### PR TITLE
Fix test execution paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,5 +113,5 @@ appstore: clean lint build-js-production
 
 .PHONY: test
 test: composer
-	$(CURDIR)/vendor/phpunit/phpunit/phpunit --coverage-clover clover.xml -c phpunit.xml
+	$(CURDIR)/vendor/phpunit/phpunit/phpunit --coverage-clover clover.xml -c tests/phpunit.xml
 	$(CURDIR)/vendor/phpunit/phpunit/phpunit -c phpunit.integration.xml

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -21,5 +21,5 @@
  *
  */
 
-require_once __DIR__ . '/../../../tests/bootstrap.php';
+require_once __DIR__ . '/bootstrap.php';
 require_once __DIR__ . '/../vendor/autoload.php';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -21,5 +21,5 @@
  *
  */
 
-require_once __DIR__ . '/bootstrap.php';
+require_once __DIR__ . '/../../../lib/base.php';
 require_once __DIR__ . '/../vendor/autoload.php';

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -1,4 +1,4 @@
-<phpunit bootstrap="../../../tests/bootstrap.php" colors="true">
+<phpunit bootstrap="./bootstrap.php" colors="true">
     <filter>
         <whitelist>
             <directory suffix=".php">lib</directory>


### PR DESCRIPTION
I could not get the tests to run correctly, but at least now the tests run. Fixes #1387 

In my case, they fail with `Error: Class 'OC' not found`, even when placed in the `apps` directory of an active Nextcloud installation. Could anyone point me to how to properly run the tests, or where the app should be placed to run these tests?