### PR TITLE
mobile view indicate votes via bar

### DIFF
--- a/src/js/components/Base/Counter.vue
+++ b/src/js/components/Base/Counter.vue
@@ -22,7 +22,7 @@
 
 <template>
 	<div class="counter">
-		<div v-if="iconStyle" class="counter--icon">
+		<div v-if="counterStyle === 'iconStyle'" class="counter--icon">
 			<div class="yes">
 				<span>{{ option.yes }}</span>
 			</div>
@@ -34,7 +34,7 @@
 			</div>
 		</div>
 
-		<div v-if="bubbleStyle" class="counter--bubble">
+		<div v-if="counterStyle === 'bubbleStyle'" class="counter--bubble">
 			<div v-if="showNo" class="no" :style="{flex: option.no }">
 				<span />
 			</div>
@@ -45,6 +45,20 @@
 
 			<div v-if="option.yes" class="yes" :style="{ flex: option.yes }">
 				<span> {{ option.yes }} </span>
+			</div>
+		</div>
+
+		<div v-if="counterStyle === 'barStyle'" class="counter--bar">
+			<div v-if="showNo" class="no" :style="{flex: option.no }">
+				<span />
+			</div>
+
+			<div v-if="option.yes" class="yes" :style="{ flex: option.yes }">
+				<span />
+			</div>
+
+			<div v-if="option.maybe && showMaybe" class="maybe" :style="{flex: option.maybe }">
+				<span />
 			</div>
 		</div>
 	</div>
@@ -60,9 +74,9 @@ export default {
 			type: Object,
 			default: undefined,
 		},
-		bubbleStyle: {
-			type: Boolean,
-			default: false,
+		counterStyle: {
+			type: String,
+			default: 'iconStyle',
 		},
 		showMaybe: {
 			type: Boolean,
@@ -71,11 +85,6 @@ export default {
 		showNo: {
 			type: Boolean,
 			default: false,
-		},
-	},
-	computed: {
-		iconStyle() {
-			return !this.bubbleStyle
 		},
 	},
 }
@@ -135,8 +144,34 @@ export default {
 	}
 
 	.no {
-		// background-color: var(--color-polls-foreground-no);
 		background-color: transparent;
+	}
+
+}
+
+.counter--bar {
+	display: flex;
+	width: 100%;
+	flex: 1;
+	height: 4px;
+
+	> * {
+		text-align: center;
+	}
+
+	.yes {
+		background-color: var(--color-polls-foreground-yes);
+		order: 1;
+	}
+
+	.maybe {
+		background-color: var(--color-polls-foreground-maybe);
+		order: 2;
+	}
+
+	.no {
+		background-color: transparent;
+		order: 3;
 	}
 
 }

--- a/src/js/components/VoteTable/VoteTableHeaderItem.vue
+++ b/src/js/components/VoteTable/VoteTableHeaderItem.vue
@@ -27,7 +27,7 @@
 		<Confirmation v-if="isConfirmed" :option="option" />
 		<Counter v-else :show-maybe="Boolean(poll.allowMaybe)"
 			:option="option"
-			:bubble-style="!tableMode"
+			:counter-style="tableMode ? 'iconStyle' : 'barStyle'"
 			:show-no="!tableMode" />
 	</div>
 </template>
@@ -104,10 +104,15 @@ export default {
 }
 
 .mobile {
+	.vote-table-header-item {
+		flex-direction: column;
+		&.confirmed {
+			flex-direction: row;
+		}
+	}
 	.counter {
 		flex: 1;
 		order: 2;
-		width: 130px;
 	}
 
 	.confirmation {


### PR DESCRIPTION
Changed rank indicator from pills/bubbles to a bar in mobile view
Before
![rank-bubbles view](https://user-images.githubusercontent.com/26707476/89107710-3670bc80-d433-11ea-8b3d-14d7a67b032d.png)

After
![rank-bar-view](https://user-images.githubusercontent.com/26707476/89107691-18a35780-d433-11ea-8a9d-09da0381a1b0.png)
