### PR TITLE
Revert "Merge pull request #2585 from nextcloud/enh/hide-projects-2"

### DIFF
--- a/src/js/views/SideBar.vue
+++ b/src/js/views/SideBar.vue
@@ -55,7 +55,7 @@
 			<SideBarTabShare />
 		</AppSidebarTab>
 
-		<AppSidebarTab v-if="projectsEnabled && acl.loggedIn && useCollaboration"
+		<AppSidebarTab v-if="acl.loggedIn && useCollaboration"
 			:id="'collaboration'"
 			:order="4"
 			:name="t('polls', 'Collaboration')">
@@ -91,7 +91,6 @@
 import { AppSidebar, AppSidebarTab } from '@nextcloud/vue'
 import { mapState } from 'vuex'
 import { emit } from '@nextcloud/event-bus'
-import { loadState } from '@nextcloud/initial-state'
 import SidebarConfigurationIcon from 'vue-material-design-icons/Wrench.vue'
 import SidebarOptionsIcon from 'vue-material-design-icons/FormatListChecks.vue'
 import SidebarShareIcon from 'vue-material-design-icons/ShareVariant.vue'
@@ -124,12 +123,6 @@ export default {
 			type: String,
 			default: t('polls', 'Comments').toLowerCase(),
 		},
-	},
-
-	data() {
-		return {
-			projectsEnabled: loadState('core', 'projects_enabled', false),
-		}
 	},
 
 	computed: {


### PR DESCRIPTION
Revert https://github.com/nextcloud/polls/pull/2585 as `master` targets NC24

Handing off to @dartcafe to revert this revert when `master` targets NC25