### PR TITLE
use submit event of form to add a comment

### DIFF
--- a/src/js/components/Comments/CommentAdd.vue
+++ b/src/js/components/Comments/CommentAdd.vue
@@ -24,11 +24,9 @@
 	<div class="newCommentRow comment new-comment">
 		<user-div :user-id="currentUser" />
 
-		<form class="commentAdd" name="send-comment">
-			<input v-model="comment" class="message" data-placeholder="New Comment ..."
-				@keyup.enter="writeComment">
-			<button v-show="!isLoading" class="submit-comment icon-confirm"
-				@click="writeComment" />
+		<form class="commentAdd" name="send-comment" @submit="writeComment">
+			<input v-model="comment" class="message" data-placeholder="New Comment ..."/>
+			<button v-show="!isLoading" type="submit" class="submit-comment icon-confirm"></button>
 			<span v-show="isLoading" class="icon-loading-small" style="float:right;" />
 		</form>
 	</div>


### PR DESCRIPTION
I simplified the comment form by removing the duplicate `writeComment` call.
`@submit` on form is triggered when
1. clicked on button with `type="submit"`
2. hit enter in an input field