### PR TITLE
Fix/branch stable1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [2.0.1 - release] - 2021-06-11
+## Only available for Nextcloud 19
+- prevent to run in migration error upon server update, see #1723
+- Bugfix release in order to fix the problems, which came from the update to version 2.0
+
 ## [1.9.6 - release] - 2021-06-08
 ### Fixes
 - removed Compatibility with NC19 Minimum version is NC20

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -5,7 +5,7 @@
     <name>Polls</name>
     <summary>A polls app, similar to doodle/dudle with the possibility to restrict access.</summary>
     <description>A polls app, similar to doodle/dudle with the possibility to restrict access (members, certain groups/users, hidden and public).</description>
-    <version>1.9.6</version>
+    <version>2.0.1</version>
     <licence>agpl</licence>
     <author>Vinzenz Rosenkranz</author>
     <author>René Gieling</author>

--- a/lib/Migration/Version0010Date20191227063812.php
+++ b/lib/Migration/Version0010Date20191227063812.php
@@ -119,11 +119,11 @@ class Version0010Date20191227063812 extends SimpleMigrationStep {
 				'default' => 1
 			]);
 			$table->addColumn('options', 'text', [
-				'notnull' => true,
+				'notnull' => false,
 				'default' => ''
 			]);
 			$table->addColumn('settings', 'text', [
-				'notnull' => true,
+				'notnull' => false,
 				'default' => ''
 			]);
 			$table->addColumn('vote_limit', 'integer', [
@@ -171,7 +171,7 @@ class Version0010Date20191227063812 extends SimpleMigrationStep {
 				'length' => 254
 			]);
 			$table->addColumn('user', 'text', [
-				'notnull' => true,
+				'notnull' => false,
 				'default' => ''
 			]);
 			$table->setPrimaryKey(['id']);

--- a/lib/Migration/Version0104Date20200314074611.php
+++ b/lib/Migration/Version0104Date20200314074611.php
@@ -47,7 +47,7 @@ class Version0104Date20200314074611 extends SimpleMigrationStep {
 		$table = $schema->getTable('polls_polls');
 		$table->changeColumn('description', [
 			'type' => Type::getType('text'),
-			'notnull' => true,
+			'notnull' => false,
 			'default' => ''
 		]);
 

--- a/lib/Migration/Version0105Date20200523142076.php
+++ b/lib/Migration/Version0105Date20200523142076.php
@@ -66,7 +66,7 @@ class Version0105Date20200523142076 extends SimpleMigrationStep {
 				'default' => 0
 			]);
 			$table->addColumn('preferences', 'text', [
-				'notnull' => true,
+				'notnull' => false,
 				'default' => '',
 			]);
 			$table->setPrimaryKey(['id']);

--- a/lib/Migration/Version0106Date20201031080745.php
+++ b/lib/Migration/Version0106Date20201031080745.php
@@ -50,16 +50,16 @@ class Version0106Date20201031080745 extends SimpleMigrationStep {
 
 			if (!$table->hasColumn('display_name')) {
 				$table->addColumn('display_name', 'string', [
-					'notnull' => false,
 					'length' => 64,
+					'notnull' => false,
 					'default' => ''
 				]);
 			}
 
 			if (!$table->hasColumn('email_address')) {
 				$table->addColumn('email_address', 'string', [
-					'notnull' => false,
 					'length' => 254,
+					'notnull' => false,
 					'default' => ''
 				]);
 			}

--- a/lib/Migration/Version0107Date20201210204702.php
+++ b/lib/Migration/Version0107Date20201210204702.php
@@ -44,7 +44,7 @@ class Version0107Date20201210204702 extends SimpleMigrationStep {
 		if ($schema->hasTable('polls_options')) {
 			$table = $schema->getTable('polls_options');
 			$table->changeColumn('poll_option_text', [
-				'notnull' => true,
+				'notnull' => false,
 				'default' => ''
 			]);
 			$table->changeColumn('timestamp', [

--- a/lib/Migration/Version0107Date20201210213303.php
+++ b/lib/Migration/Version0107Date20201210213303.php
@@ -44,11 +44,11 @@ class Version0107Date20201210213303 extends SimpleMigrationStep {
 		if ($schema->hasTable('polls_votes')) {
 			$table = $schema->getTable('polls_votes');
 			$table->changeColumn('user_id', [
-				'notnull' => true,
+				'notnull' => false,
 				'default' => ''
 			]);
 			$table->changeColumn('vote_option_text', [
-				'notnull' => true,
+				'notnull' => false,
 				'default' => ''
 			]);
 		}

--- a/lib/Migration/Version0107Date20201217071304.php
+++ b/lib/Migration/Version0107Date20201217071304.php
@@ -44,7 +44,7 @@ class Version0107Date20201217071304 extends SimpleMigrationStep {
 		if ($schema->hasTable('polls_share')) {
 			$table = $schema->getTable('polls_share');
 			$table->changeColumn('user_id', [
-				'notnull' => true,
+				'notnull' => false,
 				'default' => ''
 			]);
 		}

--- a/lib/Migration/Version0107Date20210121220707.php
+++ b/lib/Migration/Version0107Date20210121220707.php
@@ -49,11 +49,11 @@ class Version0107Date20210121220707 extends SimpleMigrationStep {
 			]);
 			$table->changeColumn('user_id', [
 				'length' => 64,
-				'notnull' => true,
+				'notnull' => false,
 				'default' => ''
 			]);
 			$table->changeColumn('message_id', [
-				'notnull' => true,
+				'notnull' => false,
 				'default' => ''
 			]);
 			if ($table->hasColumn('message')) {

--- a/lib/Migration/Version0108Date20210307130003.php
+++ b/lib/Migration/Version0108Date20210307130003.php
@@ -83,7 +83,7 @@ class Version0108Date20210307130003 extends SimpleMigrationStep {
 			]);
 			$table->addColumn('table', 'string', [
 				'length' => 64,
-				'notnull' => true,
+				'notnull' => false,
 				'default' => ''
 			]);
 			$table->addColumn('poll_id', 'integer', [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "polls",
-	"version": "1.9.5",
+	"version": "2.0.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {


### PR DESCRIPTION
## This is a bugfix which addresses the problem for the falsely released version 2.0.0

Details: 
* this version is identically to version 1.9.6 (downgrade)
* only compatible with Nextcloud 20 and 21
* No changes to the database

Additionally change to prevent #1723, since the migrationService doesn't allow `notNull=true` and `default='' anymore`.

To update the polls version manually: 
* disable polls
* delete `../apps/polls` in your Nextcloud installation
* extract the contents of the package (after it is available) to `../apps` in your Nextcloud installation, You should find a fresh created folder `polls`in your `apps` folder
* enable polls

Theoretically anything should work
