### PR TITLE
Fixes for Version 3.8.1

### DIFF
--- a/lib/Controller/PublicController.php
+++ b/lib/Controller/PublicController.php
@@ -231,7 +231,7 @@ class PublicController extends BaseController {
 	 */
 	public function setVote(int $optionId, string $setTo, string $token): JSONResponse {
 		return $this->response(fn () => [
-			'vote' => $this->voteService->set($optionId, $setTo, $this->acl->setToken($token, Acl::PERMISSION_COMMENT_ADD))
+			'vote' => $this->voteService->set($optionId, $setTo, $this->acl->setToken($token, Acl::PERMISSION_VOTE_EDIT))
 		], $token);
 	}
 

--- a/lib/Db/Comment.php
+++ b/lib/Db/Comment.php
@@ -77,9 +77,9 @@ class Comment extends Entity implements JsonSerializable {
 	}
 
 	/**
-	 * @return mixed
+	 * @return array
 	 */
-	public function jsonSerialize() {
+	public function jsonSerialize(): array {
 		return [
 			'id' => $this->getId(),
 			'pollId' => $this->getPollId(),

--- a/lib/Db/Log.php
+++ b/lib/Db/Log.php
@@ -82,9 +82,9 @@ class Log extends Entity implements JsonSerializable {
 	}
 
 	/**
-	 * @return mixed
+	 * @return array
 	 */
-	public function jsonSerialize() {
+	public function jsonSerialize(): array {
 		return [
 			'id' => $this->getId(),
 			'pollId' => $this->getPollId(),

--- a/lib/Db/Option.php
+++ b/lib/Db/Option.php
@@ -125,9 +125,9 @@ class Option extends Entity implements JsonSerializable {
 	}
 
 	/**
-	 * @return mixed
+	 * @return array
 	 */
-	public function jsonSerialize() {
+	public function jsonSerialize(): array {
 		return [
 			'id' => $this->getId(),
 			'pollId' => $this->getPollId(),

--- a/lib/Db/Poll.php
+++ b/lib/Db/Poll.php
@@ -191,9 +191,9 @@ class Poll extends Entity implements JsonSerializable {
 	}
 
 	/**
-	 * @return mixed
+	 * @return array
 	 */
-	public function jsonSerialize() {
+	public function jsonSerialize(): array {
 		return [
 			'id' => $this->getId(),
 			'type' => $this->getType(),

--- a/lib/Db/Preferences.php
+++ b/lib/Db/Preferences.php
@@ -75,9 +75,9 @@ class Preferences extends Entity implements JsonSerializable {
 	}
 
 	/**
-	 * @return mixed
+	 * @return array
 	 */
-	public function jsonSerialize() {
+	public function jsonSerialize(): array {
 		return [
 			'id' => $this->getId(),
 			'userId' => $this->getUserId(),

--- a/lib/Db/Share.php
+++ b/lib/Db/Share.php
@@ -133,9 +133,9 @@ class Share extends Entity implements JsonSerializable {
 	}
 
 	/**
-	 * @return mixed
+	 * @return array
 	 */
-	public function jsonSerialize() {
+	public function jsonSerialize(): array {
 		return [
 			'id' => $this->getId(),
 			'token' => $this->getToken(),

--- a/lib/Db/Subscription.php
+++ b/lib/Db/Subscription.php
@@ -52,9 +52,9 @@ class Subscription extends Entity implements JsonSerializable {
 	}
 
 	/**
-	 * @return mixed
+	 * @return array
 	 */
-	public function jsonSerialize() {
+	public function jsonSerialize(): array {
 		return [
 			'id' => $this->getId(),
 			'pollId' => $this->getPollId(),

--- a/lib/Db/Vote.php
+++ b/lib/Db/Vote.php
@@ -77,9 +77,9 @@ class Vote extends Entity implements JsonSerializable {
 	}
 
 	/**
-	 * @return mixed
+	 * @return array
 	 */
-	public function jsonSerialize() {
+	public function jsonSerialize(): array {
 		return [
 			'id' => $this->getId(),
 			'pollId' => $this->getPollId(),

--- a/lib/Db/Watch.php
+++ b/lib/Db/Watch.php
@@ -60,9 +60,9 @@ class Watch extends Entity implements JsonSerializable {
 	}
 
 	/**
-	 * @return mixed
+	 * @return array
 	 */
-	public function jsonSerialize() {
+	public function jsonSerialize(): array {
 		return [
 			'id' => $this->getId(),
 			'pollId' => $this->getPollId(),

--- a/lib/Model/Settings/AppSettings.php
+++ b/lib/Model/Settings/AppSettings.php
@@ -169,9 +169,9 @@ class AppSettings implements JsonSerializable {
 	}
 
 	/**
-	 * @return mixed
+	 * @return array
 	 */
-	public function jsonSerialize() {
+	public function jsonSerialize(): array {
 		// convert group ids to group objects
 		$publicSharesGroups = [];
 		$comboGroups = [];


### PR DESCRIPTION
* surpress error logs with PHP 8.1 by changing return type of `jsonSerialize()` to `: array`
`Error: Return type of [...]::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice at [...]`
* fix permission on voting in public polls, whan comments are disabled

fix #2600