### PR TITLE
Share poll via email #822

### DIFF
--- a/lib/Controller/PollController.php
+++ b/lib/Controller/PollController.php
@@ -178,7 +178,6 @@ class PollController extends Controller {
 	 * @return DataResponse
 	 */
 	public function getByToken($token) {
-
 		try {
 			return $this->get($this->acl->setToken($token)->getPollId());
 		} catch (DoesNotExistException $e) {

--- a/lib/Controller/ShareController.php
+++ b/lib/Controller/ShareController.php
@@ -210,6 +210,14 @@ class ShareController extends Controller {
 				$userShare = $this->mapper->insert($userShare);
 				return new DataResponse($userShare, Http::STATUS_OK);
 
+			} elseif ($publicShare->getType() === 'email') {
+
+				$publicShare->setType('external');
+				$publicShare->setUserId($userName);
+				$this->mapper->update($publicShare);
+				$this->logger->alert(json_encode($publicShare));
+				return new DataResponse($publicShare, Http::STATUS_OK);
+
 			} else {
 				return new DataResponse(['message'=> 'Wrong share type: ' . $userShare->getType()], Http::STATUS_FORBIDDEN);
 			}

--- a/lib/Controller/SystemController.php
+++ b/lib/Controller/SystemController.php
@@ -83,6 +83,16 @@ class SystemController extends Controller {
 	}
 
 	/**
+	 * Validate string as email address
+	 * @NoAdminRequired
+	 * @param string $query
+	 * @return Boolval
+	 */
+	 private function isValidEmail($email) {
+		 return (!preg_match('/^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/', $email)) ? FALSE : TRUE;
+	 }
+
+	/**
 	 * Get a list of NC users, groups and contacts
 	 * @NoCSRFRequired
 	 * @NoAdminRequired
@@ -94,8 +104,28 @@ class SystemController extends Controller {
 	 * @param array $skipUsers - user names to skip in return array
 	 * @return DataResponse
 	 */
-	public function getSiteUsersAndGroups($query = '', $getGroups = true, $getUsers = true, $getContacts = true, $skipGroups = array(), $skipUsers = array()) {
+	public function getSiteUsersAndGroups($query = '', $getGroups = true, $getUsers = true, $getContacts = true, $getMail = false, $skipGroups = array(), $skipUsers = array()) {
 		$list = array();
+		// if (filter_var($query, FILTER_VALIDATE_EMAIL)) {
+		if ($this->isValidEmail($query)) {
+			$list[] = [
+				'id' => '',
+				'user' => '',
+				'organisation' => '',
+				'displayName' => '',
+				'emailAddress' => $query,
+				'desc' => $query,
+				'type' => 'email',
+				'icon' => 'icon-mail',
+				'avatarURL' => '',
+				'avatar' => '',
+				'lastLogin' => '',
+				'cloudId' => ''
+
+			];
+		}
+
+
 		if ($getGroups) {
 			$groups = $this->groupManager->search($query);
 			foreach ($groups as $group) {

--- a/lib/Controller/VoteController.php
+++ b/lib/Controller/VoteController.php
@@ -135,7 +135,6 @@ class VoteController extends Controller {
 	 */
 	public function set($pollId, $option, $userId, $setTo) {
 
-		$this->logger->alert('Deleting vote no. ' . $option);
 		try {
 			$vote = $this->mapper->findSingleVote($pollId, $option['pollOptionText'], $userId);
 			$vote->setVoteAnswer($setTo);

--- a/lib/Model/Acl.php
+++ b/lib/Model/Acl.php
@@ -249,7 +249,7 @@ class Acl implements JsonSerializable {
 
 		return count(
 			array_filter($this->shareMapper->findByPoll($this->getPollId()), function($item) {
-				if (($item->getType() === 'user' || $item->getType() === 'external') && $item->getUserId() === $this->getUserId()) {
+				if (($item->getType() === 'user' || $item->getType() === 'external' || $item->getType() === 'email') && $item->getUserId() === $this->getUserId()) {
 					return true;
 				}
 			})

--- a/lib/Service/MailService.php
+++ b/lib/Service/MailService.php
@@ -266,18 +266,16 @@ class MailService {
 		$owner = $this->userManager->get($poll->getOwner());
 		$sentMails = [];
 		$abortedMails = [];
-		// $this->logger->debug('Search users for token ' . $token);
+
 		$recipients = $this->getRecipientsByShare(
 			$this->shareMapper->findByToken($token),
 			$this->config->getUserValue($poll->getOwner(), 'core', 'lang'),
 			$poll->getOwner()
 		);
 
-		// $this->logger->debug('Found these recipients: ' . json_encode($recipients));
 		foreach ($recipients as $recipient) {
 			$trans = $this->transFactory->get('polls', $recipient['language']);
 
-			// $this->logger->debug('Build eMailTemplate for  ' . $recipient['userId']);
 
 			$emailTemplate = $this->mailer->createEMailTemplate('polls.Invitation', [
 				'owner' => $owner->getDisplayName(),
@@ -300,7 +298,10 @@ class MailService {
 				$recipient['link']
 			);
 
-			$emailTemplate->addFooter($trans->t('This email is sent to you, because you are invited to vote in this poll by the poll owner.'));
+			$emailTemplate->addBodyText( $trans->t('This link gives you personal access to the poll named above. </br> Press the button above or copy the following link and add it in your browser\'s location bar: ') );
+			$emailTemplate->addBodyText( $recipient['link'] );
+
+			$emailTemplate->addFooter($trans->t('This email is sent to you, because you are invited to vote in this poll by the poll owner. At least your name or your email address is recorded in this poll. If you want to get removed from this poll, contact the site administrator or the initiator of this poll, where the mail is sent from.'));
 
 			try {
 				// $this->logger->debug('Send Mail to ' . $recipient);

--- a/lib/Service/MailService.php
+++ b/lib/Service/MailService.php
@@ -170,6 +170,22 @@ class MailService {
 				)
 			);
 
+		} elseif ($share->getType() === 'email') {
+			// $this->logger->debug('User share ' . json_encode($share));
+
+			$recipients[] = array(
+				'userId' => $share->getUserEmail(),
+				'eMailAddress' => $share->getUserEmail(),
+				'displayName' => $share->getUserEmail(),
+				'language' => $defaultLang,
+				'link' => $this->urlGenerator->getAbsoluteURL(
+					$this->urlGenerator->linkToRoute(
+						'polls.page.vote_publicpublic',
+						array('token' => $share->getToken())
+					)
+				)
+			);
+
 		} elseif ($share->getType() === 'contact') {
 			// $this->logger->debug('Contact share ' . json_encode($share));
 			$contacts = $contactsManager->search($share->getUserId(), array('FN'));
@@ -192,7 +208,7 @@ class MailService {
 				return;
 			}
 
-		} elseif ($share->getType() === 'external' || $share->getType() === 'mail') {
+		} elseif ($share->getType() === 'external' || $share->getType() === 'email') {
 			// $this->logger->debug('External share ' . json_encode($share));
 
 			$recipients[] = array(

--- a/src/js/components/Base/UserDiv.vue
+++ b/src/js/components/Base/UserDiv.vue
@@ -104,28 +104,14 @@ export default {
 			if (this.icon) {
 				if (this.type === 'contact') {
 					return 'icon-mail'
+				} else if (this.type === 'email') {
+					return 'icon-mail'
 				}
 				return 'icon-' + this.type
 			} else {
 				return ''
 			}
 		}
-
-		// computedDisplayName() {
-		// 	let value = this.displayName
-		//
-		// 	if (!this.displayName) {
-		// 		if (this.type === 'user') {
-		// 			value = this.userId
-		// 		} else if (this.type === 'group') {
-		// 			value = value + ' (' + t('polls', 'Group') + ')'
-		// 		} else {
-		// 			value = this.userId
-		// 		}
-		// 	}
-		// 	return value
-
-		// }
 	}
 }
 

--- a/src/js/components/SideBar/SideBarTabShare.vue
+++ b/src/js/components/SideBar/SideBarTabShare.vue
@@ -28,7 +28,7 @@
 
 		<h3>{{ t('polls','Invitations') }}</h3>
 
-		<span>{{ t('polls','Invited users will get informed immediately via eMail!') }} </span>
+		<span>{{ t('polls','Invited users will get informed immediately via email!') }} </span>
 		<TransitionGroup :css="false" tag="ul" class="shared-list">
 			<li v-for="(share) in invitationShares" :key="share.id">
 				<UserDiv
@@ -127,6 +127,7 @@ export default {
 				getUsers: true,
 				getGroups: true,
 				getContacts: true,
+				getMail: true,
 				query: ''
 			}
 		}
@@ -141,7 +142,6 @@ export default {
 			'invitationShares',
 			'publicShares'
 		])
-
 	},
 
 	methods: {
@@ -172,7 +172,7 @@ export default {
 
 			if (share.userId !== '' && share.userId !== null) {
 				return share.userId
-			} else if (share.type === 'mail') {
+			} else if (share.type === 'email') {
 				return share.userEmail
 			} else {
 				return t('polls', 'Unknown user')
@@ -190,7 +190,7 @@ export default {
 				if (share.userEmail) {
 					displayName = displayName + ' (' + share.userEmail + ')'
 				}
-			} else if (share.type === 'mail') {
+			} else if (share.type === 'email') {
 				displayName = share.userEmail
 				if (share.userId) {
 					displayName = share.userId + ' (' + displayName + ')'

--- a/src/js/components/VoteTable/VoteHeaderPublic.vue
+++ b/src/js/components/VoteTable/VoteHeaderPublic.vue
@@ -185,9 +185,14 @@ export default {
 			if (this.validatePublicUsername()) {
 				this.$store.dispatch('createPersonalShare', { token: this.$route.params.token, userName: this.userName })
 					.then((response) => {
-						this.token = response.token
-						this.redirecting = true
-						this.$router.replace({ name: 'publicVote', params: { token: response.token } })
+						if (this.$route.params.token === response.token) {
+							this.$store.dispatch({ type: 'loadPollMain', pollId: this.$route.params.id, token: this.$route.params.token })
+							// this.$router.go(0)
+						} else {
+							this.token = response.token
+							this.redirecting = true
+							this.$router.replace({ name: 'publicVote', params: { token: this.token } })
+						}
 					})
 					.catch(() => {
 						OC.Notification.showTemporary(t('polls', 'Error saving username', 1, this.poll.title), { type: 'error' })

--- a/src/js/store/modules/shares.js
+++ b/src/js/store/modules/shares.js
@@ -58,7 +58,7 @@ const getters = {
 	},
 
 	invitationShares: state => {
-		const invitationTypes = ['user', 'group', 'mail', 'external', 'contact']
+		const invitationTypes = ['user', 'group', 'email', 'external', 'contact']
 		return state.list.filter(function(share) {
 			return invitationTypes.includes(share.type)
 		})

--- a/src/js/views/Vote.vue
+++ b/src/js/views/Vote.vue
@@ -35,12 +35,19 @@
 					</ActionButton>
 				</Actions>
 			</div>
+
 			<PollTitle class="poll-title" />
+
 			<PollInformation />
+
 			<VoteHeaderPublic v-if="!OC.currentUser" />
+
 			<PollDescription />
+
 			<VoteList v-show="!tableMode && options.list.length" />
+
 			<VoteTable v-show="tableMode && options.list.length" />
+
 			<div v-if="!options.list.length" class="emptycontent">
 				<div class="icon-toggle-filelist" />
 				<button v-if="acl.allowEdit" @click="openOptions">
@@ -52,6 +59,7 @@
 			</div>
 
 			<Subscription v-if="OC.currentUser" />
+
 			<div class="additional">
 				<ParticipantsList v-if="acl.allowSeeUsernames" />
 			</div>


### PR DESCRIPTION
fix #822 
Enter email address and select the user
![grafik](https://user-images.githubusercontent.com/26707476/77846643-c23db800-71b7-11ea-98b4-c682d13a160e.png)
Email is sent out to some.user@foo.com
After the user enters a username, the share type is updated from email invitation to external share.
The initial share token stays valid.
![grafik](https://user-images.githubusercontent.com/26707476/77846667-f022fc80-71b7-11ea-9ac2-97d52766a79e.png)

