### PR TITLE
Update owncloud version

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -5,7 +5,7 @@
     <name>Polls</name>
     <summary>A polls app, similar to doodle/dudle with the possibility to restrict access.</summary>
     <description>A polls app, similar to doodle/dudle with the possibility to restrict access (members, certain groups/users, hidden and public).</description>
-    <version>0.8.3</version>
+    <version>0.8.3.1</version>
     <licence>agpl</licence>
     <author>Vinzenz Rosenkranz</author>
     <author>René Gieling</author>
@@ -23,7 +23,7 @@
     <screenshot>https://raw.githubusercontent.com/nextcloud/polls/master/screenshots/vote.png</screenshot>
     <screenshot>https://raw.githubusercontent.com/nextcloud/polls/master/screenshots/edit-poll.png</screenshot>
     <dependencies>
-        <owncloud min-version="8.2" max-version="10.0" />
+        <owncloud min-version="8.2" max-version="10" />
         <nextcloud min-version="11" max-version="14" />
     </dependencies>
 </info>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -5,7 +5,7 @@
     <name>Polls</name>
     <summary>A polls app, similar to doodle/dudle with the possibility to restrict access.</summary>
     <description>A polls app, similar to doodle/dudle with the possibility to restrict access (members, certain groups/users, hidden and public).</description>
-    <version>0.8.3.1</version>
+    <version>0.8.4</version>
     <licence>agpl</licence>
     <author>Vinzenz Rosenkranz</author>
     <author>René Gieling</author>


### PR DESCRIPTION
> App developers should re-release their apps after setting the “max-version” field to “10” instead of “10.0” in “appinfo/info.xml”, and increase the app’s version as well
to make sure ownCloud picks up the change. This is required because else ownCloud 10.1 will think that the apps are not compatible any more and will refuse to update or enable them.

https://central.owncloud.org/t/owncloud-core-switching-to-semver-apps-need-re-release/17054