### PR TITLE
Load different sidebar when user has (no) edit rights

### DIFF
--- a/src/js/components/SideBar/SideBarOnlyComments.vue
+++ b/src/js/components/SideBar/SideBarOnlyComments.vue
@@ -1,0 +1,79 @@
+<!--
+  - @copyright Copyright (c) 2018 René Gieling <github@dartcafe.de>
+  -
+  - @author René Gieling <github@dartcafe.de>
+  -
+  - @license GNU AGPL version 3 or any later version
+  -
+  - This program is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU Affero General Public License as
+  - published by the Free Software Foundation, either version 3 of the
+  - License, or (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  - GNU Affero General Public License for more details.
+  -
+  - You should have received a copy of the GNU Affero General Public License
+  - along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -
+  -->
+
+<template>
+	<AppSidebar ref="sideBar" :title="t('polls', 'Details')" @close="$emit('closeSideBar')">
+		<UserDiv slot="primary-actions" :user-id="poll.owner" :description="t('polls', 'Owner')" />
+
+		<AppSidebarTab :name="t('polls', 'Comments')" icon="icon-comment">
+			<SideBarTabComments />
+		</AppSidebarTab>
+	</AppSidebar>
+</template>
+
+<script>
+import { AppSidebar, AppSidebarTab } from '@nextcloud/vue'
+
+import SideBarTabComments from './SideBarTabComments'
+import { mapState } from 'vuex'
+
+export default {
+	name: 'SideBarOnlyComments',
+	components: {
+		SideBarTabComments,
+		AppSidebar,
+		AppSidebarTab
+	},
+
+	computed: {
+		...mapState({
+			poll: state => state.poll,
+			acl: state => state.acl
+		})
+	}
+
+}
+
+</script>
+
+<style scoped lang="scss">
+
+	ul {
+		& > li {
+			margin-bottom: 30px;
+			& > .comment-item {
+				display: flex;
+				align-items: center;
+
+				& > .date {
+					right: 0;
+					top: 5px;
+					opacity: 0.5;
+				}
+			}
+			& > .message {
+				margin-left: 44px;
+				flex: 1 1;
+			}
+		}
+	}
+</style>

--- a/src/js/views/Vote.vue
+++ b/src/js/views/Vote.vue
@@ -30,7 +30,8 @@
 			<Subscription />
 		</div>
 
-		<SideBar v-if="sideBarOpen" @closeSideBar="toggleSideBar" />
+		<SideBar v-if="sideBarOpen && acl.allowEdit" @closeSideBar="toggleSideBar" />
+		<SideBarOnlyComments v-if="sideBarOpen && !acl.allowEdit" @closeSideBar="toggleSideBar" />
 		<LoadingOverlay v-if="loading" />
 	</AppContent>
 </template>
@@ -40,6 +41,7 @@ import Subscription from '../components/Subscription/Subscription'
 import VoteHeader from '../components/VoteTable/VoteHeader'
 import VoteTable from '../components/VoteTable/VoteTable'
 import SideBar from '../components/SideBar/SideBar'
+import SideBarOnlyComments from '../components/SideBar/SideBarOnlyComments'
 import { mapState, mapGetters } from 'vuex'
 
 export default {
@@ -48,6 +50,7 @@ export default {
 		Subscription,
 		VoteHeader,
 		VoteTable,
+		SideBarOnlyComments,
 		SideBar
 	},
 


### PR DESCRIPTION
Workaround for nextcloud/nextcloud-vue/issues/747 with an ugly animation. Prevents displaying wrong tabs, when user ha (no) edit rights. Otherwise a sidebar wth empty or missing tabs is rendered and maybe confusing to normal users. 