### PR TITLE
store personal token for a public poll in a cookie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - Added email addresses for owner's poll export
 - Grouping comments for less noise
 - Bulk import for text polls
+- Save username of a public poll (using cookie)
 - Changed icon set
 - some more design changes
 
@@ -19,6 +20,11 @@ All notable changes to this project will be documented in this file.
 - Fix LDAP user search
 - Dont't add tags to description in plain text invitation mail
 - poll list in admin page should not link to a poll
+
+## [3.6.0-beta2] - tbd
+## New
+- #2261 - Added the option to add links to terms and private policy to public registration dialog
+- #2313 - Translation missing (#2349)
 
 ## [3.6.0-beta1] - 2022-04-02
 ## Changes

--- a/src/js/components/Poll/PublicRegisterModal.vue
+++ b/src/js/components/Poll/PublicRegisterModal.vue
@@ -35,6 +35,9 @@
 							no-submit
 							focus
 							@submit="submitRegistration" />
+						<CheckboxRadioSwitch :checked.sync="saveCookie">
+							{{ t('polls', 'Save username in cookie for 30 days.') }}
+						</CheckboxRadioSwitch>
 					</div>
 
 					<div :class="['status-message', userNameCheck.status]">
@@ -99,7 +102,7 @@ import debounce from 'lodash/debounce'
 import axios from '@nextcloud/axios'
 import { showError } from '@nextcloud/dialogs'
 import { generateUrl } from '@nextcloud/router'
-import { Button as VueButton, Modal } from '@nextcloud/vue'
+import { Button as VueButton, Modal, CheckboxRadioSwitch } from '@nextcloud/vue'
 import { mapState } from 'vuex'
 import RichText from '@juliushaertl/vue-richtext'
 import InputDiv from '../Base/InputDiv'
@@ -109,10 +112,11 @@ export default {
 	name: 'PublicRegisterModal',
 
 	components: {
-		SimpleLink,
+		CheckboxRadioSwitch,
 		InputDiv,
 		Modal,
 		RichText,
+		SimpleLink,
 		VueButton,
 	},
 
@@ -127,6 +131,7 @@ export default {
 			isValidEmailAddress: false,
 			modal: true,
 			modalSize: 'large',
+			saveCookie: true,
 		}
 	},
 
