### PR TITLE
hide vote table if too many cells are predicted

### DIFF
--- a/src/js/components/Actions/ActionCopyMailAdresses.vue
+++ b/src/js/components/Actions/ActionCopyMailAdresses.vue
@@ -65,11 +65,11 @@ export default {
 
 	computed: {
 		...mapGetters({
-			participantsVoted: 'poll/participantsVoted',
+			countParticipantsVoted: 'poll/countParticipantsVoted',
 		}),
 
 		caption() {
-			return n('polls', '%n Participant', '%n Participants', this.participantsVoted.length)
+			return n('polls', '%n Participant', '%n Participants', this.countParticipantsVoted)
 		},
 	},
 	methods: {

--- a/src/js/components/Poll/ParticipantsList.vue
+++ b/src/js/components/Poll/ParticipantsList.vue
@@ -22,13 +22,13 @@
 
 <template lang="html">
 	<div class="participants-list">
-		<h2 v-if="participantsVoted.length">
-			{{ n('polls', '%n Participant', '%n Participants', participantsVoted.length) }}
+		<h2 v-if="countParticipantsVoted">
+			{{ n('polls', '%n Participant', '%n Participants', countParticipantsVoted) }}
 		</h2>
 		<h2 v-else>
 			{{ t('polls','No Participants until now') }}
 		</h2>
-		<div v-if="participantsVoted.length" class="participants-list__list">
+		<div v-if="countParticipantsVoted" class="participants-list__list">
 			<UserItem v-for="(participant) in participantsVoted"
 				:key="participant.userId"
 				v-bind="participant"
@@ -61,6 +61,7 @@ export default {
 		}),
 
 		...mapGetters({
+			countParticipantsVoted: 'poll/countParticipantsVoted',
 			participantsVoted: 'poll/participantsVoted',
 		}),
 	},

--- a/src/js/components/Poll/PollInformation.vue
+++ b/src/js/components/Poll/PollInformation.vue
@@ -48,8 +48,8 @@
 			<div :class="resultsClass">
 				{{ resultsCaption }}
 			</div>
-			<div v-if="participantsVoted.length && acl.allowSeeResults" class="icon-user">
-				{{ n('polls', '%n Participant', '%n Participants', participantsVoted.length) }}
+			<div v-if="countParticipantsVoted && acl.allowSeeResults" class="icon-user">
+				{{ n('polls', '%n Participant', '%n Participants', countParticipantsVoted) }}
 			</div>
 			<div class="icon-polls-unconfirmed">
 				{{ n('polls', '%n option', '%n options', countOptions) }}
@@ -112,10 +112,10 @@ export default {
 		}),
 
 		...mapGetters({
-			participantsVoted: 'poll/participantsVoted',
 			closed: 'poll/isClosed',
 			confirmedOptions: 'options/confirmed',
 			countOptions: 'options/count',
+			countParticipantsVoted: 'poll/countParticipantsVoted',
 			countVotes: 'votes/countVotes',
 			countAllVotes: 'votes/countAllVotes',
 			proposalsAllowed: 'poll/proposalsAllowed',

--- a/src/js/components/VoteTable/VoteTable.vue
+++ b/src/js/components/VoteTable/VoteTable.vue
@@ -127,7 +127,7 @@ export default {
 		...mapGetters({
 			hideResults: 'poll/hideResults',
 			closed: 'poll/isClosed',
-			participants: 'poll/participants',
+			participants: 'poll/safeParticipants',
 			options: 'options/rankedOptions',
 			proposalsExist: 'options/proposalsExist',
 		}),

--- a/src/js/store/modules/votes.js
+++ b/src/js/store/modules/votes.js
@@ -51,9 +51,21 @@ const mutations = {
 			&& vote.voteOptionText === payload.option.pollOptionText)
 		if (index > -1) {
 			state.list[index] = Object.assign(state.list[index], payload.vote)
-		} else {
-			state.list.push(payload.vote)
+			return
 		}
+
+		state.list.push(payload.vote)
+
+		// TODO: performance check for preferred strategy
+		// for (let i = 0; i < state.list.length; i++) {
+		// if (parseInt(state.list[i].pollId) === payload.pollId
+		// && state.list[i].userId === payload.vote.userId
+		// && state.list[i].voteOptionText === payload.option.pollOptionText) {
+		// state.list[i] = Object.assign(state.list[i], payload.vote)
+		// return
+		// }
+		// }
+		// state.list.push(payload.vote)
 	},
 }
 

--- a/src/js/views/Vote.vue
+++ b/src/js/views/Vote.vue
@@ -52,6 +52,12 @@
 			</EmptyContent>
 		</div>
 
+		<div v-if="countHiddenParticipants" class="area__footer">
+			<h2>
+				{{ t('polls', 'Due to performance concerns {countHiddenParticipants} voters are hidden.', { countHiddenParticipants }) }}
+			</h2>
+		</div>
+
 		<div v-if="poll.anonymous" class="area__footer">
 			<div>
 				{{ t('poll', 'Although participant\'s names are hidden, this is not a real anonymous poll because they are not hidden from the owner.') }}
@@ -120,6 +126,8 @@ export default {
 			pollTypeIcon: 'poll/typeIcon',
 			viewMode: 'settings/viewMode',
 			proposalsAllowed: 'poll/proposalsAllowed',
+			countHiddenParticipants: 'poll/countHiddenParticipants',
+			safeTable: 'poll/safeTable',
 		}),
 
 		showEmailEdit() {


### PR DESCRIPTION
related to #1643 and #1450

Vue can get knocked out, if too many component copies are generated. With a lot of options and participants, a poll table can grow to many thousend cells. A current use case showed some 125 participants with over 60 entries; Resulting in a table with more than 7.500 cells. 

The app gets really unusable, freezes the browser window/tab and crashes due to too many recursions (`too much recursion`). So a workaround is implemented which hides all votes but the votes of the current user, if the number of calsulated cells crosses a threshold of 200 cells. 

This current implementation is just a workaround, further investigation and another strategy for displaying huge tables must be found.