### PR TITLE
Changed calculation of whole day events.

### DIFF
--- a/src/js/components/Options/OptionItem.vue
+++ b/src/js/components/Options/OptionItem.vue
@@ -109,7 +109,8 @@ export default {
 			// is the duration divisable through 24 hours without rest
 			// then we have a day long event (one or multiple days)
 			// In this case we want to suppress the display of any time information
-			const dayLongEvent = from.unix() === moment(from).startOf('day').unix() && this.option.duration && this.option.duration % 86400 === 0
+			const dayLongEvent = from.unix() === moment(from).startOf('day').unix() && to.unix() === moment(to).startOf('day').unix() && from.unix() !== to.unix()
+
 			const dayModifier = dayLongEvent ? 1 : 0
 			// modified to date, in case of day long events, a second gets substracted
 			// to set the begin of the to day to the end of the previous date


### PR DESCRIPTION
quick fix #1981 
The calculation of full day events has changed, but there is work to do for the both days in the year, when daylight saving changes. In these cases the event duration is 23 or 25 hours. 

There is also an impact when shifting options over these dates. 