### PR TITLE
Change on calculating expiry time stamp

### DIFF
--- a/js/create_edit.js
+++ b/js/create_edit.js
@@ -321,7 +321,8 @@ $(document).ready(function () {
 			var year = date.getFullYear();
 			var month = date.getMonth();
 			var day = date.getDate();
-			var newDate = new Date(year, month, day).getTime()/1000;
+			// set expiry date to the last second before midnight of the choosen date (local time)
+			var newDate = new Date(year, month, day, 23, 59, 59).getTime()/1000; 
 			document.getElementById('expireTs').value = newDate;
 		},
 		timepicker: false,

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -335,6 +335,8 @@ class PageController extends Controller {
 		$isAnonymous,
 		$hideNames
 	) {
+		
+		
 		$event = $this->eventMapper->find($pollId);
 		$event->setTitle($pollTitle);
 		$event->setDescription($pollDesc);
@@ -369,8 +371,7 @@ class PageController extends Controller {
 
 		$expire = null;
 		if ($expireTs !== 0 && $expireTs !== '') {
-			// Add one day, so it expires at the end of a day
-			$expire = date('Y-m-d H:i:s', $expireTs + 60 * 60 * 24);
+			$expire = date('Y-m-d H:i:s', $expireTs);
 		}
 		$event->setExpire($expire);
 
@@ -478,8 +479,7 @@ class PageController extends Controller {
 
 		$expire = null;
 		if ($expireTs !== 0 && $expireTs !== '') {
-			// Add one day, so it expires at the end of a day
-			$expire = date('Y-m-d H:i:s', $expireTs + 60 * 60 * 24);
+			$expire = date('Y-m-d H:i:s', $expireTs);
 		}
 		$event->setExpire($expire);
 

--- a/templates/create.tmpl.php
+++ b/templates/create.tmpl.php
@@ -57,7 +57,7 @@
 		$title = $poll->getTitle();
 		$desc = $poll->getDescription();
 		if ($poll->getExpire() !== null) {
-			$expireTs = strtotime($poll->getExpire()) - 60*60*24; //remove one day, which has been added to expire at the end of a day
+			$expireTs = strtotime($poll->getExpire());
 			$expireStr = date('d.m.Y', $expireTs);
 		}
 		$access = $poll->getAccess();


### PR DESCRIPTION
When entering an expiry date, the routines add 24 hours to target the end of the day. When displaying it again in the edit form, there are again 24 hours substracted. 

Because of the different timezones this may fail. The user enters a date regarding to his local timezone, which is also used by the js function, which writes this to the hidden fields, where the server respects the server time zone. 

Example: 
Field value 08.12.2017 (local tz)
DB says 2017-12-08 23:00:00 (server tz)
On loading: 07.12.2017 (DB entry/server tz - 24 hours)

The commit adds 23:59:59 to the date, regarding the local tz. and doues no more add or substract 24 hours. 
Example: 
Field value 08.12.2017 -> timestamp 08.12.2017 23:59:59 (local tz)
DB says 2017-12-08 22:59:59 (server tz)
On loading: 08.12.2017 (DB entry/server tz without substracting)

Tested with firefox. Not sure if there are side effects or special behavior of other browsers.