### PR TITLE
remove invalid entries from polls_share

### DIFF
--- a/lib/Db/ShareMapper.php
+++ b/lib/Db/ShareMapper.php
@@ -163,7 +163,7 @@ class ShareMapper extends QBMapper {
 					$row['user_id']
 				];
 
-				if (in_array($currentRecord, $entries2Keep)) {
+				if (in_array($currentRecord, $entries2Keep) || $row['user_id'] === null || $row['type'] === '') {
 					$delete->setParameter('id', $row['id']);
 					$delete->execute();
 				} else {


### PR DESCRIPTION
remove existing shares with `user_id === null` or empty `type`
fixes #1376 
fixes #1377