### PR TITLE
Use the email templating and use the language of the recipient

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -38,85 +38,10 @@ class Application extends App {
 	 * Application constructor.
 	 * @param array $urlParams
 	 */
-	public function __construct(array $urlParams = array()) {
+	public function __construct(array $urlParams = []) {
 		parent::__construct('polls', $urlParams);
-
-		$container = $this->getContainer();
-		$server = $container->getServer();
-
-		/**
-		 * Controllers
-		 */
-		$container->registerService('PageController', function(IContainer $c) {
-			return new PageController(
-				$c->query('AppName'),
-				$c->query('Request'),
-				$c->query('UserManager'),
-				$c->query('GroupManager'),
-				$c->query('AvatarManager'),
-				$c->query('Logger'),
-				$c->query('L10N'),
-				$c->query('ServerContainer')->getURLGenerator(),
-				$c->query('UserId'),
-				$c->query('CommentMapper'),
-				$c->query('OptionsMapper'),
-				$c->query('EventMapper'),
-				$c->query('NotificationMapper'),
-				$c->query('VotesMapper')
-			);
-		});
-
-		$container->registerService('UserManager', function(IContainer $c) {
-			return $c->query('ServerContainer')->getUserManager();
-		});
-
-		$container->registerService('GroupManager', function(IContainer $c) {
-			return $c->query('ServerContainer')->getGroupManager();
-		});
-
-		$container->registerService('AvatarManager', function(IContainer $c) {
-			return $c->query('ServerContainer')->getAvatarManager();
-		});
-
-		$container->registerService('Logger', function(IContainer $c) {
-			return $c->query('ServerContainer')->getLogger();
-		});
-
-		$container->registerService('L10N', function(IContainer $c) {
-			return $c->query('ServerContainer')->getL10N($c->query('AppName'));
-		});
-
-		$container->registerService('CommentMapper', function(IContainer $c) use ($server) {
-			return new CommentMapper(
-				$server->getDatabaseConnection()
-			);
-		});
-
-		$container->registerService('OptionsMapper', function(IContainer $c) use ($server) {
-			return new OptionsMapper(
-				$server->getDatabaseConnection()
-			);
-		});
-
-		$container->registerService('EventMapper', function(IContainer $c) use ($server) {
-			return new EventMapper(
-				$server->getDatabaseConnection()
-			);
-		});
-
-		$container->registerService('NotificationMapper', function(IContainer $c) use ($server) {
-			return new NotificationMapper(
-				$server->getDatabaseConnection()
-			);
-		});
-
-		$container->registerService('VotesMapper', function(IContainer $c) use ($server) {
-			return new VotesMapper(
-				$server->getDatabaseConnection()
-			);
-		});
-
 	}
+
 	/**
 	 * Register navigation entry for main navigation.
 	 */

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -82,12 +82,13 @@ class PageController extends Controller {
 	 * @param IAvatarManager $avatarManager
 	 * @param ILogger $logger
 	 * @param IL10N $trans
+	 * @param IFactory $transFactory
 	 * @param IURLGenerator $urlGenerator
 	 * @param string $userId
 	 * @param CommentMapper $commentMapper
+	 * @param OptionsMapper $optionsMapper
 	 * @param EventMapper $eventMapper
 	 * @param NotificationMapper $notificationMapper
-	 * @param OptionsMapper $optionsMapper
 	 * @param VotesMapper $VotesMapper
 	 * @param IMailer $mailer
 	 */
@@ -111,6 +112,7 @@ class PageController extends Controller {
 		IMailer $mailer
 	) {
 		parent::__construct($appName, $request);
+		$this->request = $request;
 		$this->config = $config;
 		$this->userMgr = $userMgr;
 		$this->groupManager = $groupManager;
@@ -121,9 +123,9 @@ class PageController extends Controller {
 		$this->urlGenerator = $urlGenerator;
 		$this->userId = $userId;
 		$this->commentMapper = $commentMapper;
+		$this->optionsMapper = $optionsMapper;
 		$this->eventMapper = $eventMapper;
 		$this->notificationMapper = $notificationMapper;
-		$this->optionsMapper = $optionsMapper;
 		$this->votesMapper = $VotesMapper;
 		$this->mailer = $mailer;
 	}

--- a/tests/Unit/Controller/PageControllerTest.php
+++ b/tests/Unit/Controller/PageControllerTest.php
@@ -68,7 +68,7 @@ class PageControllerTest extends UnitTestCase {
 		$transFactory = $this->getMockBuilder('OCP\L10N\IFactory')
 			->disableOriginalConstructor()
 			->getMock();
-		$mailer = $this->getMockBuilder('OCP\IMailer')
+		$mailer = $this->getMockBuilder('OCP\Mail\IMailer')
 			->disableOriginalConstructor()
 			->getMock();
 		$commentMapper = $this->getMockBuilder('OCA\Polls\Db\CommentMapper')

--- a/tests/Unit/Controller/PageControllerTest.php
+++ b/tests/Unit/Controller/PageControllerTest.php
@@ -89,23 +89,21 @@ class PageControllerTest extends UnitTestCase {
 
 		$this->controller = new PageController(
 			'polls',
-			$avatarManager,
-			$config,
-			$groupManager,
-			$l10n,
-			$logger,
 			$request,
-			$urlGenerator,
-			$user,
+			$config,
 			$userManager,
-			$transFactory,
-			$mailer,
+			$groupManager,
+			$avatarManager,
+			$logger,
+			$l10n,
+			$urlGenerator,
+			$this->userId,
 			$commentMapper,
-			$optionsMapper,
 			$eventMapper,
 			$notificationMapper,
+			$optionsMapper,
 			$votesMapper,
-			$this->userId
+			$mailer
 		);
 	}
 

--- a/tests/Unit/Controller/PageControllerTest.php
+++ b/tests/Unit/Controller/PageControllerTest.php
@@ -104,7 +104,7 @@ class PageControllerTest extends UnitTestCase {
 			$optionsMapper,
 			$eventMapper,
 			$notificationMapper,
-			$votesMapper
+			$votesMapper,
 			$this->userId,
 		);
 	}

--- a/tests/Unit/Controller/PageControllerTest.php
+++ b/tests/Unit/Controller/PageControllerTest.php
@@ -105,7 +105,7 @@ class PageControllerTest extends UnitTestCase {
 			$eventMapper,
 			$notificationMapper,
 			$votesMapper,
-			$this->userId,
+			$this->userId
 		);
 	}
 

--- a/tests/Unit/Controller/PageControllerTest.php
+++ b/tests/Unit/Controller/PageControllerTest.php
@@ -38,25 +38,37 @@ class PageControllerTest extends UnitTestCase {
 	 * {@inheritDoc}
 	 */
 	public function setUp() {
-		$request = $this->getMockBuilder('OCP\IRequest')
+		$avatarManager = $this->getMockBuilder('OCP\IAvatarManager')
 			->disableOriginalConstructor()
 			->getMock();
-		$userManager = $this->getMockBuilder('OCP\IUserManager')
+		$config = $this->getMockBuilder('OCP\IConfig')
 			->disableOriginalConstructor()
 			->getMock();
 		$groupManager = $this->getMockBuilder('OCP\IGroupManager')
 			->disableOriginalConstructor()
 			->getMock();
-		$avatarManager = $this->getMockBuilder('OCP\IAvatarManager')
+		$l10n = $this->getMockBuilder('OCP\IL10N')
 			->disableOriginalConstructor()
 			->getMock();
 		$logger = $this->getMockBuilder('OCP\ILogger')
 			->disableOriginalConstructor()
 			->getMock();
-		$l10n = $this->getMockBuilder('OCP\IL10N')
+		$request = $this->getMockBuilder('OCP\IRequest')
 			->disableOriginalConstructor()
 			->getMock();
 		$urlGenerator = $this->getMockBuilder('OCP\IURLGenerator')
+			->disableOriginalConstructor()
+			->getMock();
+		$user = $this->getMockBuilder('OCP\IUser')
+			->disableOriginalConstructor()
+			->getMock();
+		$userManager = $this->getMockBuilder('OCP\IUserManager')
+			->disableOriginalConstructor()
+			->getMock();
+		$transFactory = $this->getMockBuilder('OCP\IL10N\IFactory')
+			->disableOriginalConstructor()
+			->getMock();
+		$mailer = $this->getMockBuilder('OCP\IMailer')
 			->disableOriginalConstructor()
 			->getMock();
 		$commentMapper = $this->getMockBuilder('OCA\Polls\Db\CommentMapper')
@@ -77,19 +89,23 @@ class PageControllerTest extends UnitTestCase {
 
 		$this->controller = new PageController(
 			'polls',
-			$request,
-			$userManager,
-			$groupManager,
 			$avatarManager,
-			$logger,
+			$config,
+			$groupManager,
 			$l10n,
+			$logger,
+			$request,
 			$urlGenerator,
-			$this->userId,
+			$user,
+			$userManager,
+			$transFactory,
+			$mailer,
 			$commentMapper,
 			$optionsMapper,
 			$eventMapper,
 			$notificationMapper,
 			$votesMapper
+			$this->userId,
 		);
 	}
 

--- a/tests/Unit/Controller/PageControllerTest.php
+++ b/tests/Unit/Controller/PageControllerTest.php
@@ -65,7 +65,7 @@ class PageControllerTest extends UnitTestCase {
 		$userManager = $this->getMockBuilder('OCP\IUserManager')
 			->disableOriginalConstructor()
 			->getMock();
-		$transFactory = $this->getMockBuilder('OCP\IL10N\IFactory')
+		$transFactory = $this->getMockBuilder('OCP\L10N\IFactory')
 			->disableOriginalConstructor()
 			->getMock();
 		$mailer = $this->getMockBuilder('OCP\IMailer')

--- a/tests/Unit/Controller/PageControllerTest.php
+++ b/tests/Unit/Controller/PageControllerTest.php
@@ -96,12 +96,13 @@ class PageControllerTest extends UnitTestCase {
 			$avatarManager,
 			$logger,
 			$l10n,
+			$transFactory,
 			$urlGenerator,
 			$this->userId,
 			$commentMapper,
+			$optionsMapper,
 			$eventMapper,
 			$notificationMapper,
-			$optionsMapper,
 			$votesMapper,
 			$mailer
 		);


### PR DESCRIPTION
> ![bildschirmfoto von 2018-11-15 22-31-54](https://user-images.githubusercontent.com/213943/48583123-a0c38f80-e926-11e8-8929-30922e75a05a.png)

I simplified the text of the email a bit.
Feel free to extend it again, but I think it's good and simple enough.

Alternative text I would suggest is:
* addHeading (black text on grey): `<title of poll>`
* addBodyText (grey text on white): `<user name> participated/voted`
* addBodyButton (white text on blue): `Go to poll`

Fix #178 
Fix #419 