### PR TITLE
Convert navigation and sidebar to views

### DIFF
--- a/lib/Listener/OptionListener.php
+++ b/lib/Listener/OptionListener.php
@@ -58,5 +58,7 @@ class OptionListener implements IEventListener {
 			$this->logService->setLog($event->getPollId(), $event->getLogMsg(), $event->getActor());
 		}
 		$this->watchService->writeUpdate($event->getPollId(), $this->table);
+		// If options are changed, simulate vote change to force recalculating of votes
+		$this->watchService->writeUpdate($event->getPollId(), Watch::OBJECT_VOTES);
 	}
 }

--- a/lib/Listener/PollListener.php
+++ b/lib/Listener/PollListener.php
@@ -61,6 +61,10 @@ class PollListener implements IEventListener {
 		}
 
 		$this->watchService->writeUpdate($event->getPollId(), $this->table);
+		// If the poll configuration is changed, simulate vote change
+		$this->watchService->writeUpdate($event->getPollId(), Watch::OBJECT_VOTES);
+		// If the poll configuration is changed, simulate option change
+		$this->watchService->writeUpdate($event->getPollId(), Watch::OBJECT_OPTIONS);
 
 		if ($event->getLogMsg()) {
 			$this->logService->setLog($event->getPollId(), $event->getLogMsg(), $event->getActor());

--- a/lib/Listener/VoteListener.php
+++ b/lib/Listener/VoteListener.php
@@ -58,5 +58,7 @@ class VoteListener implements IEventListener {
 			$this->logService->setLog($event->getPollId(), $event->getLogMsg(), $event->getActor());
 		}
 		$this->watchService->writeUpdate($event->getPollId(), $this->table);
+		// If a vote is changed, simulate option change to force recalculating of votes
+		$this->watchService->writeUpdate($event->getPollId(), Watch::OBJECT_OPTIONS);
 	}
 }

--- a/src/js/App.vue
+++ b/src/js/App.vue
@@ -45,7 +45,7 @@ import './assets/scss/hacks.scss'
 import './assets/scss/icons.scss'
 import './assets/scss/print.scss'
 
-// TODO: remove comments, when @media:prefers-color-scheme is completely supported by core
+// TODO: remove, when @media:prefers-color-scheme is completely supported by core
 import './assets/scss/transitions.scss'
 import './assets/scss/experimental.scss'
 import { watchPolls } from './mixins/watchPolls'
