### PR TITLE
Default view for poll types

### DIFF
--- a/src/js/components/Navigation/NavigationSettings.vue
+++ b/src/js/components/Navigation/NavigationSettings.vue
@@ -26,6 +26,14 @@
 			type="checkbox" class="checkbox">
 		<label for="calendarPeek">{{ t('polls', 'Use calendar lookup') }}</label>
 
+		<input id="defaultViewTextPoll" v-model="defaultViewTextPoll"
+			type="checkbox" class="checkbox">
+		<label for="defaultViewTextPoll">{{ t('polls', 'Text polls default to table view') }}</label>
+
+		<input id="defaultViewDatePoll" v-model="defaultViewDatePoll"
+			type="checkbox" class="checkbox">
+		<label for="defaultViewDatePoll">{{ t('polls', 'Date polls default to table view') }}</label>
+
 		<input id="experimental" v-model="experimental"
 			type="checkbox" class="checkbox">
 		<label for="experimental">{{ t('polls', 'Try experimental styles') }}</label>
@@ -55,11 +63,52 @@ import { mapState } from 'vuex'
 export default {
 	name: 'NavigationSettings',
 
+	data() {
+		return {
+			viewOptions: [
+				'desktop',
+				'mobile',
+			],
+		}
+	},
+
 	computed: {
 		...mapState({
 			settings: state => state.settings.user,
 		}),
 		// Add bindings
+		calendarPeek: {
+			get() {
+				return this.settings.calendarPeek
+			},
+			set(value) {
+				this.writeValue({ calendarPeek: value })
+			},
+		},
+		defaultViewTextPoll: {
+			get() {
+				return (this.settings.defaultViewTextPoll === 'mobile')
+			},
+			set(value) {
+				if (value) {
+					this.writeValue({ defaultViewTextPoll: 'mobile' })
+				} else {
+					this.writeValue({ defaultViewTextPoll: 'desktop' })
+				}
+			},
+		},
+		defaultViewDatePoll: {
+			get() {
+				return (this.settings.defaultViewDatePoll === 'mobile')
+			},
+			set(value) {
+				if (value) {
+					this.writeValue({ defaultViewDatePoll: 'mobile' })
+				} else {
+					this.writeValue({ defaultViewDatePoll: 'desktop' })
+				}
+			},
+		},
 		experimental: {
 			get() {
 				return this.settings.experimental
@@ -90,14 +139,6 @@ export default {
 			},
 			set(value) {
 				this.writeValue({ glassyNavigation: value })
-			},
-		},
-		calendarPeek: {
-			get() {
-				return this.settings.calendarPeek
-			},
-			set(value) {
-				this.writeValue({ calendarPeek: value })
 			},
 		},
 		glassySidebar: {

--- a/src/js/components/VoteTable/VoteTable.vue
+++ b/src/js/components/VoteTable/VoteTable.vue
@@ -21,7 +21,7 @@
   -->
 
 <template lang="html">
-	<div class="vote-table" :class="[tableMode ? 'desktop' : 'mobile', { expired: expired }]">
+	<div class="vote-table" :class="[viewMode, { expired: expired }]">
 		<div class="vote-table__users fixed">
 			<UserItem v-for="(participant) in participants"
 				:key="participant.userId"
@@ -41,7 +41,7 @@
 				:option="option"
 				:class="{ 'confirmed' : option.confirmed }"
 				:poll-type="poll.type"
-				:table-mode="tableMode" />
+				:view-mode="viewMode" />
 		</transition-group>
 
 		<transition-group v-if="poll.type === 'datePoll' && getCurrentUser() && settings.calendarPeek"
@@ -133,9 +133,9 @@ export default {
 	mixins: [confirmOption],
 
 	props: {
-		tableMode: {
-			type: Boolean,
-			default: false,
+		viewMode: {
+			type: String,
+			default: 'desktop',
 		},
 		ranked: {
 			type: Boolean,

--- a/src/js/components/VoteTable/VoteTableHeaderItem.vue
+++ b/src/js/components/VoteTable/VoteTableHeaderItem.vue
@@ -23,12 +23,12 @@
 <template>
 	<div class="vote-table-header-item"
 		:class=" { winner: isWinner }">
-		<OptionItem :option="option" :display="tableMode ? 'dateBox' : 'textBox'" />
+		<OptionItem :option="option" :display="optionStyle" />
 		<Confirmation v-if="isConfirmed" :option="option" />
 		<Counter v-else :show-maybe="Boolean(poll.allowMaybe)"
 			:option="option"
-			:counter-style="tableMode ? 'iconStyle' : 'barStyle'"
-			:show-no="!tableMode" />
+			:counter-style="counterStyle"
+			:show-no="showNo" />
 	</div>
 </template>
 
@@ -52,9 +52,9 @@ export default {
 			type: Object,
 			default: undefined,
 		},
-		tableMode: {
-			type: Boolean,
-			default: false,
+		viewMode: {
+			type: String,
+			default: 'desktop',
 		},
 	},
 
@@ -69,6 +69,23 @@ export default {
 			confirmedOptions: 'poll/options/confirmed',
 		}),
 
+		optionStyle() {
+			if (this.viewMode === 'desktop') {
+				return 'dateBox'
+			} else {
+				return 'textBox'
+			}
+		},
+		counterStyle() {
+			if (this.viewMode === 'desktop') {
+				return 'iconStyle'
+			} else {
+				return 'barStyle'
+			}
+		},
+		showNo() {
+			return (this.viewMode === 'desktop')
+		},
 		isWinner() {
 			// highlight best option until poll is expired and
 			// at least one option is confirmed

--- a/src/js/store/modules/settings.js
+++ b/src/js/store/modules/settings.js
@@ -32,6 +32,10 @@ const defaultSettings = () => {
 			imageUrl: '',
 			glassyNavigation: false,
 			glassySidebar: false,
+			defaultView: {
+				textPoll: 'mobile',
+				datePoll: 'desktop',
+			},
 		},
 	}
 }

--- a/src/js/store/modules/settings.js
+++ b/src/js/store/modules/settings.js
@@ -32,11 +32,13 @@ const defaultSettings = () => {
 			imageUrl: '',
 			glassyNavigation: false,
 			glassySidebar: false,
-			defaultView: {
-				textPoll: 'mobile',
-				datePoll: 'desktop',
-			},
+			defaultViewTextPoll: 'mobile',
+			defaultViewDatePoll: 'desktop',
 		},
+		viewModes: [
+			'mobile',
+			'desktop',
+		],
 	}
 }
 
@@ -79,7 +81,6 @@ const actions = {
 				throw error
 			})
 	},
-
 }
 
 export default { namespaced, state, mutations, actions }

--- a/src/js/views/Vote.vue
+++ b/src/js/views/Vote.vue
@@ -128,8 +128,8 @@ export default {
 			delay: 50,
 			isLoading: true,
 			ranked: false,
-			manualViewDatePoll: false,
-			manualViewTextPoll: false,
+			manualViewDatePoll: '',
+			manualViewTextPoll: '',
 		}
 	},
 
