### PR TITLE
added hide options if booked out and move some logic to backend

### DIFF
--- a/lib/Controller/PublicController.php
+++ b/lib/Controller/PublicController.php
@@ -196,7 +196,7 @@ class PublicController extends Controller {
 	 */
 	public function getComments(string $token): DataResponse {
 		return $this->response(function () use ($token) {
-			return ['comments' => $this->commentService->list(null, $token)];
+			return ['comments' => $this->commentService->list(0, $token)];
 		});
 	}
 
@@ -207,7 +207,7 @@ class PublicController extends Controller {
 	 */
 	public function getVotes(string $token): DataResponse {
 		return $this->response(function () use ($token) {
-			return ['votes' => $this->voteService->list(null, $token)];
+			return ['votes' => $this->voteService->list(0, $token)];
 		});
 	}
 
@@ -218,7 +218,7 @@ class PublicController extends Controller {
 	 */
 	public function getOptions(string $token): DataResponse {
 		return $this->response(function () use ($token) {
-			return ['options' => $this->optionService->list(null, $token)];
+			return ['options' => $this->optionService->list(0, $token)];
 		});
 	}
 
@@ -251,7 +251,7 @@ class PublicController extends Controller {
 	 */
 	public function addComment(string $token, string $message): DataResponse {
 		return $this->response(function () use ($token, $message) {
-			return ['comment' => $this->commentService->add(null, $token, $message)];
+			return ['comment' => $this->commentService->add(0, $token, $message)];
 		});
 	}
 

--- a/lib/Db/Option.php
+++ b/lib/Db/Option.php
@@ -78,8 +78,8 @@ class Option extends Entity implements JsonSerializable {
 	/** @var int $maybe */
 	public $maybe = 0;
 
-	/** @var int $realno */
-	public $realno = 0;
+	/** @var int $realNo */
+	public $realNo = 0;
 
 	/** @var int $votes */
 	public $votes = 0;
@@ -109,7 +109,7 @@ class Option extends Entity implements JsonSerializable {
 			'no' => $this->no,
 			'yes' => $this->yes,
 			'maybe' => $this->maybe,
-			'realno' => $this->realno,
+			'realNo' => $this->realNo,
 			'votes' => $this->votes,
 			'isBookedUp' => $this->isBookedUp,
 		];

--- a/lib/Db/Option.php
+++ b/lib/Db/Option.php
@@ -65,6 +65,29 @@ class Option extends Entity implements JsonSerializable {
 	/** @var int $duration */
 	protected $duration;
 
+	// public variables, not in the db
+	/** @var int $rank */
+	public $rank = 0;
+
+	/** @var int $yes */
+	public $yes = 0;
+
+	/** @var int $no */
+	public $no = 0;
+
+	/** @var int $maybe */
+	public $maybe = 0;
+
+	/** @var int $realno */
+	public $realno = 0;
+
+	/** @var int $votes */
+	public $votes = 0;
+
+	/** @var bool $isBookedUp */
+	public $isBookedUp = false;
+
+
 	public function jsonSerialize() {
 		if (intval($this->timestamp) > 0) {
 			$timestamp = $this->timestamp;
@@ -82,12 +105,13 @@ class Option extends Entity implements JsonSerializable {
 			'order' => intval($timestamp ? $timestamp : $this->order),
 			'confirmed' => intval($this->confirmed),
 			'duration' => intval($this->duration),
-			'no' => 0,
-			'yes' => 0,
-			'maybe' => 0,
-			'realno' => 0,
-			'rank' => 0,
-			'votes' => 0,
+			'rank' => $this->rank,
+			'no' => $this->no,
+			'yes' => $this->yes,
+			'maybe' => $this->maybe,
+			'realno' => $this->realno,
+			'votes' => $this->votes,
+			'isBookedUp' => $this->isBookedUp,
 		];
 	}
 }

--- a/lib/Db/Poll.php
+++ b/lib/Db/Poll.php
@@ -163,7 +163,7 @@ class Poll extends Entity implements JsonSerializable {
 			'adminAccess' => intVal($this->adminAccess),
 			'ownerDisplayName' => $this->getDisplayName(),
 			'important' => intVal($this->important),
-			'hideBookedUp'=> intVal($this->hideBookedUp)
+			'hideBookedUp' => intVal($this->hideBookedUp)
 		];
 	}
 

--- a/lib/Db/Poll.php
+++ b/lib/Db/Poll.php
@@ -70,7 +70,7 @@ use OCA\Polls\Model\User;
  * @method void setAdminAccess(integer $value)
  * @method int getImportant()
  * @method void setImportant(integer $value)
- * @method int setHideBookedUp()
+ * @method int getHideBookedUp()
  * @method void setHideBookedUp(integer $value)
  */
 class Poll extends Entity implements JsonSerializable {

--- a/lib/Db/Poll.php
+++ b/lib/Db/Poll.php
@@ -70,6 +70,8 @@ use OCA\Polls\Model\User;
  * @method void setAdminAccess(integer $value)
  * @method int getImportant()
  * @method void setImportant(integer $value)
+ * @method int setHideBookedUp()
+ * @method void setHideBookedUp(integer $value)
  */
 class Poll extends Entity implements JsonSerializable {
 	public const TYPE_DATE = 'datePoll';
@@ -134,8 +136,11 @@ class Poll extends Entity implements JsonSerializable {
 	/** @var int $important*/
 	protected $important;
 
-	/** @var int $important*/
+	/** @var int $allowComment*/
 	protected $allowComment;
+
+	/** @var int $hideBookedUp*/
+	protected $hideBookedUp;
 
 	public function jsonSerialize() {
 		return [
@@ -157,7 +162,8 @@ class Poll extends Entity implements JsonSerializable {
 			'showResults' => $this->showResults === 'expired' ? Poll::SHOW_RESULTS_CLOSED : $this->showResults,
 			'adminAccess' => intVal($this->adminAccess),
 			'ownerDisplayName' => $this->getDisplayName(),
-			'important' => intVal($this->important)
+			'important' => intVal($this->important),
+			'hideBookedUp'=> intVal($this->hideBookedUp)
 		];
 	}
 
@@ -178,6 +184,7 @@ class Poll extends Entity implements JsonSerializable {
 		$this->setDeleted($array['deleted'] ?? $this->getDeleted());
 		$this->setAdminAccess($array['adminAccess'] ?? $this->getAdminAccess());
 		$this->setImportant($array['important'] ?? $this->getImportant());
+		$this->setHideBookedUp($array['hideBookedUp'] ?? $this->getHideBookedUp());
 		return $this;
 	}
 

--- a/lib/Migration/Version0108Date20210207134703.php
+++ b/lib/Migration/Version0108Date20210207134703.php
@@ -54,6 +54,13 @@ class Version0108Date20210207134703 extends SimpleMigrationStep {
 					'default' => 1
 				]);
 			}
+			if (!$table->hasColumn('hide_booked_up')) {
+				$table->addColumn('hide_booked_up', 'integer', [
+					'length' => 11,
+					'notnull' => true,
+					'default' => 1
+				]);
+			}
 		}
 		return $schema;
 	}

--- a/lib/Model/Acl.php
+++ b/lib/Model/Acl.php
@@ -287,9 +287,7 @@ class Acl implements JsonSerializable {
 		}
 		return count(
 			array_filter($this->shareMapper->findByPoll($this->getPollId()), function ($item) {
-				if ($item->getType() === Share::TYPE_GROUP && $this->groupManager->isInGroup($this->getUserId(), $item->getUserId())) {
-					return true;
-				}
+				return ($item->getType() === Share::TYPE_GROUP && $this->groupManager->isInGroup($this->getUserId(), $item->getUserId()));
 			})
 		);
 	}
@@ -305,16 +303,14 @@ class Acl implements JsonSerializable {
 		}
 		return count(
 			array_filter($this->shareMapper->findByPoll($this->getPollId()), function ($item) {
-				if (in_array($item->getType(), [
-					Share::TYPE_USER,
-					Share::TYPE_EXTERNAL,
-					Share::TYPE_EMAIL,
-					Share::TYPE_CONTACT
-				])
-					&& $item->getUserId() === $this->getUserId()
-				) {
-					return true;
-				}
+				return ($item->getUserId() === $this->getUserId()
+					&& in_array($item->getType(), [
+						Share::TYPE_USER,
+						Share::TYPE_EXTERNAL,
+						Share::TYPE_EMAIL,
+						Share::TYPE_CONTACT
+					])
+				);
 			})
 		);
 	}

--- a/lib/Service/CommentService.php
+++ b/lib/Service/CommentService.php
@@ -81,7 +81,7 @@ class CommentService {
 	/**
 	 * Add comment
 	 */
-	public function add(?int $pollId = 0, ?string $token = '', string $message): Comment {
+	public function add(int $pollId = 0, ?string $token = '', string $message): Comment {
 		if ($token) {
 			$this->acl->setToken($token)->request(Acl::PERMISSION_COMMENT);
 		} else {

--- a/lib/Service/OptionService.php
+++ b/lib/Service/OptionService.php
@@ -418,16 +418,14 @@ class OptionService {
 	private function filterBookedUp() {
 		$exceptVotes = $this->getUsersVotes();
 		$this->options = array_filter($this->options, function ($option) use ($exceptVotes) {
-			if (!$option->getIsBookedUp() || in_array($option->getPollOptionText(), $exceptVotes)) {
-				return $option;
-			}
+			return (!$option->getIsBookedUp() || in_array($option->getPollOptionText(), $exceptVotes));
 		});
 	}
 
 	/**
-	 * Calculate the votes of each option
-	 * unvoted counts as no
-	 * realNo reports the actually opted out votes
+	 * Calculate the votes of each option and determines if the option is booked up
+	 * - unvoted counts as no
+	 * - realNo reports the actually opted out votes
 	 *
 	 * @return void
 	 */
@@ -435,28 +433,22 @@ class OptionService {
 		foreach ($this->options as $option) {
 			$option->yes = count(
 				array_filter($this->votes, function ($vote) use ($option) {
-					if ($vote->getVoteOptionText() === $option->getPollOptionText()
-						&& $vote->getVoteAnswer() === 'yes') {
-						return $vote;
-					}
+					return ($vote->getVoteOptionText() === $option->getPollOptionText()
+						&& $vote->getVoteAnswer() === 'yes') ;
 				})
 			);
 
 			$option->realNo = count(
 				array_filter($this->votes, function ($vote) use ($option) {
-					if ($vote->getVoteOptionText() === $option->getPollOptionText()
-						&& $vote->getVoteAnswer() === 'no') {
-						return $vote;
-					}
+					return ($vote->getVoteOptionText() === $option->getPollOptionText()
+						&& $vote->getVoteAnswer() === 'no');
 				})
 			);
 
 			$option->maybe = count(
 				array_filter($this->votes, function ($vote) use ($option) {
-					if ($vote->getVoteOptionText() === $option->getPollOptionText()
-						&& $vote->getVoteAnswer() === 'maybe') {
-						return $vote;
-					}
+					return ($vote->getVoteOptionText() === $option->getPollOptionText()
+						&& $vote->getVoteAnswer() === 'maybe');
 				})
 			);
 

--- a/lib/Service/OptionService.php
+++ b/lib/Service/OptionService.php
@@ -147,15 +147,15 @@ class OptionService {
 				// If the user opted in, do not hide them
 				// First: Find votes, where the user voted yes or maybe
 				$userId = $this->acl->getUserId();
-				$exceptVotes = array_filter($votes, function ($vote) use ($userId){
+				$exceptVotes = array_filter($votes, function ($vote) use ($userId) {
 					if ($vote->getUserId() === $userId && in_array($vote->getVoteAnswer(), ['yes', 'maybe'])) {
 						return $vote;
 					}
 				});
 
 				// Second: Extract only the vote option texts to an array
-				$exceptVotes = array_values(array_map(function ($vote){
-   					return $vote->getVoteOptionText();
+				$exceptVotes = array_values(array_map(function ($vote) {
+					return $vote->getVoteOptionText();
 				}, $exceptVotes));
 
 				// Third: Reduce options to options, which are not booked up or
@@ -165,18 +165,18 @@ class OptionService {
 						return $option;
 					}
 				});
-			} else if ($this->acl->isAllowed(Acl::PERMISSION_SEE_RESULTS)) {
+			} elseif ($this->acl->isAllowed(Acl::PERMISSION_SEE_RESULTS)) {
 
 				// sort array by yes and maybe votes
 				usort($options, function ($a, $b) {
-					    $diff = $b->yes - $a->yes;
-    					return ($diff !== 0) ? $diff : $b->maybe - $a->maybe;
+					$diff = $b->yes - $a->yes;
+					return ($diff !== 0) ? $diff : $b->maybe - $a->maybe;
 				});
 
 				// calculate the rank
-				for ($i=0; $i < count($options); $i++) {
-					if ($i > 0 && $options[$i]->yes === $options[$i-1]->yes && $options[$i]->maybe === $options[$i-1]->maybe) {
-						$options[$i]->rank = $options[$i-1]->rank;
+				for ($i = 0; $i < count($options); $i++) {
+					if ($i > 0 && $options[$i]->yes === $options[$i - 1]->yes && $options[$i]->maybe === $options[$i - 1]->maybe) {
+						$options[$i]->rank = $options[$i - 1]->rank;
 					} else {
 						$options[$i]->rank = $i + 1;
 					}
@@ -184,9 +184,8 @@ class OptionService {
 
 				// restore original order
 				usort($options, function ($a, $b) {
-					    return $a->getOrder() - $b->getOrder();
+					return $a->getOrder() - $b->getOrder();
 				});
-
 			}
 
 			return array_values($options);

--- a/lib/Service/OptionService.php
+++ b/lib/Service/OptionService.php
@@ -427,7 +427,7 @@ class OptionService {
 	/**
 	 * Calculate the votes of each option
 	 * unvoted counts as no
-	 * realno reports the actually opted out votes
+	 * realNo reports the actually opted out votes
 	 *
 	 * @return void
 	 */
@@ -442,7 +442,7 @@ class OptionService {
 				})
 			);
 
-			$option->realno = count(
+			$option->realNo = count(
 				array_filter($this->votes, function ($vote) use ($option) {
 					if ($vote->getVoteOptionText() === $option->getPollOptionText()
 						&& $vote->getVoteAnswer() === 'no') {

--- a/lib/Service/OptionService.php
+++ b/lib/Service/OptionService.php
@@ -117,7 +117,6 @@ class OptionService {
 			if ($this->poll->getHideBookedUp() && !$this->acl->isAllowed(Acl::PERMISSION_EDIT)) {
 				// hide booked up options except the user has edit permission
 				$this->filterBookedUp();
-
 			} elseif ($this->acl->isAllowed(Acl::PERMISSION_SEE_RESULTS)) {
 				$this->calculateRanks();
 			}
@@ -409,7 +408,6 @@ class OptionService {
 		return array_values(array_map(function ($vote) {
 			return $vote->getVoteOptionText();
 		}, $exceptVotes));
-
 	}
 
 	/**
@@ -473,7 +471,6 @@ class OptionService {
 				$option->no = $this->countParticipants - $option->maybe - $option->yes;
 			}
 		}
-
 	}
 
 	/**
@@ -503,7 +500,6 @@ class OptionService {
 		usort($this->options, function ($a, $b) {
 			return $a->getOrder() - $b->getOrder();
 		});
-
 	}
 
 	/**

--- a/lib/Service/OptionService.php
+++ b/lib/Service/OptionService.php
@@ -96,14 +96,10 @@ class OptionService {
 	 */
 	public function list(int $pollId = 0, string $token = ''): array {
 		if ($token) {
-			$this->acl->setToken($token);
+			$this->acl->setToken($token)->request(Acl::PERMISSION_VIEW);
 			$pollId = $this->acl->getPollId();
 		} else {
 			$this->acl->setPollId($pollId)->request(Acl::PERMISSION_VIEW);
-		}
-
-		if (!$this->acl->isAllowed(Acl::PERMISSION_VIEW)) {
-			throw new NotAuthorizedException;
 		}
 
 		try {
@@ -133,9 +129,8 @@ class OptionService {
 	 * @return Option
 	 */
 	public function get(int $optionId): Option {
-		$this->acl->setPollId($this->optionMapper->find($optionId)->getPollId())->request(Acl::PERMISSION_VIEW);
-		$this->acl->request(Acl::PERMISSION_VIEW);
-
+		$this->acl->setPollId($this->optionMapper->find($optionId)->getPollId())
+			->request(Acl::PERMISSION_VIEW);
 		return $this->optionMapper->find($optionId);
 	}
 

--- a/lib/Service/OptionService.php
+++ b/lib/Service/OptionService.php
@@ -134,10 +134,7 @@ class OptionService {
 	 */
 	public function get(int $optionId): Option {
 		$this->acl->setPollId($this->optionMapper->find($optionId)->getPollId())->request(Acl::PERMISSION_VIEW);
-
-		if (!$this->acl->isAllowed(Acl::PERMISSION_VIEW)) {
-			throw new NotAuthorizedException;
-		}
+		$this->acl->request(Acl::PERMISSION_VIEW);
 
 		return $this->optionMapper->find($optionId);
 	}
@@ -377,7 +374,7 @@ class OptionService {
 			if ($duration === 0) {
 				$this->option->setPollOptionText(date('c', $timestamp));
 			} elseif ($duration > 0) {
-				$this->option->setPollOptionText(date('c', $timestamp) .' - ' . date('c', $timestamp + $duration));
+				$this->option->setPollOptionText(date('c', $timestamp) . ' - ' . date('c', $timestamp + $duration));
 			} else {
 				$this->option->setPollOptionText($pollOptionText);
 			}

--- a/lib/Service/VoteService.php
+++ b/lib/Service/VoteService.php
@@ -85,7 +85,7 @@ class VoteService {
 	/**
 	 * Read all votes of a poll based on the poll id and return list as array
 	 */
-	public function list(?int $pollId = 0, string $token = ''): array {
+	public function list(int $pollId = 0, string $token = ''): array {
 		if ($token) {
 			$this->acl->setToken($token);
 		} else {

--- a/src/js/components/Base/Confirmation.vue
+++ b/src/js/components/Base/Confirmation.vue
@@ -48,7 +48,6 @@ export default {
 		}),
 
 		...mapGetters({
-			votesRank: 'votes/ranked',
 			participantsVoted: 'poll/participantsVoted',
 			closed: 'poll/closed',
 			confirmedOptions: 'options/confirmed',

--- a/src/js/components/Options/OptionsDate.vue
+++ b/src/js/components/Options/OptionsDate.vue
@@ -24,7 +24,7 @@
 	<div>
 		<ConfigBox v-if="countOptions" :title="t('polls', 'Available Options')" icon-class="icon-calendar-000">
 			<transition-group is="ul">
-				<OptionItem v-for="(option) in sortedOptions"
+				<OptionItem v-for="(option) in options"
 					:key="option.id"
 					:option="option"
 					:show-confirmed="true"
@@ -113,7 +113,6 @@ export default {
 		}),
 
 		...mapGetters({
-			sortedOptions: 'options/sorted',
 			pollIsClosed: 'poll/closed',
 			countOptions: 'options/count',
 		}),

--- a/src/js/components/Options/OptionsText.vue
+++ b/src/js/components/Options/OptionsText.vue
@@ -89,7 +89,7 @@ export default {
 
 	computed: {
 		...mapState({
-			options: state => state.options,
+			options: state => state.options.list,
 			acl: state => state.poll.acl,
 		}),
 
@@ -100,7 +100,7 @@ export default {
 
 		sortOptions: {
 			get() {
-				return this.options.list
+				return this.options
 			},
 			set(value) {
 				this.$store.dispatch('options/reorder', value)

--- a/src/js/components/Options/OptionsText.vue
+++ b/src/js/components/Options/OptionsText.vue
@@ -100,7 +100,7 @@ export default {
 
 		sortOptions: {
 			get() {
-				return this.options
+				return this.options.list
 			},
 			set(value) {
 				this.$store.dispatch('options/reorder', value)

--- a/src/js/components/Options/OptionsText.vue
+++ b/src/js/components/Options/OptionsText.vue
@@ -94,14 +94,13 @@ export default {
 		}),
 
 		...mapGetters({
-			sortedOptions: 'options/sorted',
 			PollIsClosed: 'poll/closed',
 			countOptions: 'options/count',
 		}),
 
 		sortOptions: {
 			get() {
-				return this.sortedOptions
+				return this.options
 			},
 			set(value) {
 				this.$store.dispatch('options/reorder', value)

--- a/src/js/components/SideBar/SideBarTabConfiguration.vue
+++ b/src/js/components/SideBar/SideBarTabConfiguration.vue
@@ -56,6 +56,10 @@
 				use-num-modifiers
 				@add="pollOptionLimit++"
 				@subtract="pollOptionLimit--" />
+			<CheckBoxDiv v-if="pollOptionLimit"
+				v-model="hideBookedUp"
+				class="indented"
+				:label="t('polls', 'Hide not availabe Options')" />
 		</ConfigBox>
 
 		<ConfigBox :title="t('polls', 'Poll closing status')" :icon-class="closed ? 'icon-polls-closed' : 'icon-polls-open'">
@@ -213,6 +217,15 @@ export default {
 					value = 1
 				}
 				this.writeValue({ optionLimit: value })
+			},
+		},
+
+		hideBookedUp: {
+			get() {
+				return (this.poll.hideBookedUp > 0)
+			},
+			set(value) {
+				this.writeValue({ hideBookedUp: +value })
 			},
 		},
 

--- a/src/js/components/VoteTable/VoteItem.vue
+++ b/src/js/components/VoteTable/VoteItem.vue
@@ -60,7 +60,11 @@ export default {
 		}),
 
 		isVotable() {
-			return this.isActive && this.isValidUser && !this.pollIsClosed && !this.isLocked && !this.isBlocked
+			return this.isActive
+				&& this.isValidUser
+				&& !this.pollIsClosed
+				&& !this.isLocked
+				&& !this.option.isBookedUp
 		},
 
 		isActive() {
@@ -76,10 +80,6 @@ export default {
 				option: this.option,
 				userId: this.userId,
 			}).voteAnswer
-		},
-
-		isBlocked() {
-			return this.optionLimit > 0 && this.optionLimit <= this.option.yes && this.answer !== 'yes'
 		},
 
 		isLocked() {

--- a/src/js/components/VoteTable/VoteTable.vue
+++ b/src/js/components/VoteTable/VoteTable.vue
@@ -130,16 +130,16 @@ export default {
 			acl: state => state.poll.acl,
 			poll: state => state.poll,
 			settings: state => state.settings.user,
+			options: state => state.options.list,
 		}),
 
 		...mapGetters({
 			closed: 'poll/closed',
 			participants: 'poll/participants',
-			sortedOptions: 'options/sorted',
 		}),
 
 		rankedOptions() {
-			return orderBy(this.sortedOptions, this.ranked ? 'rank' : 'order', 'asc')
+			return orderBy(this.options, this.ranked ? 'rank' : 'order', 'asc')
 		},
 	},
 

--- a/src/js/mixins/watchPolls.js
+++ b/src/js/mixins/watchPolls.js
@@ -47,10 +47,16 @@ export const watchPolls = {
 								// load poll list only, when not in public poll
 								dispatches.push('polls/load')
 							}
-							if (item.pollId === parseInt(this.$route.params.id)) {
+							if (item.pollId === parseInt(this.$route.params.id ?? this.$store.state.share.pollId)) {
 								// if current poll is affected, load current poll configuration
 								dispatches.push('poll/get')
+								// load also options and votes
+								dispatches.push('votes/list')
+								dispatches.push('options/list')
 							}
+						} else if (['votes', 'options'].includes(item.table)) {
+							dispatches.push('votes/list')
+							dispatches.push('options/list')
 						} else {
 							// a table of the current poll was reported, load
 							// corresponding stores

--- a/src/js/store/modules/options.js
+++ b/src/js/store/modules/options.js
@@ -21,7 +21,6 @@
  */
 
 import axios from '@nextcloud/axios'
-import orderBy from 'lodash/orderBy'
 import { generateUrl } from '@nextcloud/router'
 
 const defaultOptions = () => {
@@ -80,34 +79,6 @@ const mutations = {
 const getters = {
 	count: (state) => {
 		return state.list.length
-	},
-
-	sorted: (state, getters, rootState, rootGetters) => {
-		let rankedOptions = []
-		state.list.forEach((option) => {
-			rankedOptions.push({
-				...option,
-				rank: 0,
-				no: 0,
-				yes: rootState.votes.list.filter(vote => vote.voteOptionText === option.pollOptionText && vote.voteAnswer === 'yes').length,
-				maybe: rootState.votes.list.filter(vote => vote.voteOptionText === option.pollOptionText && vote.voteAnswer === 'maybe').length,
-				realno: rootState.votes.list.filter(vote => vote.voteOptionText === option.pollOptionText && vote.voteAnswer === 'no').length,
-				votes: rootGetters['poll/participantsVoted'].length,
-			})
-		})
-
-		rankedOptions = orderBy(rankedOptions, ['yes', 'maybe'], ['desc', 'desc'])
-
-		for (let i = 0; i < rankedOptions.length; i++) {
-			rankedOptions[i].no = rankedOptions[i].votes - rankedOptions[i].yes - rankedOptions[i].maybe
-			if (i > 0 && rankedOptions[i].yes === rankedOptions[i - 1].yes && rankedOptions[i].maybe === rankedOptions[i - 1].maybe) {
-				rankedOptions[i].rank = rankedOptions[i - 1].rank
-			} else {
-				rankedOptions[i].rank = i + 1
-			}
-		}
-
-		return orderBy(rankedOptions, 'order')
 	},
 
 	confirmed: state => {

--- a/src/js/store/modules/poll.js
+++ b/src/js/store/modules/poll.js
@@ -45,6 +45,7 @@ const defaultPoll = () => {
 		showResults: 'always',
 		adminAccess: 0,
 		important: 0,
+		hideBookedUp: 0,
 	}
 }
 


### PR DESCRIPTION
Some tests showed, that the blocking of options is not possible if an OptionLimit is set and the results are hidden, because the frontend misses information to apply the logic
* moved the calculation of votes per option to the backend
* moved rank determining to backend
* load optoins and votes in watchPoll, if poll configuration, options or votes were affected
* added a configuration option to hide booked up options to the voters.