@@ -55,9 +55,7 @@ export default {
 	components: {
 		Content,
 		LoadingOverlay: () => import('./components/Base/LoadingOverlay'),
-		// Navigation: () => import('./components/Navigation/Navigation'),
 		SettingsDlg,
-		// SideBar: () => import('./components/SideBar/SideBar'),
 	},
 
 	mixins: [watchPolls],

--- a/src/js/App.vue
+++ b/src/js/App.vue
@@ -36,7 +36,6 @@
 <script>
 import SettingsDlg from './components/Settings/SettingsDlg'
 import { getCurrentUser } from '@nextcloud/auth'
-import { showError } from '@nextcloud/dialogs'
 import { Content } from '@nextcloud/vue'
 import { subscribe, unsubscribe } from '@nextcloud/event-bus'
 import { mapState } from 'vuex'
@@ -107,9 +106,6 @@ export default {
 	created() {
 		if (getCurrentUser()) {
 			this.$store.dispatch('settings/get')
-			if (this.$route.name !== 'publicVote') {
-				this.updatePolls()
-			}
 			if (this.$route.params.id && !this.$route.params.token) {
 				this.loadPoll(true)
 			}
@@ -127,10 +123,6 @@ export default {
 
 		subscribe('load-poll', (silent) => {
 			this.loadPoll(silent)
-		})
-
-		subscribe('update-polls', () => {
-			this.updatePolls()
 		})
 
 		subscribe('toggle-sidebar', (payload) => {
@@ -153,7 +145,6 @@ export default {
 	beforeDestroy() {
 		this.cancelToken.cancel()
 		unsubscribe('load-poll')
-		unsubscribe('update-polls')
 		unsubscribe('toggle-sidebar')
 		unsubscribe('transitions-on')
 		unsubscribe('transitions-off')
@@ -210,25 +201,6 @@ export default {
 			}
 		},
 
-		async updatePolls() {
-			const dispatches = []
-			if (this.$route.name === 'publicVote') {
-				return
-			}
-
-			dispatches.push('polls/list')
-
-			if (getCurrentUser().isAdmin) {
-				dispatches.push('pollsAdmin/load')
-			}
-
-			try {
-				const requests = dispatches.map((dispatches) => this.$store.dispatch(dispatches))
-				await Promise.all(requests)
-			} catch {
-				showError(t('polls', 'Error loading poll list'))
-			}
-		},
 	},
 }
 

--- a/src/js/App.vue
+++ b/src/js/App.vue
@@ -22,13 +22,16 @@
 
 <template>
 	<Content app-name="polls" :style="appStyle" :class="[transitionClass, { 'edit': acl.allowEdit, 'experimental': settings.experimental, 'bgimage': settings.useImage, 'bgcolored': settings.experimental }]">
-		<SettingsDlg />
-		<Navigation v-if="getCurrentUser()" :class="{ 'glassy': settings.glassyNavigation }" />
+		<router-view v-if="getCurrentUser()"
+			name="navigation"
+			:class="{ 'glassy': settings.glassyNavigation }" />
 		<router-view />
-		<SideBar v-if="sideBarOpen && $store.state.poll.id && (acl.allowEdit || poll.allowComment)"
+		<router-view v-if="sideBarOpen && $store.state.poll.id && (acl.allowEdit || poll.allowComment)"
+			name="sidebar"
 			:active="activeTab"
 			:class="{ 'glassy': settings.glassySidebar }" />
 		<LoadingOverlay v-if="loading" />
+		<SettingsDlg />
 	</Content>
 </template>
 
@@ -55,9 +58,9 @@ export default {
 	components: {
 		Content,
 		LoadingOverlay: () => import('./components/Base/LoadingOverlay'),
-		Navigation: () => import('./components/Navigation/Navigation'),
+		// Navigation: () => import('./components/Navigation/Navigation'),
 		SettingsDlg,
-		SideBar: () => import('./components/SideBar/SideBar'),
+		// SideBar: () => import('./components/SideBar/SideBar'),
 	},
 
 	mixins: [watchPolls],

--- a/src/js/App.vue
+++ b/src/js/App.vue
@@ -22,9 +22,7 @@
 
 <template>
 	<Content app-name="polls" :style="appStyle" :class="[transitionClass, { 'edit': acl.allowEdit, 'experimental': settings.experimental, 'bgimage': settings.useImage, 'bgcolored': settings.experimental }]">
-		<router-view v-if="getCurrentUser()"
-			name="navigation"
-			:class="{ 'glassy': settings.glassyNavigation }" />
+		<router-view name="navigation" :class="{ 'glassy': settings.glassyNavigation }" />
 		<router-view />
 		<router-view v-if="sideBarOpen && $store.state.poll.id && (acl.allowEdit || poll.allowComment)"
 			name="sidebar"

--- a/src/js/App.vue
+++ b/src/js/App.vue
@@ -21,10 +21,10 @@
   -->
 
 <template>
-	<Content app-name="polls" :style="appStyle" :class="[transitionClass, { 'edit': acl.allowEdit, 'experimental': settings.experimental, 'bgimage': settings.useImage, 'bgcolored': settings.experimental }]">
+	<Content app-name="polls" :style="appStyle" :class="[transitionClass, { 'edit': allowEdit, 'experimental': settings.experimental, 'bgimage': settings.useImage, 'bgcolored': settings.experimental }]">
 		<router-view name="navigation" :class="{ 'glassy': settings.glassyNavigation }" />
 		<router-view />
-		<router-view v-if="sideBarOpen && $store.state.poll.id && (acl.allowEdit || poll.allowComment)"
+		<router-view v-if="showSidebar"
 			name="sidebar"
 			:active="activeTab"
 			:class="{ 'glassy': settings.glassySidebar }" />
@@ -76,8 +76,13 @@ export default {
 		...mapState({
 			settings: (state) => state.settings.user,
 			poll: (state) => state.poll,
-			acl: (state) => state.poll.acl,
+			allowEdit: (state) => state.poll.acl.allowEdit,
 		}),
+
+		showSidebar() {
+			return this.sideBarOpen && this.poll.id && (this.allowEdit || this.poll.allowComment)
+		},
+
 		appStyle() {
 			if (this.settings.useImage && this.settings.experimental) {
 				return {

--- a/src/js/components/Comments/Comments.vue
+++ b/src/js/components/Comments/Comments.vue
@@ -60,6 +60,5 @@ export default {
 		},
 
 	},
-
 }
 </script>

--- a/src/js/mixins/watchPolls.js
+++ b/src/js/mixins/watchPolls.js
@@ -31,13 +31,10 @@ export const watchPolls = {
 					emit('update-polls')
 					if (item.pollId === parseInt(this.$route.params.id ?? this.$store.state.share.pollId)) {
 						// if current poll is affected, load current poll configuration
-						// load also options and votes
-						dispatches = [...dispatches, 'poll/get', 'votes/list', 'options/list']
+						dispatches = [...dispatches, 'poll/get']
 					}
-				} else if (['votes', 'options'].includes(item.table)) {
-					dispatches = [...dispatches, 'votes/list', 'options/list']
 				} else {
-					// a table of the current poll was reported, load
+					// a table change of the current poll was reported, load
 					// corresponding stores
 					dispatches = [...dispatches, item.table + '/list']
 				}

--- a/src/js/mixins/watchPolls.js
+++ b/src/js/mixins/watchPolls.js
@@ -2,6 +2,7 @@
 import axios from '@nextcloud/axios'
 import { generateUrl } from '@nextcloud/router'
 import exception from '../Exceptions/Exceptions'
+import { emit } from '@nextcloud/event-bus'
 
 export const watchPolls = {
 	data() {
@@ -26,12 +27,8 @@ export const watchPolls = {
 			let dispatches = []
 			tables.forEach((item) => {
 				this.lastUpdated = Math.max(item.updated, this.lastUpdated)
-				// an updated poll table is reported
 				if (item.table === 'polls') {
-					if (this.$route.name !== 'publicVote') {
-						// load poll list only, when not in public poll
-						dispatches = [...dispatches, 'polls/list']
-					}
+					emit('update-polls')
 					if (item.pollId === parseInt(this.$route.params.id ?? this.$store.state.share.pollId)) {
 						// if current poll is affected, load current poll configuration
 						// load also options and votes

--- a/src/js/router.js
+++ b/src/js/router.js
@@ -31,6 +31,8 @@ const List = () => import('./views/PollList')
 const Administration = () => import('./views/Administration')
 const Vote = () => import('./views/Vote')
 const NotFound = () => import('./views/NotFound')
+const SideBar = () => import('./views/SideBar')
+const Navigation = () => import('./views/Navigation')
 
 Vue.use(Router)
 
@@ -52,6 +54,7 @@ export default new Router({
 			path: '/list/:type?',
 			components: {
 				default: List,
+				navigation: Navigation,
 			},
 			props: true,
 			name: 'list',
@@ -60,6 +63,7 @@ export default new Router({
 			path: '/administration',
 			components: {
 				default: Administration,
+				navigation: Navigation,
 			},
 			name: 'administration',
 		},
@@ -67,6 +71,7 @@ export default new Router({
 			path: '/not-found',
 			components: {
 				default: NotFound,
+				navigation: Navigation,
 			},
 			name: 'notfound',
 		},
@@ -74,6 +79,8 @@ export default new Router({
 			path: '/vote/:id',
 			components: {
 				default: Vote,
+				navigation: Navigation,
+				sidebar: SideBar,
 			},
 			props: true,
 			name: 'vote',
@@ -86,6 +93,7 @@ export default new Router({
 			path: '/s/:token',
 			components: {
 				default: Vote,
+				sidebar: SideBar,
 			},
 			props: true,
 			name: 'publicVote',

--- a/src/js/router.js
+++ b/src/js/router.js
@@ -86,10 +86,6 @@ export default new Router({
 			name: 'vote',
 		},
 		{
-			path: '/poll/:token',
-			redirect: '/s/:token',
-		},
-		{
 			path: '/s/:token',
 			components: {
 				default: Vote,

--- a/src/js/views/Navigation.vue
+++ b/src/js/views/Navigation.vue
@@ -57,11 +57,11 @@
 
 import { AppNavigation, AppNavigationNew, AppNavigationItem } from '@nextcloud/vue'
 import { mapGetters, mapState } from 'vuex'
-import { showError } from '@nextcloud/dialogs'
 import { getCurrentUser } from '@nextcloud/auth'
+import { showError } from '@nextcloud/dialogs'
+import { emit, subscribe, unsubscribe } from '@nextcloud/event-bus'
 import CreateDlg from '../components/Create/CreateDlg'
 import PollNavigationItems from '../components/Navigation/PollNavigationItems'
-import { emit } from '@nextcloud/event-bus'
 
 export default {
 	name: 'Navigation',
@@ -94,8 +94,16 @@ export default {
 		},
 	},
 
+	created() {
+		this.updatePolls()
+		subscribe('update-polls', () => {
+			this.updatePolls()
+		})
+	},
+
 	beforeDestroy() {
 		window.clearInterval(this.reloadTimer)
+		unsubscribe('update-polls')
 	},
 
 	methods: {
@@ -112,6 +120,23 @@ export default {
 
 		showSettings() {
 			emit('show-settings')
+		},
+
+		async updatePolls() {
+			const dispatches = []
+
+			dispatches.push('polls/list')
+
+			if (getCurrentUser().isAdmin) {
+				dispatches.push('pollsAdmin/load')
+			}
+
+			try {
+				const requests = dispatches.map((dispatches) => this.$store.dispatch(dispatches))
+				await Promise.all(requests)
+			} catch {
+				showError(t('polls', 'Error loading poll list'))
+			}
 		},
 
 		async clonePoll(pollId) {

--- a/src/js/views/Navigation.vue
+++ b/src/js/views/Navigation.vue
@@ -59,8 +59,8 @@ import { AppNavigation, AppNavigationNew, AppNavigationItem } from '@nextcloud/v
 import { mapGetters, mapState } from 'vuex'
 import { showError } from '@nextcloud/dialogs'
 import { getCurrentUser } from '@nextcloud/auth'
-import CreateDlg from '../Create/CreateDlg'
-import PollNavigationItems from './PollNavigationItems'
+import CreateDlg from '../components/Create/CreateDlg'
+import PollNavigationItems from '../components/Navigation/PollNavigationItems'
 import { emit } from '@nextcloud/event-bus'
 
 export default {

--- a/src/js/views/SideBar.vue
+++ b/src/js/views/SideBar.vue
@@ -68,10 +68,10 @@ export default {
 	name: 'SideBar',
 
 	components: {
-		SideBarTabConfiguration: () => import('./SideBarTabConfiguration'),
-		SideBarTabComments: () => import('./SideBarTabComments'),
-		SideBarTabOptions: () => import('./SideBarTabOptions'),
-		SideBarTabShare: () => import('./SideBarTabShare'),
+		SideBarTabConfiguration: () => import('../components/SideBar/SideBarTabConfiguration'),
+		SideBarTabComments: () => import('../components/SideBar/SideBarTabComments'),
+		SideBarTabOptions: () => import('../components/SideBar/SideBarTabOptions'),
+		SideBarTabShare: () => import('../components/SideBar/SideBarTabShare'),
 		AppSidebar,
 		AppSidebarTab,
 	},


### PR DESCRIPTION
* Load navigation and sidebar async via router
* Refresh poll list only, if navigation is loaded (this irrelevant in public polls, so avoid uneccessary request)
* decide dependent objects (options, votes) in servide listeners