@@ -148,37 +148,33 @@ export default {
 
 		viewTextPoll() {
 			if (this.manualViewTextPoll) {
-				if (this.settings.user.defaultView.textPoll === 'desktop') {
-					return 'mobile'
-				} else {
-					return 'desktop'
-				}
+				return this.manualViewTextPoll
 			} else {
-				return this.settings.user.defaultView.textPoll
+				if (window.innerWidth > 480) {
+					return this.settings.user.defaultViewTextPoll
+				} else {
+					return 'mobile'
+				}
 			}
 		},
 
 		viewDatePoll() {
 			if (this.manualViewDatePoll) {
-				if (this.settings.user.defaultView.datePoll === 'desktop') {
-					return 'mobile'
-				} else {
-					return 'desktop'
-				}
+				return this.manualViewDatePoll
 			} else {
-				if (window.innerWidth < 481) {
-					return 'mobile'
+				if (window.innerWidth > 480) {
+					return this.settings.user.defaultViewDatePoll
 				} else {
-					return this.settings.user.defaultView.datePoll
+					return 'mobile'
 				}
 			}
 		},
 
 		viewMode() {
-			if (this.poll.type === 'datePoll') {
-				return this.viewDatePoll
-			} else if (this.poll.type === 'textPoll') {
+			if (this.poll.type === 'textPoll') {
 				return this.viewTextPoll
+			} else if (this.poll.type === 'datePoll') {
+				return this.viewDatePoll
 			} else {
 				return 'desktop'
 			}
@@ -275,6 +271,14 @@ export default {
 			emit('toggle-sidebar', { open: true, activeTab: 'options' })
 		},
 
+		getNextViewMode() {
+			if (this.settings.viewModes.indexOf(this.viewMode) < 0) {
+				return this.settings.viewModes[1]
+			} else {
+				return this.settings.viewModes[(this.settings.viewModes.indexOf(this.viewMode) + 1) % this.settings.viewModes.length]
+			}
+		},
+
 		openConfiguration() {
 			emit('toggle-sidebar', { open: true, activeTab: 'configuration' })
 		},
@@ -286,9 +290,17 @@ export default {
 		toggleView() {
 			emit('transitions-off', { delay: 500 })
 			if (this.poll.type === 'datePoll') {
-				this.manualViewDatePoll = !this.manualViewDatePoll
-			} else {
-				this.manualViewTextPoll = !this.manualViewTextPoll
+				if (this.manualViewDatePoll) {
+					this.manualViewDatePoll = ''
+				} else {
+					this.manualViewDatePoll = this.getNextViewMode()
+				}
+			} else if (this.poll.type === 'textPoll') {
+				if (this.manualViewTextPoll) {
+					this.manualViewTextPoll = ''
+				} else {
+					this.manualViewTextPoll = this.getNextViewMode()
+				}
 			}
 		},
 

--- a/src/js/views/Vote.vue
+++ b/src/js/views/Vote.vue
@@ -67,8 +67,8 @@
 			<PersonalLink v-if="share.userId" />
 		</div>
 
-		<div class="area__main">
-			<VoteTable v-show="options.length" :table-mode="tableMode" :ranked="ranked" />
+		<div class="area__main" :class="viewMode">
+			<VoteTable v-show="options.length" :view-mode="viewMode" :ranked="ranked" />
 			<div v-if="!options.length" class="emptycontent">
 				<div class="icon-toggle-filelist" />
 				<button v-if="acl.allowEdit" @click="openOptions">
@@ -127,8 +127,9 @@ export default {
 			voteSaved: false,
 			delay: 50,
 			isLoading: true,
-			tableMode: (window.innerWidth > 480),
 			ranked: false,
+			manualViewDatePoll: false,
+			manualViewTextPoll: false,
 		}
 	},
 
@@ -138,11 +139,50 @@ export default {
 			acl: state => state.poll.acl,
 			options: state => state.poll.options.list,
 			share: state => state.poll.share,
+			settings: state => state.settings,
 		}),
 
 		...mapGetters({
 			isExpired: 'poll/expired',
 		}),
+
+		viewTextPoll() {
+			if (this.manualViewTextPoll) {
+				if (this.settings.user.defaultView.textPoll === 'desktop') {
+					return 'mobile'
+				} else {
+					return 'desktop'
+				}
+			} else {
+				return this.settings.user.defaultView.textPoll
+			}
+		},
+
+		viewDatePoll() {
+			if (this.manualViewDatePoll) {
+				if (this.settings.user.defaultView.datePoll === 'desktop') {
+					return 'mobile'
+				} else {
+					return 'desktop'
+				}
+			} else {
+				if (window.innerWidth < 481) {
+					return 'mobile'
+				} else {
+					return this.settings.user.defaultView.datePoll
+				}
+			}
+		},
+
+		viewMode() {
+			if (this.poll.type === 'datePoll') {
+				return this.viewDatePoll
+			} else if (this.poll.type === 'textPoll') {
+				return this.viewTextPoll
+			} else {
+				return 'desktop'
+			}
+		},
 
 		linkifyDescription() {
 			return linkifyStr(this.poll.description)
@@ -156,7 +196,7 @@ export default {
 			return moment.unix(this.poll.expire).format('LLLL')
 		},
 		viewCaption() {
-			if (this.tableMode) {
+			if (this.viewMode === 'desktop') {
 				return t('polls', 'Switch to mobile view')
 			} else {
 				return t('polls', 'Switch to desktop view')
@@ -195,7 +235,7 @@ export default {
 		},
 
 		toggleViewIcon() {
-			if (this.tableMode) {
+			if (this.viewMode === 'desktop') {
 				return 'icon-phone'
 			} else {
 				return 'icon-desktop'
@@ -245,19 +285,26 @@ export default {
 
 		toggleView() {
 			emit('transitions-off', { delay: 500 })
-			this.tableMode = !this.tableMode
+			if (this.poll.type === 'datePoll') {
+				this.manualViewDatePoll = !this.manualViewDatePoll
+			} else {
+				this.manualViewTextPoll = !this.manualViewTextPoll
+			}
 		},
 
 		loadPoll() {
 			this.isLoading = true
+			emit('transitions-off')
 			this.$store
 				.dispatch({ type: 'poll/get', pollId: this.$route.params.id, token: this.$route.params.token })
 				.then((response) => {
 					this.isLoading = false
+					emit('transitions-off', 500)
 					window.document.title = this.windowTitle
 				})
 				.catch(() => {
 					this.isLoading = false
+					emit('transitions-off', 500)
 					this.$router.replace({ name: 'notfound' })
 				})
 		},


### PR DESCRIPTION
fix #744 

Define the default view for text and date polls
* The initial default setting for text polls is now mobile view (list layout)
* The initial default setting for date polls is now desktop view (table layout)
* The user can define his preffered setting
* Changing the view mode is possible und is kept for the poll type, when switching between polls
* initial setting on mobile layout is mobile view, regardless what default is set
