### PR TITLE
fix link to create poll on empty main site

### DIFF
--- a/templates/main.tmpl.php
+++ b/templates/main.tmpl.php
@@ -60,7 +60,7 @@
 		<div id="emptycontent" class="">
 			<div class="icon-polls"></div>
 			<h2><?php p($l->t('No existing polls.')); ?></h2>
-			<a href="/index.php/apps/polls/create" class="button new">
+			<a href="<?php p($urlGenerator->linkToRoute('polls.page.create_poll')); ?>" class="button new">
 				<span><?php p($l->t('Click here to add a poll')); ?></span>
 			</a>
 		</div>


### PR DESCRIPTION
On an empty main site, the link to poll creation on the middle of the page is broken when nextcloud is running on a subfolder.

This PR fixes this by using the same link as used for the + button in the breadcrumb bar.