### PR TITLE
Fix date display in IE and Safari (NaN)

### DIFF
--- a/js/vote.js
+++ b/js/vote.js
@@ -19,7 +19,7 @@ $(document).ready(function () {
     var prev = '';
     var dateStr = '';
     $('.hidden-dates').each(function(i, obj) {
-        var exDt = new Date(obj.value+'+0000'); // add +0000 = UTC
+        var exDt = new Date(obj.value.replace(/ /g,"T")+"Z");
         var day = ('0' + exDt.getDate()).substr(-2);
         var month = ('0' + (exDt.getMonth()+1)).substr(-2);
         var day_month = day + '.' + month;


### PR DESCRIPTION
IE and Safari couldn't interprate the date format correctly. This patch correct the display on common browsers.