### PR TITLE
Catch email send errors on registration to public poll

### DIFF
--- a/lib/Service/ShareService.php
+++ b/lib/Service/ShareService.php
@@ -331,9 +331,13 @@ class ShareService {
 			throw new NotAuthorizedException;
 		}
 
-		// send invitaitoin mail, if invitationSent has no timestamp
-		if (!$this->share->getInvitationSent()) {
-			$this->mailService->resendInvitation($this->share->getToken());
+		// send invitation mail, if invitationSent has no timestamp
+		try {
+			if (!$this->share->getInvitationSent()) {
+				$this->mailService->resendInvitation($this->share->getToken());
+			}
+		} catch (\Exception $e) {
+			$this->logger->error('Error sending Mail to ' . $this->share->getEmailAddress());
 		}
 
 		return $this->share;

--- a/src/js/components/Poll/PublicRegisterModal.vue
+++ b/src/js/components/Poll/PublicRegisterModal.vue
@@ -264,9 +264,13 @@ export default {
 						this.$router.replace({ name: 'publicVote', params: { token: response.token } })
 						this.closeModal()
 					}
+					if (this.share.emailAddress && !this.share.invitationSent) {
+						showError(t('polls', 'Email could not be sent to {emailAddress}', { emailAddress: this.share.emailAddress }))
+					}
 				} catch {
-					showError(t('polls', 'Error saving name', 1, this.poll.title))
+					showError(t('polls', 'Error saving name'))
 				}
+
 			}
 		},
 	},


### PR DESCRIPTION
Should fix #1559, if mail can't be sent out. 
* Log error 
* Show a different error toast to the user
* Do not prevent entering poll