### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/src/js/components/Activity/ActivityItem.vue
+++ b/src/js/components/Activity/ActivityItem.vue
@@ -58,7 +58,7 @@ export default {
 			const subject = this.activity.subject_rich[0]
 			const parameters = JSON.parse(JSON.stringify(this.activity.subject_rich[1]))
 			if (parameters.after && typeof parameters.after.id === 'string' && parameters.after.id.startsWith('dt:')) {
-				const dateTime = parameters.after.id.substr(3)
+				const dateTime = parameters.after.id.slice(3)
 				parameters.after.name = moment(dateTime).format('L LTS')
 			}
 

--- a/src/js/components/Base/RadioGroupDiv.vue
+++ b/src/js/components/Base/RadioGroupDiv.vue
@@ -36,7 +36,7 @@
 <script>
 import { CheckboxRadioSwitch } from '@nextcloud/vue'
 
-const RandId = () => Math.random().toString(36).replace(/[^a-z]+/g, '').substr(2, 10)
+const RandId = () => Math.random().toString(36).replace(/[^a-z]+/g, '').slice(2, 12)
 
 export default {
 	name: 'RadioGroupDiv',

--- a/src/js/components/Calendar/CalendarInfo.vue
+++ b/src/js/components/Calendar/CalendarInfo.vue
@@ -70,9 +70,9 @@ export default {
 			}
 
 			const hex = this.event.displayColor.replace(/#/, '')
-			const r = parseInt(hex.substr(0, 2), 16)
-			const g = parseInt(hex.substr(2, 2), 16)
-			const b = parseInt(hex.substr(4, 2), 16)
+			const r = parseInt(hex.slice(0, 2), 16)
+			const g = parseInt(hex.slice(2, 4), 16)
+			const b = parseInt(hex.slice(4, 6), 16)
 
 			const l = [
 				0.299 * r,


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.