### PR TITLE
hide results

### DIFF
--- a/lib/Controller/VoteController.php
+++ b/lib/Controller/VoteController.php
@@ -111,7 +111,9 @@ class VoteController extends Controller {
 				$this->acl->setPollId($pollId);
 			}
 
-			if (!$this->acl->getAllowSeeUsernames()) {
+			if (!$this->acl->getAllowSeeResults()) {
+				return new DataResponse((array) $this->mapper->findByPollAndUser($pollId, $this->userId), Http::STATUS_OK);
+			} elseif (!$this->acl->getAllowSeeUsernames()) {
 				$this->anonymizer->set($pollId, $this->acl->getUserId());
 				return new DataResponse((array) $this->anonymizer->getVotes(), Http::STATUS_OK);
 			} else {

--- a/lib/Db/VoteMapper.php
+++ b/lib/Db/VoteMapper.php
@@ -59,6 +59,27 @@ class VoteMapper extends QBMapper {
 	/**
 	 * @param int $pollId
 	 * @throws \OCP\AppFramework\Db\DoesNotExistException if not found
+	 * @return array
+	 */
+
+	public function findByPollAndUser($pollId, $userId) {
+		$qb = $this->db->getQueryBuilder();
+
+		$qb->select('*')
+		   ->from($this->getTableName())
+		   ->where(
+			   $qb->expr()->eq('poll_id', $qb->createNamedParameter($pollId, IQueryBuilder::PARAM_INT))
+		   )
+		   ->andWhere(
+			   $qb->expr()->eq('user_id', $qb->createNamedParameter($userId, IQueryBuilder::PARAM_STR))
+		   );
+
+		return $this->findEntities($qb);
+	}
+
+	/**
+	 * @param int $pollId
+	 * @throws \OCP\AppFramework\Db\DoesNotExistException if not found
 	 * @return Vote
 	 */
 

--- a/lib/Model/Acl.php
+++ b/lib/Model/Acl.php
@@ -320,6 +320,23 @@ class Acl implements JsonSerializable {
 	 * @NoAdminRequired
 	 * @return bool
 	 */
+	public function getAllowSeeResults(): bool {
+		if ($this->poll->getShowResults() === 'always' || $this->getIsOwner()) {
+		// if ($this->poll->getShowResults() === 'always') {
+			return true;
+		} elseif ($this->poll->getShowResults() === 'never') {
+			return false;
+		} elseif ($this->poll->getShowResults() === 'expired') {
+			return $this->getExpired();
+		} else {
+			return false;
+		}
+	}
+
+	/**
+	 * @NoAdminRequired
+	 * @return bool
+	 */
 	public function getAllowSeeUsernames(): bool {
 		return !($this->poll->getAnonymous() && !$this->getIsOwner()); ;
 	}
@@ -404,6 +421,7 @@ class Acl implements JsonSerializable {
 			'allowVote'         => $this->getAllowVote(),
 			'allowComment'      => $this->getAllowComment(),
 			'allowEdit'         => $this->getAllowEdit(),
+			'allowSeeResults'   => $this->getAllowSeeResults(),
 			'allowSeeUsernames' => $this->getAllowSeeUsernames(),
 			'allowSeeAllVotes'  => $this->getAllowSeeAllVotes(),
 			'userHasVoted'		=> $this->getUserHasVoted(),

--- a/src/js/components/Base/PollInformation.vue
+++ b/src/js/components/Base/PollInformation.vue
@@ -24,10 +24,12 @@
 	<div class="poll-information">
 		<UserBubble v-if="poll.owner" :user="poll.owner" :display-name="poll.ownerDisplayName" />
 		{{ t('polls', 'started this poll on %n. ', 1, moment.unix(poll.created).format('LLLL')) }}
-		<span v-if="expired">{{ t('polls', 'Voting is no more possible, because this poll expired since %n.', 1, moment.unix(poll.expire).format('LLLL')) }}</span>
+		<span v-if="expired">{{ t('polls', 'Voting is no more possible, because this poll expired since %n. ', 1, moment.unix(poll.expire).format('LLLL')) }}</span>
 		<span v-if="!expired && poll.expire && acl.allowVote">{{ t('polls', 'You can place your vote until %n. ', 1, moment.unix(poll.expire).format('LLLL')) }}</span>
 		<span v-if="poll.anonymous">{{ t('polls', 'The names of other participants are hidden, as this is an anonymous poll. ') }}</span>
-		<span>{{ n('polls', '%n person participated in this poll until now.', '%n persons participated in this poll until now.', participantsVoted.length) }}</span>
+		<span v-if="acl.allowSeeResults">{{ n('polls', '%n person participated in this poll until now.', '%n persons participated in this poll until now. ', participantsVoted.length) }}</span>
+		<span v-if="!acl.allowSeeResults">{{ t('polls', 'Results are hidden. ') }}</span>
+		<span v-if="!acl.allowSeeResults && poll.showResults === 'expired'">{{ t('polls', 'They will be revealed after the poll is expired. ') }}</span>
 	</div>
 </template>
 

--- a/src/js/components/SideBar/SideBarTabConfiguration.vue
+++ b/src/js/components/SideBar/SideBarTabConfiguration.vue
@@ -71,6 +71,22 @@
 			<label for="public" class="title">{{ t('polls', 'Visible to other users') }} </label>
 		</div>
 
+		<div class="config-box">
+			<label class="title icon-category-auth"> {{ t('polls', 'Result display') }} </label>
+
+			<input id="always" v-model="pollShowResults" value="always"
+				type="radio" class="radio">
+			<label for="always" class="title">{{ t('polls', 'Always show results') }} </label>
+
+			<input id="expired" v-model="pollShowResults" value="expired"
+				type="radio" class="radio">
+			<label for="expired" class="title">{{ t('polls', 'Hide results until poll is expired') }} </label>
+
+			<input id="never" v-model="pollShowResults" value="never"
+				type="radio" class="radio">
+			<label for="never" class="title">{{ t('polls', 'Never show results') }} </label>
+		</div>
+
 		<ButtonDiv :icon="poll.deleted ? 'icon-history' : 'icon-delete'" :title="poll.deleted ? t('polls', 'Restore poll') : t('polls', 'Delete poll')"
 			@click="switchDeleted()" />
 		<ButtonDiv v-if="poll.deleted" icon="icon-delete" class="error"
@@ -140,6 +156,15 @@ export default {
 			},
 			set(value) {
 				this.writeValue({ access: value })
+			}
+		},
+
+		pollShowResults: {
+			get() {
+				return this.poll.showResults
+			},
+			set(value) {
+				this.writeValue({ showResults: value })
 			}
 		},
 

--- a/src/js/components/SideBar/SideBarTabConfiguration.vue
+++ b/src/js/components/SideBar/SideBarTabConfiguration.vue
@@ -72,7 +72,7 @@
 		</div>
 
 		<div class="config-box">
-			<label class="title icon-category-auth"> {{ t('polls', 'Result display') }} </label>
+			<label class="title icon-screen"> {{ t('polls', 'Result display') }} </label>
 
 			<input id="always" v-model="pollShowResults" value="always"
 				type="radio" class="radio">


### PR DESCRIPTION
resolves #265 
Added "Show results" to configuration:
* always
* after poll expiration
* never

![grafik](https://user-images.githubusercontent.com/26707476/78995272-4aba4200-7b42-11ea-855a-ed0fae4b62ae.png)

The poll owner will see the results always and the participants get an information, that the result is hidden.
![grafik](https://user-images.githubusercontent.com/26707476/78995334-6b829780-7b42-11ea-9ab8-9c118f1e9702.png)


