### PR TITLE
Update max-version to current dev version 16

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -23,6 +23,6 @@
     <screenshot>https://raw.githubusercontent.com/nextcloud/polls/master/screenshots/vote.png</screenshot>
     <screenshot>https://raw.githubusercontent.com/nextcloud/polls/master/screenshots/edit-poll.png</screenshot>
     <dependencies>
-        <nextcloud min-version="14" max-version="15" />
+        <nextcloud min-version="14" max-version="16" />
     </dependencies>
 </info>


### PR DESCRIPTION
This is necessary to make the Polls app work on the current master / dev version of Nextcloud which is version 16. :)

Please review @dartcafe @splitt3r @v1r0x 