### PR TITLE
Fix migration from versions prior to 1.8

### DIFF
--- a/lib/Db/Comment.php
+++ b/lib/Db/Comment.php
@@ -43,6 +43,7 @@ use OCP\AppFramework\Db\Entity;
  * @method void setTimestamp(integer $value)
  */
 class Comment extends Entity implements JsonSerializable {
+	public const TABLE = 'polls_comments';
 
 	/** @var int $pollId */
 	protected $pollId;

--- a/lib/Db/CommentMapper.php
+++ b/lib/Db/CommentMapper.php
@@ -32,8 +32,10 @@ use OCP\AppFramework\Db\QBMapper;
  * @template-extends QBMapper<Comment>
  */
 class CommentMapper extends QBMapper {
+	public const TABLE = Comment::TABLE;
+
 	public function __construct(IDBConnection $db) {
-		parent::__construct($db, 'polls_comments', Comment::class);
+		parent::__construct($db, self::TABLE, Comment::class);
 	}
 
 	/**

--- a/lib/Db/Log.php
+++ b/lib/Db/Log.php
@@ -43,6 +43,7 @@ use OCP\AppFramework\Db\Entity;
  * @method void setMessageId(string $value)
  */
 class Log extends Entity implements JsonSerializable {
+	public const TABLE = 'polls_log';
 	public const MSG_ID_ADDPOLL = 'addPoll';
 	public const MSG_ID_UPDATEPOLL = 'updatePoll';
 	public const MSG_ID_DELETEPOLL = 'deletePoll';

--- a/lib/Db/LogMapper.php
+++ b/lib/Db/LogMapper.php
@@ -35,8 +35,10 @@ use OCP\Migration\IOutput;
  * @template-extends QBMapper<Log>
  */
 class LogMapper extends QBMapper {
+	public const TABLE = Log::TABLE;
+
 	public function __construct(IDBConnection $db) {
-		parent::__construct($db, 'polls_log', Log::class);
+		parent::__construct($db, self::TABLE, Log::class);
 	}
 
 	public function find(int $id): Log {

--- a/lib/Db/Option.php
+++ b/lib/Db/Option.php
@@ -51,6 +51,7 @@ use OCP\IUser;
  * @method void setTimestamp(integer $value)
  */
 class Option extends Entity implements JsonSerializable {
+	public const TABLE = 'polls_options';
 
 	/** @var int $pollId */
 	protected $pollId;

--- a/lib/Db/OptionMapper.php
+++ b/lib/Db/OptionMapper.php
@@ -35,8 +35,10 @@ use OCP\Migration\IOutput;
  * @template-extends QBMapper<Option>
  */
 class OptionMapper extends QBMapper {
+	public const TABLE = Option::TABLE;
+
 	public function __construct(IDBConnection $db) {
-		parent::__construct($db, 'polls_options', Option::class);
+		parent::__construct($db, self::TABLE, Option::class);
 	}
 
 	/**

--- a/lib/Db/Poll.php
+++ b/lib/Db/Poll.php
@@ -74,6 +74,7 @@ use OCA\Polls\Model\User;
  * @method void setUseNo(integer $value)
  */
 class Poll extends Entity implements JsonSerializable {
+	public const TABLE = 'polls_polls';
 	public const TYPE_DATE = 'datePoll';
 	public const TYPE_TEXT = 'textPoll';
 	public const ACCESS_HIDDEN = 'hidden';

--- a/lib/Db/PollMapper.php
+++ b/lib/Db/PollMapper.php
@@ -32,8 +32,10 @@ use OCP\AppFramework\Db\QBMapper;
  * @template-extends QBMapper<Poll>
  */
 class PollMapper extends QBMapper {
+	public const TABLE = Poll::TABLE;
+
 	public function __construct(IDBConnection $db) {
-		parent::__construct($db, 'polls_polls', Poll::class);
+		parent::__construct($db, self::TABLE, Poll::class);
 	}
 
 	/**

--- a/lib/Db/Preferences.php
+++ b/lib/Db/Preferences.php
@@ -38,6 +38,7 @@ use OCP\AppFramework\Db\Entity;
  * @method void setPreferences(string $value)
  */
 class Preferences extends Entity implements JsonSerializable {
+	public const TABLE = 'polls_preferences';
 
 	/** @var string $userId */
 	protected $userId;

--- a/lib/Db/PreferencesMapper.php
+++ b/lib/Db/PreferencesMapper.php
@@ -35,8 +35,10 @@ use OCP\Migration\IOutput;
  * @template-extends QBMapper<Preferences>
  */
 class PreferencesMapper extends QBMapper {
+	public const TABLE = Preferences::TABLE;
+
 	public function __construct(IDBConnection $db) {
-		parent::__construct($db, 'polls_preferences', Preferences::class);
+		parent::__construct($db, self::TABLE, Preferences::class);
 	}
 
 	/**
@@ -65,7 +67,7 @@ class PreferencesMapper extends QBMapper {
 				->setParameter('userId', '');
 			$query->execute();
 
-			// remove duplicate preferences from oc_polls_preferences
+			// remove duplicate preferences from polls_preferences
 			// preserve the last user setting in the db
 			$query = $this->db->getQueryBuilder();
 			$query->select('id', 'user_id')

--- a/lib/Db/Share.php
+++ b/lib/Db/Share.php
@@ -47,6 +47,7 @@ use OCA\Polls\Model\UserGroupClass;
  * @method void setDisplayName(string $value)
  */
 class Share extends Entity implements JsonSerializable {
+	public const TABLE = 'polls_share';
 
 	// Only authenticated access
 	public const TYPE_USER = 'user';

--- a/lib/Db/ShareMapper.php
+++ b/lib/Db/ShareMapper.php
@@ -35,8 +35,10 @@ use OCP\Migration\IOutput;
  * @template-extends QBMapper<Share>
  */
 class ShareMapper extends QBMapper {
+	public const TABLE = Share::TABLE;
+
 	public function __construct(IDBConnection $db) {
-		parent::__construct($db, 'polls_share', Share::class);
+		parent::__construct($db, self::TABLE, Share::class);
 	}
 
 	/**
@@ -162,7 +164,7 @@ class ShareMapper extends QBMapper {
 				->setParameter('type', 'public')
 				->execute();
 
-			// remove duplicates from oc_polls_share
+			// remove duplicates from polls_share
 			// preserve the first entry
 			$query = $this->db->getQueryBuilder();
 			$query->select('id', 'type', 'poll_id', 'user_id')

--- a/lib/Db/Subscription.php
+++ b/lib/Db/Subscription.php
@@ -37,6 +37,7 @@ use OCP\AppFramework\Db\Entity;
  * @method void setUserId(string $value)
  */
 class Subscription extends Entity implements JsonSerializable {
+	public const TABLE = 'polls_notif';
 
 	/** @var int $pollId */
 	protected $pollId;

--- a/lib/Db/SubscriptionMapper.php
+++ b/lib/Db/SubscriptionMapper.php
@@ -35,8 +35,10 @@ use OCP\Migration\IOutput;
  * @template-extends QBMapper<Subscription>
  */
 class SubscriptionMapper extends QBMapper {
+	public const TABLE = Subscription::TABLE;
+
 	public function __construct(IDBConnection $db) {
-		parent::__construct($db, 'polls_notif', Subscription::class);
+		parent::__construct($db, self::TABLE, Subscription::class);
 	}
 
 	/**
@@ -108,7 +110,7 @@ class SubscriptionMapper extends QBMapper {
 	public function removeDuplicates(?IOutput $output = null): int {
 		$count = 0;
 		try {
-			// remove duplicates from oc_polls_share
+			// remove duplicates from polls_share
 			// preserve the first entry
 			$query = $this->db->getQueryBuilder();
 			$query->select('id', 'poll_id', 'user_id')

--- a/lib/Db/Vote.php
+++ b/lib/Db/Vote.php
@@ -42,6 +42,7 @@ use OCP\AppFramework\Db\Entity;
  * @method void setVoteAnswer(string $value)
  */
 class Vote extends Entity implements JsonSerializable {
+	public const TABLE = 'polls_votes';
 
 	/** @var int $pollId */
 	protected $pollId;

--- a/lib/Db/VoteMapper.php
+++ b/lib/Db/VoteMapper.php
@@ -35,8 +35,10 @@ use OCP\Migration\IOutput;
  * @template-extends QBMapper<Vote>
  */
 class VoteMapper extends QBMapper {
+	public const TABLE = Vote::TABLE;
+
 	public function __construct(IDBConnection $db) {
-		parent::__construct($db, 'polls_votes', Vote::class);
+		parent::__construct($db, self::TABLE, Vote::class);
 	}
 
 	/**

--- a/lib/Db/Watch.php
+++ b/lib/Db/Watch.php
@@ -38,6 +38,7 @@ use OCP\AppFramework\Db\Entity;
  * @method void setUpdated(integer $value)
  */
 class Watch extends Entity implements JsonSerializable {
+	public const TABLE = 'polls_watch';
 	public const OBJECT_POLLS = "polls";
 	public const OBJECT_VOTES = "votes";
 	public const OBJECT_OPTIONS = "options";

--- a/lib/Db/WatchMapper.php
+++ b/lib/Db/WatchMapper.php
@@ -30,8 +30,10 @@ use OCP\AppFramework\Db\QBMapper;
  * @template-extends QBMapper<Watch>
  */
 class WatchMapper extends QBMapper {
+	public const TABLE = Watch::TABLE;
+
 	public function __construct(IDBConnection $db) {
-		parent::__construct($db, 'polls_watch', Watch::class);
+		parent::__construct($db, self::TABLE, Watch::class);
 	}
 
 	/**

--- a/lib/Migration/DeleteInvalidRecords.php
+++ b/lib/Migration/DeleteInvalidRecords.php
@@ -33,6 +33,7 @@ use OCP\Migration\IOutput;
 use OCA\Polls\Db\LogMapper;
 use OCA\Polls\Db\OptionMapper;
 use OCA\Polls\Db\PreferencesMapper;
+use OCA\Polls\Db\Poll;
 use OCA\Polls\Db\ShareMapper;
 use OCA\Polls\Db\SubscriptionMapper;
 use OCA\Polls\Db\VoteMapper;
@@ -67,12 +68,12 @@ class DeleteInvalidRecords implements IRepairStep {
 	private $voteMapper;
 
 	protected $childTables = [
-		'polls_comments',
-		'polls_log',
-		'polls_notif',
-		'polls_options',
-		'polls_share',
-		'polls_votes',
+		CommentMapper::TABLE,
+		LogMapper::TABLE,
+		SubscriptionMapper::TABLE,
+		OptionMapper::TABLE,
+		ShareMapper::TABLE,
+		VoteMapper::TABLE,
 	];
 
 	public function __construct(
@@ -101,7 +102,7 @@ class DeleteInvalidRecords implements IRepairStep {
 
 	public function run(IOutput $output):void {
 		$schema = new SchemaWrapper($this->connection);
-		if ($schema->hasTable('polls_polls')) {
+		if ($schema->hasTable(Poll::TABLE)) {
 			$this->removeOrphaned();
 			$this->logMapper->removeDuplicates($output);
 			$this->optionMapper->removeDuplicates($output);

--- a/lib/Migration/FixVotes.php
+++ b/lib/Migration/FixVotes.php
@@ -71,15 +71,18 @@ class FixVotes implements IRepairStep {
 	 */
 	public function run(IOutput $output) {
 		$schema = new SchemaWrapper($this->connection);
-		if ($schema->hasTable('polls_options')) {
-			$foundOptions = $this->optionMapper->findOptionsWithDuration();
-			foreach ($foundOptions as $option) {
-				$this->voteMapper->fixVoteOptionText(
-					$option->getPollId(),
-					$option->getId(),
-					$option->getPollOptionTextStart(),
-					$option->getPollOptionText(),
-				);
+		if ($schema->hasTable(OptionMapper::TABLE)) {
+			$table = $schema->getTable(OptionMapper::TABLE);
+			if ($table->hasColumn('duration')) {
+				$foundOptions = $this->optionMapper->findOptionsWithDuration();
+				foreach ($foundOptions as $option) {
+					$this->voteMapper->fixVoteOptionText(
+						$option->getPollId(),
+						$option->getId(),
+						$option->getPollOptionTextStart(),
+						$option->getPollOptionText(),
+					);
+				}
 			}
 		}
 	}

--- a/lib/Migration/TableSchema.php
+++ b/lib/Migration/TableSchema.php
@@ -28,6 +28,15 @@ use OCP\DB\Types;
 use OCP\DB\ISchemaWrapper;
 use OCP\Migration\IOutput;
 use Doctrine\DBAL\Types\Type;
+use OCA\Polls\Db\Comment;
+use OCA\Polls\Db\Log;
+use OCA\Polls\Db\Option;
+use OCA\Polls\Db\Preferences;
+use OCA\Polls\Db\Poll;
+use OCA\Polls\Db\Share;
+use OCA\Polls\Db\Subscription;
+use OCA\Polls\Db\Vote;
+use OCA\Polls\Db\Watch;
 
 /**
  * Database definition for installing and migrations
@@ -38,34 +47,34 @@ use Doctrine\DBAL\Types\Type;
  */
 
 abstract class TableSchema {
-	public const FK_PARENT_TABLE = 'polls_polls';
+	public const FK_PARENT_TABLE = Poll::Table;
 
 	public const FK_CHILD_TABLES = [
-		'polls_comments',
-		'polls_log',
-		'polls_notif',
-		'polls_options',
-		'polls_share',
-		'polls_votes',
+		Comment::TABLE,
+		Log::TABLE,
+		Subscription::TABLE,
+		Option::TABLE,
+		Share::TABLE,
+		Vote::TABLE,
 	];
 
 	public const UNIQUE_TABLES = [
-		'polls_log',
-		'polls_notif',
-		'polls_options',
-		'polls_preferences',
-		'polls_share',
-		'polls_votes',
+		Log::TABLE,
+		Subscription::TABLE,
+		Option::TABLE,
+		Subscription::TABLE,
+		Share::TABLE,
+		Vote::TABLE,
 	];
 
 	public const UNIQUE_INDICES = [
-		'polls_options' => ['name' => 'UNIQ_options', 'unique' => true, 'columns' => ['poll_id', 'poll_option_text', 'timestamp']],
-		'polls_log' => ['name' => 'UNIQ_unprocessed', 'unique' => true, 'columns' => ['processed', 'poll_id', 'user_id', 'message_id']],
-		'polls_notif' => ['name' => 'UNIQ_subscription', 'unique' => true, 'columns' => ['poll_id', 'user_id']],
-		'polls_share' => ['name' => 'UNIQ_shares', 'unique' => true, 'columns' => ['poll_id', 'user_id']],
-		'polls_votes' => ['name' => 'UNIQ_votes', 'unique' => true, 'columns' => ['poll_id', 'user_id', 'vote_option_text']],
-		'polls_preferences' => ['name' => 'UNIQ_preferences', 'unique' => true, 'columns' => ['user_id']],
-		'polls_watch' => ['name' => 'UNIQ_watch', 'unique' => true, 'columns' => ['poll_id', 'table']],
+		Option::TABLE => ['name' => 'UNIQ_options', 'unique' => true, 'columns' => ['poll_id', 'poll_option_text', 'timestamp']],
+		Log::TABLE => ['name' => 'UNIQ_unprocessed', 'unique' => true, 'columns' => ['processed', 'poll_id', 'user_id', 'message_id']],
+		Subscription::TABLE => ['name' => 'UNIQ_subscription', 'unique' => true, 'columns' => ['poll_id', 'user_id']],
+		Share::TABLE => ['name' => 'UNIQ_shares', 'unique' => true, 'columns' => ['poll_id', 'user_id']],
+		Vote::TABLE => ['name' => 'UNIQ_votes', 'unique' => true, 'columns' => ['poll_id', 'user_id', 'vote_option_text']],
+		Subscription::TABLE => ['name' => 'UNIQ_preferences', 'unique' => true, 'columns' => ['user_id']],
+		Watch::TABLE => ['name' => 'UNIQ_watch', 'unique' => true, 'columns' => ['poll_id', 'table']],
 	];
 
 	/**
@@ -134,12 +143,12 @@ abstract class TableSchema {
 	 * ];
 	 */
 	public const GONE_COLUMNS = [
-		'polls_polls' => [
+		Poll::Table => [
 			'full_anonymous',
 			'options',
 			'settings',
 		],
-		'polls_comments' => [
+		Comment::TABLE => [
 			'dt',
 		],
 	];
@@ -148,7 +157,7 @@ abstract class TableSchema {
 	 * define primary keys (only set on table creation)
 	 * Format:
 	 * public const PRIMARYKEY = [
-	 *   'polls_polls' => [
+	 *   Poll::Table => [
 	 *     'id' => [
 	 *       'type' => Types::INTEGER,
 	 *       'options' => ['autoincrement' => true, 'notnull' => true]
@@ -159,7 +168,7 @@ abstract class TableSchema {
 	 *     ],
 	 *     ...,
 	 *   ],
-	 *   'polls_options' => [
+	 *   Option::TABLE => [
 	 *     'id' => [
 	 *       'type' => Types::INTEGER,
 	 *       'options' => ['autoincrement' => true, 'notnull' => true]
@@ -175,7 +184,7 @@ abstract class TableSchema {
 	 */
 
 	public const TABLES = [
-		'polls_polls' => [
+		Poll::Table => [
 			'id' => ['type' => Types::INTEGER, 'options' => ['autoincrement' => true, 'notnull' => true]],
 			'type' => ['type' => Types::STRING, 'options' => ['notnull' => true, 'default' => 'datePoll', 'length' => 64]],
 			'title' => ['type' => Types::STRING, 'options' => ['notnull' => false, 'default' => '', 'length' => 128]],
@@ -198,7 +207,7 @@ abstract class TableSchema {
 			'use_no' => ['type' => Types::INTEGER, 'options' => ['notnull' => true, 'default' => 1]],
 			'proposals_expire' => ['type' => Types::INTEGER, 'options' => ['notnull' => true, 'default' => 0]],
 		],
-		'polls_options' => [
+		Option::TABLE => [
 			'id' => ['type' => Types::INTEGER, 'options' => ['autoincrement' => true, 'notnull' => true]],
 			'poll_id' => ['type' => Types::INTEGER, 'options' => ['notnull' => true, 'default' => 0]],
 			'poll_option_text' => ['type' => Types::STRING, 'options' => ['notnull' => false, 'default' => '', 'length' => 256]],
@@ -209,7 +218,7 @@ abstract class TableSchema {
 			'owner' => ['type' => Types::STRING, 'options' => ['notnull' => false, 'default' => '', 'length' => 256]],
 			'released' => ['type' => Types::INTEGER, 'options' => ['notnull' => true, 'default' => 0]],
 		],
-		'polls_votes' => [
+		Vote::TABLE => [
 			'id' => ['type' => Types::INTEGER, 'options' => ['autoincrement' => true, 'notnull' => true]],
 			'poll_id' => ['type' => Types::INTEGER, 'options' => ['notnull' => true, 'default' => 0]],
 			'user_id' => ['type' => Types::STRING, 'options' => ['notnull' => false, 'default' => '', 'length' => 256]],
@@ -217,7 +226,7 @@ abstract class TableSchema {
 			'vote_option_text' => ['type' => Types::STRING, 'options' => ['notnull' => false, 'default' => '', 'length' => 256]],
 			'vote_answer' => ['type' => Types::STRING, 'options' => ['notnull' => false, 'default' => '', 'length' => 64]],
 		],
-		'polls_comments' => [
+		Comment::TABLE => [
 			'id' => ['type' => Types::INTEGER, 'options' => ['autoincrement' => true, 'notnull' => true]],
 			'poll_id' => ['type' => Types::INTEGER, 'options' => ['notnull' => true, 'default' => 0]],
 			'user_id' => ['type' => Types::STRING, 'options' => ['notnull' => false, 'default' => '', 'length' => 256]],
@@ -225,7 +234,7 @@ abstract class TableSchema {
 			'timestamp' => ['type' => Types::INTEGER, 'options' => ['notnull' => true, 'default' => 0]],
 
 		],
-		'polls_share' => [
+		Share::TABLE => [
 			'id' => ['type' => Types::INTEGER, 'options' => ['autoincrement' => true, 'notnull' => true]],
 			'token' => ['type' => Types::STRING, 'options' => ['notnull' => false, 'default' => '', 'length' => 64]],
 			'type' => ['type' => Types::STRING, 'options' => ['notnull' => false, 'default' => '', 'length' => 64]],
@@ -235,12 +244,12 @@ abstract class TableSchema {
 			'email_address' => ['type' => Types::STRING, 'options' => ['notnull' => false, 'default' => '', 'length' => 256]],
 			'invitation_sent' => ['type' => Types::INTEGER, 'options' => ['notnull' => true, 'default' => 0]],
 		],
-		'polls_notif' => [
+		Subscription::TABLE => [
 			'id' => ['type' => Types::INTEGER, 'options' => ['autoincrement' => true, 'notnull' => true]],
 			'poll_id' => ['type' => Types::INTEGER, 'options' => ['notnull' => true, 'default' => 0]],
 			'user_id' => ['type' => Types::STRING, 'options' => ['notnull' => false, 'default' => '', 'length' => 256]],
 		],
-		'polls_log' => [
+		Log::TABLE => [
 			'id' => ['type' => Types::INTEGER, 'options' => ['autoincrement' => true, 'notnull' => true]],
 			'poll_id' => ['type' => Types::INTEGER, 'options' => ['notnull' => true, 'default' => 0]],
 			'user_id' => ['type' => Types::STRING, 'options' => ['notnull' => false, 'default' => '', 'length' => 256]],
@@ -249,13 +258,13 @@ abstract class TableSchema {
 			'created' => ['type' => Types::INTEGER, 'options' => ['notnull' => true, 'default' => 0]],
 			'processed' => ['type' => Types::INTEGER, 'options' => ['notnull' => true, 'default' => 0]],
 		],
-		'polls_watch' => [
+		Watch::TABLE => [
 			'id' => ['type' => Types::INTEGER, 'options' => ['autoincrement' => true, 'notnull' => true]],
 			'poll_id' => ['type' => Types::INTEGER, 'options' => ['notnull' => true, 'default' => 0]],
 			'table' => ['type' => Types::STRING, 'options' => ['notnull' => false, 'default' => '', 'length' => 64]],
 			'updated' => ['type' => Types::INTEGER, 'options' => ['notnull' => true, 'default' => 0]],
 		],
-		'polls_preferences' => [
+		Subscription::TABLE => [
 			'id' => ['type' => Types::INTEGER, 'options' => ['autoincrement' => true, 'notnull' => true]],
 			'user_id' => ['type' => Types::STRING, 'options' => ['notnull' => false, 'default' => '', 'length' => 256]],
 			'timestamp' => ['type' => Types::INTEGER, 'options' => ['notnull' => true, 'default' => 0]],

--- a/lib/Migration/Version030000Date20210704120000.php
+++ b/lib/Migration/Version030000Date20210704120000.php
@@ -28,6 +28,7 @@ use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\Migration\SimpleMigrationStep;
 use OCP\Migration\IOutput;
+use OCA\Polls\DB\Poll;
 
 // use Doctrine\DBAL\Types\Type;
 
@@ -61,7 +62,7 @@ class Version030000Date20210704120000 extends SimpleMigrationStep {
 		/** @var ISchemaWrapper $schema */
 		$schema = $schemaClosure();
 
-		if ($schema->hasTable('polls_polls')) {
+		if ($schema->hasTable(Poll::TABLE)) {
 			// Call initial migration from class TableSchema
 			// Drop old tables, which are migrated in prior versions
 			TableSchema::removeObsoleteTables($schema, $output);


### PR DESCRIPTION
fix #1858
* use constnts for table names
* fix migration, where the column `duration` is missing