### PR TITLE
Fix: addBlulk endpoint no longer requires admin

### DIFF
--- a/lib/Controller/OptionController.php
+++ b/lib/Controller/OptionController.php
@@ -65,7 +65,11 @@ class OptionController extends BaseController {
 	public function add(int $pollId, int $timestamp = 0, string $text = '', int $duration = 0): JSONResponse {
 		return $this->responseCreate(fn () => ['option' => $this->optionService->add($pollId, $timestamp, $text, $duration)]);
 	}
-
+	
+	/**
+	 * Add mulitple new option
+	 * @NoAdminRequired
+	 */
 	public function addBulk(int $pollId, string $text = ''): JSONResponse {
 		return $this->responseCreate(fn () => ['options' => $this->optionService->addBulk($pollId, $text)]);
 	}


### PR DESCRIPTION
Closes #2560 

Tested with NC23.0.8 & PHP 8.0 
This change allowed a non-admin user to use the 'paste option list' feature. 

Signed-off-by: EngelPika32 <41995155+EngelPika32@users.noreply.github.com>