### PR TITLE
Allow Nextcloud 15

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -23,6 +23,6 @@
     <screenshot>https://raw.githubusercontent.com/nextcloud/polls/master/screenshots/vote.png</screenshot>
     <screenshot>https://raw.githubusercontent.com/nextcloud/polls/master/screenshots/edit-poll.png</screenshot>
     <dependencies>
-        <nextcloud min-version="14" max-version="14" />
+        <nextcloud min-version="14" max-version="15" />
     </dependencies>
 </info>


### PR DESCRIPTION
Fixes #421 


I gave it a test and all seems to work. Should I also raise the version number so you could release 0.9.1 or something like that in the appstore to make it available to beta testers that are already updating to Nextcloud 15 beta 2?