### PR TITLE
Allow URL-Parameters for username and email address in public share

### DIFF
--- a/src/js/components/Poll/PublicRegisterModal.vue
+++ b/src/js/components/Poll/PublicRegisterModal.vue
@@ -207,8 +207,16 @@ export default {
 	},
 
 	mounted() {
-		this.userName = this.share.displayName
-		this.emailAddress = this.share.emailAddress
+		if (this.$route.name === 'publicVote' && this.$route.query.name) {
+			this.userName = this.$route.query.name
+		} else {
+			this.userName = this.share.displayName
+		}
+		if (this.$route.name === 'publicVote' && this.$route.query.email) {
+			this.emailAddress = this.$route.query.email
+		} else {
+			this.emailAddress = this.share.emailAddress
+		}
 	},
 
 	methods: {

--- a/src/js/components/Shares/SharesPublic.vue
+++ b/src/js/components/Shares/SharesPublic.vue
@@ -21,7 +21,7 @@
   -->
 
 <template>
-	<ConfigBox :title="t('polls', 'Public shares')" icon-class="icon-public">
+	<ConfigBox v-tooltip.auto="paramsHint" :title="t('polls', 'Public shares')" icon-class="icon-public">
 		<TransitionGroup :css="false" tag="div" class="shared-list">
 			<PublicShareItem v-for="(share) in publicShares"
 				:key="share.id"
@@ -68,6 +68,7 @@ export default {
 				successText: t('polls', 'Link copied to clipboard'),
 				errorText: t('polls', 'Error while copying link to clipboard'),
 			},
+			paramsHint: t('polls', 'Add URL-Paramters \'name=\' and/or \'email=\' to predefine name and email address. I.e. https://example.com/s/aUubZAvweQ6PaX2?name=John Doe&email=jondoe@example.org'),
 		}
 	},
 

--- a/src/js/components/Shares/SharesPublic.vue
+++ b/src/js/components/Shares/SharesPublic.vue
@@ -68,7 +68,7 @@ export default {
 				successText: t('polls', 'Link copied to clipboard'),
 				errorText: t('polls', 'Error while copying link to clipboard'),
 			},
-			paramsHint: t('polls', 'Add URL-Paramters \'name=\' and/or \'email=\' to predefine name and email address. I.e. https://example.com/s/aUubZAvweQ6PaX2?name=John Doe&email=jondoe@example.org'),
+			paramsHint: t('polls', 'Add URL-Paramters \'name=\' and/or \'email=\' to predefine name and email address. I.e. https://example.com/s/aUubZAvweQ6PaX2?name=John Doe&email=johndoe@example.org'),
 		}
 	},
 


### PR DESCRIPTION
fixes #587
Add url Parameters
* name=John Doe
* email=johndoe@example.com

will be used to prefill the fields in the registration dialog for public polls

Example
* `https://example.com/s/aUubZAvweQ6PaX2?name=John Doe&email=jondoe@example.org` or
* `https://example.com/s/aUubZAvweQ6PaX2?name=John%20Doe&email=jondoe%40example.org`