### PR TITLE
Remove italic styling for winner entries, bold is enough

### DIFF
--- a/css/vote.scss
+++ b/css/vote.scss
@@ -76,7 +76,6 @@ $user-column-width: 265px;
 			}
 
 			.winner {
-				font-style: italic;
 				font-weight: bold;
 				color: $fg-yes;
 			}
@@ -148,7 +147,6 @@ $user-column-width: 265px;
 			content: attr(data-unvoted);
 			color: $fg-no;
 			font-size: 14px;
-			font-style: italic;
 			font-weight: bold;
 			line-height: 38px;
 		}


### PR DESCRIPTION
We never use italic and it just is not very readable or well-looking:
![polls heading](https://user-images.githubusercontent.com/925062/48733399-e3e17380-ec42-11e8-854c-bec9a952b075.png)


Please review @nextcloud/designers @nickvergessen @MorrisJobke @dartcafe 