### PR TITLE
Fix TypeError exception

### DIFF
--- a/lib/Db/NotificationMapper.php
+++ b/lib/Db/NotificationMapper.php
@@ -73,7 +73,7 @@ class NotificationMapper extends QBMapper {
 	        	$qb->expr()->eq('user_id', $qb->createNamedParameter($userId, IQueryBuilder::PARAM_STR))
 	        );
 
-		 return $this->findEntities($qb);
+		 return $this->findEntity($qb);
 	}
 
 	/**


### PR DESCRIPTION
I get the following exception when storing votes with email notifications disabled:

```
Argument 1 passed to OCP\AppFramework\Db\QBMapper::delete() must be an instance of OCP\AppFramework\Db\Entity, array given, called in …/apps/polls/lib/Controller/PageController.php on line 328
```

The fix seems obvious, since the function `findByUserAndPoll()` in `NotificationMapper` does in fact return an array, which is inconsistent with its documentation and its callers.