### PR TITLE
use plain description if config is  'mail_send_plaintext_only' #2306

### DIFF
--- a/lib/Model/Mail/InvitationMail.php
+++ b/lib/Model/Mail/InvitationMail.php
@@ -63,7 +63,7 @@ class InvitationMail extends MailBase {
 			));
 		}
 
-		$this->emailTemplate->addBodyText($this->getRichDescription(), $this->getRichDescription());
+		$this->emailTemplate->addBodyText($this->getRichDescription(), $this->poll->getDescription());
 
 		if ($this->getButtonText() && $this->url) {
 			$this->emailTemplate->addBodyButton($this->getButtonText(), $this->url);


### PR DESCRIPTION
fixes #2306

Add plain poll description for plain text email configuration