@@ -294,7 +299,7 @@ export default {
 		async submitRegistration() {
 			if (this.registrationIsValid) {
 				try {
-					const response = await this.$store.dispatch('share/register', { userName: this.userName, emailAddress: this.emailAddress })
+					const response = await this.$store.dispatch('share/register', { userName: this.userName, emailAddress: this.emailAddress, saveCookie: this.saveCookie })
 					if (this.$route.params.token === response.token) {
 						this.$store.dispatch({ type: 'poll/get', pollId: this.$route.params.id, token: this.$route.params.token })
 						this.closeModal()

--- a/src/js/components/Poll/PublicRegisterModal.vue
+++ b/src/js/components/Poll/PublicRegisterModal.vue
@@ -36,7 +36,7 @@
 							focus
 							@submit="submitRegistration" />
 						<CheckboxRadioSwitch :checked.sync="saveCookie">
-							{{ t('polls', 'Save username in cookie for 30 days.') }}
+							{{ t('polls', 'Save username in cookie for 30 days') }}
 						</CheckboxRadioSwitch>
 					</div>
 

--- a/src/js/helpers/arrayHelper.js
+++ b/src/js/helpers/arrayHelper.js
@@ -21,15 +21,24 @@
  *
  */
 
-const uniqueArrayOfObjects = function(array) {
-	return [...new Set(array.map((obj) => JSON.stringify(obj)))].map((string) => JSON.parse(string))
-}
+/**
+ * @param {Array} array Array of objects to unify
+ */
+const uniqueArrayOfObjects = (array) =>
+	[...new Set(array.map((obj) => JSON.stringify(obj)))].map((string) => JSON.parse(string))
 
-const uniqueOptions = function(options) {
-	return options.filter((option, index, array) => array.findIndex((compare) => (compare.text === option.text)) === index)
-}
+/**
+ * @param {Array} options Array of poll options to unify
+ */
+const uniqueOptions = (options) =>
+	options.filter((option, index, array) =>
+		array.findIndex((compare) =>
+			(compare.text === option.text)) === index)
 
-const uniqueParticipants = function(votes) {
+/**
+ * @param {Array} votes Array of votes to gerneate a unique array of participants from
+ */
+const uniqueParticipants = (votes) => {
 	const participants = votes.map((vote) => ({
 		userId: vote.user.userId,
 		displayName: vote.user.displayName,

--- a/src/js/helpers/cookieHelper.js
+++ b/src/js/helpers/cookieHelper.js
@@ -1,0 +1,54 @@
+/* jshint esversion: 6 */
+/**
+ * @copyright Copyright (c) 2022 Rene Gieling <github@dartcafe.de>
+ *
+ * @author Rene Gieling <github@dartcafe.de>
+ *
+ * @license  AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * @param {string} cookieName Cookie name
+ * @param {string} cookieValue Cookie value
+ * @param {number} cookieExpiration expiration from now in seconds
+ */
+const setCookie = (cookieName, cookieValue, cookieExpiration) => {
+	const currentTime = new Date()
+	currentTime.setTime(currentTime.getTime() + cookieExpiration)
+	const cookieExpiry = `expires=${currentTime.toUTCString()}`
+	document.cookie = `${cookieName}=${cookieValue};${cookieExpiry};path=/`
+}
+
+/**
+ * @param {string} cookieName Cookie name to read
+ */
+const getCookie = (cookieName) => {
+	const name = `${cookieName}=`
+	const cookiesArray = decodeURIComponent(document.cookie).split(';')
+	for (let i = 0; i < cookiesArray.length; i++) {
+		let cookie = cookiesArray[i]
+		while (cookie.charAt(0) === ' ') {
+			cookie = cookie.substring(1)
+		}
+		if (cookie.indexOf(name) === 0) {
+			return cookie.substring(name.length, cookie.length)
+		}
+	}
+	return ''
+}
+
+export { getCookie, setCookie }

--- a/src/js/helpers/detectColorScheme.js
+++ b/src/js/helpers/detectColorScheme.js
@@ -21,7 +21,7 @@
  *
  */
 
-const detectColorScheme = function() {
+const detectColorScheme = () => {
 	if (!window.matchMedia) {
 		return true
 	}

--- a/src/js/router.js
+++ b/src/js/router.js
@@ -25,6 +25,7 @@ import Router from 'vue-router'
 import axios from '@nextcloud/axios'
 import { getCurrentUser } from '@nextcloud/auth'
 import { generateUrl } from '@nextcloud/router'
+import { getCookie, setCookie } from './helpers/cookieHelper'
 
 // Dynamic loading
 const List = () => import('./views/PollList')
@@ -57,6 +58,9 @@ async function validateToken(to, from, next) {
 		} else {
 			const privateToken = getCookie(to.params.token)
 			if (privateToken) {
+				// extend expiry time for 30 days after successful access
+				const cookieExpiration = (30 * 24 * 60 * 1000)
+				setCookie(to.params.token, privateToken, cookieExpiration)
 				next({ name: 'publicVote', params: { token: privateToken } })
 			} else {
 				next()
@@ -70,25 +74,6 @@ async function validateToken(to, from, next) {
 		}
 
 	}
-}
-
-/**
- * @param {string} token public token as cookie name
- */
-function getCookie(token) {
-	const name = `${token}=`
-	const decodedCookie = decodeURIComponent(document.cookie)
-	const ca = decodedCookie.split(';')
-	for (let i = 0; i < ca.length; i++) {
-		let c = ca[i]
-		while (c.charAt(0) === ' ') {
-			c = c.substring(1)
-		}
-		if (c.indexOf(name) === 0) {
-			return c.substring(name.length, c.length)
-		}
-	}
-	return ''
 }
 
 export default new Router({

--- a/src/js/router.js
+++ b/src/js/router.js
@@ -55,7 +55,12 @@ async function validateToken(to, from, next) {
 			// reroute to the internal vote page, if the user is logged in
 			next({ name: 'vote', params: { id: response.data.share.pollId } })
 		} else {
-			next()
+			const privateToken = getCookie(to.params.token)
+			if (privateToken) {
+				next({ name: 'publicVote', params: { token: privateToken } })
+			} else {
+				next()
+			}
 		}
 	} catch (e) {
 		if (getCurrentUser()) {
@@ -65,6 +70,25 @@ async function validateToken(to, from, next) {
 		}
 
 	}
+}
+
+/**
+ * @param {string} token public token as cookie name
+ */
+function getCookie(token) {
+	const name = `${token}=`
+	const decodedCookie = decodeURIComponent(document.cookie)
+	const ca = decodedCookie.split(';')
+	for (let i = 0; i < ca.length; i++) {
+		let c = ca[i]
+		while (c.charAt(0) === ' ') {
+			c = c.substring(1)
+		}
+		if (c.indexOf(name) === 0) {
+			return c.substring(name.length, c.length)
+		}
+	}
+	return ''
 }
 
 export default new Router({

--- a/src/js/store/modules/share.js
+++ b/src/js/store/modules/share.js
@@ -23,6 +23,7 @@
 
 import axios from '@nextcloud/axios'
 import { generateUrl } from '@nextcloud/router'
+import { setCookie } from '../../helpers/cookieHelper'
 
 const defaultShares = () => ({
 	displayName: '',
@@ -73,13 +74,6 @@ const actions = {
 		}
 	},
 
-	setCookie(context, payload) {
-		const currentTime = new Date()
-		currentTime.setTime(currentTime.getTime() + (30 * 24 * 60 * 1000)) // cookie life time 30 days
-		const cookieExpiry = `expires=${currentTime.toUTCString()}`
-		document.cookie = `${context.rootState.route.params.token}=${payload.privateToken};${cookieExpiry};path=/`
-	},
-
 	async register(context, payload) {
 		if (context.rootState.route.name !== 'publicVote') {
 			return
@@ -94,10 +88,12 @@ const actions = {
 			})
 
 			if (payload.saveCookie) {
-				await context.dispatch('setCookie', { privateToken: response.data.share.token })
+				const cookieExpiration = (30 * 24 * 60 * 1000)
+				setCookie(context.rootState.route.params.token, response.data.share.token, cookieExpiration)
 			}
 
 			return { token: response.data.share.token }
+
 		} catch (e) {
 			console.error('Error writing personal share', { error: e.response }, { payload })
 			throw e

--- a/src/js/store/modules/share.js
+++ b/src/js/store/modules/share.js
@@ -73,6 +73,13 @@ const actions = {
 		}
 	},
 
+	setCookie(context, payload) {
+		const currentTime = new Date()
+		currentTime.setTime(currentTime.getTime() + (30 * 24 * 60 * 1000)) // cookie life time 30 days
+		const cookieExpiry = `expires=${currentTime.toUTCString()}`
+		document.cookie = `${context.rootState.route.params.token}=${payload.privateToken};${cookieExpiry};path=/`
+	},
+
 	async register(context, payload) {
 		if (context.rootState.route.name !== 'publicVote') {
 			return
@@ -85,6 +92,11 @@ const actions = {
 				userName: payload.userName,
 				emailAddress: payload.emailAddress,
 			})
+
+			if (payload.saveCookie) {
+				await context.dispatch('setCookie', { privateToken: response.data.share.token })
+			}
+
 			return { token: response.data.share.token }
 		} catch (e) {
 			console.error('Error writing personal share', { error: e.response }, { payload })


### PR DESCRIPTION
For a better UX a public user can decide, if he wants to keep the private token for a public poll in a cookie.
The cookie expiry is currently set to 30 days and will get renewed after every access.

![grafik](https://user-images.githubusercontent.com/26707476/161421776-b51ec90e-4203-428b-bfc2-c32a0de01e49.png)


- [x] Consider to renew cookie expiry after every access and reduce expiry duration.