### PR TITLE
Fix migration repair step

### DIFF
--- a/lib/Migration/CreateIndices.php
+++ b/lib/Migration/CreateIndices.php
@@ -24,17 +24,17 @@
 
 namespace OCA\Polls\Migration;
 
-use OC\DB\Connection;
 use OC\DB\SchemaWrapper;
+use OCP\IDBConnection;
 use OCP\Migration\IRepairStep;
 use OCP\Migration\IOutput;
 
 class CreateIndices implements IRepairStep {
 
-	/** @var Connection */
+	/** @var IDBConnection */
 	private $connection;
 
-	public function __construct(Connection $connection) {
+	public function __construct(IDBConnection $connection) {
 		$this->connection = $connection;
 	}
 

--- a/lib/Migration/RemoveIndices.php
+++ b/lib/Migration/RemoveIndices.php
@@ -23,16 +23,16 @@
 
 namespace OCA\Polls\Migration;
 
-use OC\DB\Connection;
 use OC\DB\SchemaWrapper;
+use OCP\IDBConnection;
 use OCP\Migration\IRepairStep;
 use OCP\Migration\IOutput;
 
 class RemoveIndices implements IRepairStep {
-	/** @var Connection */
+	/** @var IDBConnection */
 	private $connection;
 
-	public function __construct(Connection $connection) {
+	public function __construct(IDBConnection $connection) {
 		$this->connection = $connection;
 	}
 


### PR DESCRIPTION
@dartcafe
Regarding what i reported for #1397, it works if i use the `IDBConnection`. Probably, this one you wanted to use (as done on the migrations)? `DB\Connection` seems not to be available by automatic injection, while `IDBConnection` is...
https://docs.nextcloud.com/server/20/developer_manual/basics/dependency_injection.html?highlight=Connection#predefined-core-services