### PR TITLE
remove devDependencies from package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,13 +37,10 @@
 				"xlsx": "^0.18.0"
 			},
 			"devDependencies": {
-				"@babel/core": "^7.17.0",
-				"@babel/eslint-parser": "^7.17.0",
 				"@babel/preset-env": "^7.16.11",
 				"@babel/types": "^7.16.7",
 				"@nextcloud/browserslist-config": "^2.2.0",
 				"@nextcloud/eslint-config": "^7.0.2",
-				"@nextcloud/eslint-plugin": "^2.0.0",
 				"@nextcloud/stylelint-config": "^2.1.2",
 				"babel-loader": "^8.2.3",
 				"css-loader": "^6.6.0",
@@ -192,6 +189,7 @@
 			"resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.17.0.tgz",
 			"integrity": "sha512-PUEJ7ZBXbRkbq3qqM/jZ2nIuakUBqCYc7Qf52Lj7dlZ6zERnqisdHioL0l4wwQZnmskMeasqUNzLBFKs3nylXA==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"eslint-scope": "^5.1.1",
 				"eslint-visitor-keys": "^2.1.0",
@@ -210,6 +208,7 @@
 			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
 			"integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -219,6 +218,7 @@
 			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
 			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
 			"dev": true,
+			"peer": true,
 			"bin": {
 				"semver": "bin/semver.js"
 			}
@@ -2133,6 +2133,7 @@
 			"resolved": "https://registry.npmjs.org/@nextcloud/eslint-plugin/-/eslint-plugin-2.0.0.tgz",
 			"integrity": "sha512-j5WXTDTprr/cDilVJtC1mnrpkvD6jlEMShs72V5plllatHjO7kpZHzUfCX3dSvGwYc2ACa0XH+FbkPoZQ3+eWQ==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"requireindex": "^1.2.0"
 			},
@@ -9506,6 +9507,7 @@
 			"resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
 			"integrity": "sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=0.10.5"
 			}
@@ -12338,6 +12340,7 @@
 			"resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.17.0.tgz",
 			"integrity": "sha512-PUEJ7ZBXbRkbq3qqM/jZ2nIuakUBqCYc7Qf52Lj7dlZ6zERnqisdHioL0l4wwQZnmskMeasqUNzLBFKs3nylXA==",
 			"dev": true,
+			"peer": true,
 			"requires": {
 				"eslint-scope": "^5.1.1",
 				"eslint-visitor-keys": "^2.1.0",
@@ -12348,13 +12351,15 @@
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
 					"integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-					"dev": true
+					"dev": true,
+					"peer": true
 				},
 				"semver": {
 					"version": "6.3.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
 					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-					"dev": true
+					"dev": true,
+					"peer": true
 				}
 			}
 		},
@@ -13695,6 +13700,7 @@
 			"resolved": "https://registry.npmjs.org/@nextcloud/eslint-plugin/-/eslint-plugin-2.0.0.tgz",
 			"integrity": "sha512-j5WXTDTprr/cDilVJtC1mnrpkvD6jlEMShs72V5plllatHjO7kpZHzUfCX3dSvGwYc2ACa0XH+FbkPoZQ3+eWQ==",
 			"dev": true,
+			"peer": true,
 			"requires": {
 				"requireindex": "^1.2.0"
 			}
@@ -19362,7 +19368,8 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
 			"integrity": "sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"resolve": {
 			"version": "1.22.0",

--- a/package.json
+++ b/package.json
@@ -70,13 +70,10 @@
 		"npm": "^7.0.0"
 	},
 	"devDependencies": {
-		"@babel/core": "^7.17.0",
-		"@babel/eslint-parser": "^7.17.0",
 		"@babel/preset-env": "^7.16.11",
 		"@babel/types": "^7.16.7",
 		"@nextcloud/browserslist-config": "^2.2.0",
 		"@nextcloud/eslint-config": "^7.0.2",
-		"@nextcloud/eslint-plugin": "^2.0.0",
 		"@nextcloud/stylelint-config": "^2.1.2",
 		"babel-loader": "^8.2.3",
 		"css-loader": "^6.6.0",


### PR DESCRIPTION
Remove direct devDependencies, which are already loaded as peer dependency from @nextcloud/eslint-config