### PR TITLE
[1.4.0 beta1] Fix datetimepicker

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 	"dependencies": {
 		"@nextcloud/axios": "^1.3.1",
 		"@nextcloud/router": "^1.0.0",
-		"@nextcloud/vue": "^1.3.0",
+		"@nextcloud/vue": "^1.4.1",
 		"core-js": "^3.6.4",
 		"lodash": "^4.17.15",
 		"moment": "^2.23.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 	"dependencies": {
 		"@nextcloud/axios": "^1.3.1",
 		"@nextcloud/router": "^1.0.0",
-		"@nextcloud/vue": "^1.4.1",
+		"@nextcloud/vue": "^1.5.0",
 		"core-js": "^3.6.4",
 		"lodash": "^4.17.15",
 		"moment": "^2.23.0",

--- a/src/js/components/SideBar/SideBarTabConfiguration.vue
+++ b/src/js/components/SideBar/SideBarTabConfiguration.vue
@@ -106,15 +106,6 @@ export default {
 			acl: state => state.acl
 		}),
 
-		firstDOW() {
-			// vue2-datepicker needs 7 for sunday
-			if (moment.localeData()._week.dow === 0) {
-				return 7
-			} else {
-				return moment.localeData()._week.dow
-			}
-		},
-
 		// Add bindings
 		pollDescription: {
 			get() {
@@ -145,7 +136,7 @@ export default {
 
 		pollExpire: {
 			get() {
-				return moment.unix(this.poll.expire)
+				return moment.unix(this.poll.expire)._d
 			},
 			set(value) {
 
@@ -194,32 +185,31 @@ export default {
 			}
 		},
 
+		firstDOW() {
+			// vue2-datepicker needs 7 for sunday
+			if (moment.localeData()._week.dow === 0) {
+				return 7
+			} else {
+				return moment.localeData()._week.dow
+			}
+		},
+
 		expirationDatePicker() {
 			return {
 				editable: true,
 				minuteStep: 1,
 				type: 'datetime',
 				format: moment.localeData().longDateFormat('L') + ' ' + moment.localeData().longDateFormat('LT'),
-
-				// TODO: use this for version 2.x
-				lang: OC.getLanguage().split('-')[0],
-				firstDayOfWeek: this.firstDOW,
-
-				// TODO: use this from version 3.x on
-				// lang: {
-				// 	formatLocale: {
-				//		firstDayOfWeek: this.firstDOW,
-				// 		months: moment.months(),
-				// 		monthsShort: moment.monthsShort(),
-				// 		weekdays: moment.weekdays(),
-				// 		weekdaysMin: moment.weekdaysMin()
-				// 	}
-				// },
 				placeholder: t('polls', 'Expiration date'),
-				timePickerOptions: {
-					start: '00:00',
-					step: '01:00',
-					end: '23:30'
+				confirm: true,
+				lang: {
+					formatLocale: {
+						firstDayOfWeek: this.firstDOW,
+						months: moment.months(),
+						monthsShort: moment.monthsShort(),
+						weekdays: moment.weekdays(),
+						weekdaysMin: moment.weekdaysMin()
+					}
 				}
 			}
 		},

--- a/src/js/components/SideBar/SideBarTabOptionsDate.vue
+++ b/src/js/components/SideBar/SideBarTabOptionsDate.vue
@@ -166,28 +166,19 @@ export default {
 		optionDatePicker() {
 			return {
 				editable: false,
+				minuteStep: 1,
 				type: 'datetime',
 				format: moment.localeData().longDateFormat('L') + ' ' + moment.localeData().longDateFormat('LT'),
-
-				// TODO: use this for version 2.x
-				lang: OC.getLanguage().split('-')[0],
-				firstDayOfWeek: this.firstDOW,
-
-				// TODO: use this from version 3.x on
-				// lang: {
-				// 	formatLocale: {
-				//		firstDayOfWeek: this.firstDOW,
-				// 		months: moment.months(),
-				// 		monthsShort: moment.monthsShort(),
-				// 		weekdays: moment.weekdays(),
-				// 		weekdaysMin: moment.weekdaysMin()
-				// 	}
-				// },
 				placeholder: t('polls', 'Click to add a date'),
-				timePickerOptions: {
-					start: '00:00',
-					step: '00:30',
-					end: '23:30'
+				confirm: true,
+				lang: {
+					formatLocale: {
+						firstDayOfWeek: this.firstDOW,
+						months: moment.months(),
+						monthsShort: moment.monthsShort(),
+						weekdays: moment.weekdays(),
+						weekdaysMin: moment.weekdaysMin()
+					}
 				}
 			}
 		}


### PR DESCRIPTION
* fixed setting of expiration date 
* updated @nextcloud/vue to latest version (1.4.1) at least for security fixes
* updated date-picker options to new format (vue2-datepicker 3.4.1, which came with @nextcloud/vue 1.4.1)
  * switched to `minuteStep: 1` fixes #826
* Changed picker layout 
![grafik](https://user-images.githubusercontent.com/26707476/78719899-f8e8a080-7924-11ea-81e3-7ff02d7dc126.png)



