### PR TITLE
Fix color variable name in list.scss

### DIFF
--- a/css/list.scss
+++ b/css/list.scss
@@ -113,7 +113,7 @@ $mediabreak-3: $group-1-width + $owner-width + max($group-2-1-width, $group-2-2-
 
 .description {
 	width: $description-width;
-	color: var(--text-maxcontrast);
+	color: var(--color-text-maxcontrast);
 	}
 
 .owner {


### PR DESCRIPTION
Hi, I noticed the variable name --text-maxcontrast has been used. This variable hasn't actually been defined anywhere, so I have changed it to the variable name used by nextcloud server.