### PR TITLE
Fix query params in eventmapper

### DIFF
--- a/lib/Db/EventMapper.php
+++ b/lib/Db/EventMapper.php
@@ -78,7 +78,7 @@ class EventMapper extends Mapper {
 	 */
 	public function findAll($limit = null, $offset = null) {
 		$sql = 'SELECT * FROM ' . $this->getTableName();
-		return $this->findEntities($sql, ['*'], $limit, $offset);
+		return $this->findEntities($sql, [], $limit, $offset);
 	}
 
 	/**


### PR DESCRIPTION
The `findAll` query requires no params, thus `['*']` throws an error. This PR simply removes the param.