### PR TITLE
Change handling of objects which refer to deleted shares

### DIFF
--- a/lib/Db/Comment.php
+++ b/lib/Db/Comment.php
@@ -26,11 +26,6 @@
 namespace OCA\Polls\Db;
 
 use JsonSerializable;
-use OCA\Polls\Exceptions\ShareNotFoundException;
-use OCA\Polls\Helper\Container;
-use OCP\IUser;
-use OCP\IUserManager;
-use OCP\AppFramework\Db\Entity;
 
 /**
  * @method int getId()
@@ -55,9 +50,6 @@ class Comment extends EntityWithUser implements JsonSerializable {
 
 	/** @var string $userId */
 	protected $userId = '';
-
-	/** @var string $publicUserId */
-	protected $publicUserId = '';
 
 	/** @var int $timestamp */
 	protected $timestamp = 0;

--- a/lib/Db/Comment.php
+++ b/lib/Db/Comment.php
@@ -26,12 +26,11 @@
 namespace OCA\Polls\Db;
 
 use JsonSerializable;
-
+use OCA\Polls\Exceptions\ShareNotFoundException;
 use OCA\Polls\Helper\Container;
 use OCP\IUser;
 use OCP\IUserManager;
 use OCP\AppFramework\Db\Entity;
-use OCP\AppFramework\Db\DoesNotExistException;
 
 /**
  * @method int getId()
@@ -56,6 +55,9 @@ class Comment extends Entity implements JsonSerializable {
 
 	/** @var string $userId */
 	protected $userId = '';
+
+	/** @var string $publicUserId */
+	protected $publicUserId = '';
 
 	/** @var int $timestamp */
 	protected $timestamp = 0;
@@ -103,30 +105,44 @@ class Comment extends Entity implements JsonSerializable {
 	}
 
 	public function getDisplayName(): string {
-		if (!strncmp($this->userId, 'deleted_', 8)) {
-			return 'Deleted User';
-		}
-
 		if ($this->getIsNoUser()) {
 			// get displayName from share
 			try {
-				$share = $this->shareMapper->findByPollAndUser($this->getPollId(), $this->userId);
-				return $share->getDisplayName();
-			} catch (DoesNotExistException $e) {
-				return $this->userId;
+				$share = $this->shareMapper->findByPollAndUser($this->getPollId(), $this->getUserId());
+			} catch (ShareNotFoundException $e) {
+				// use fake share
+				$share = $e->getReplacement();
 			}
+			return $share->getDisplayName();
 		}
-		return $this->userManager->get($this->userId)->getDisplayName();
+
+		return $this->userManager->get($this->getUserId())->getDisplayName();
+	}
+
+	private function getPublicUserId() {
+		if (!$this->getUserId()) {
+			return '';
+		}
+
+		if ($this->publicUserId) {
+			return $this->publicUserId;
+		}
+
+		return $this->getUserId();
+	}
+	
+	public function generateHashedUserId() {
+		$this->publicUserId = hash('md5', $this->getUserId());
 	}
 
 	public function getUser(): array {
 		return [
-			'userId' => $this->getUserId(),
+			'userId' => $this->getPublicUserId(),
 			'displayName' => $this->getDisplayName(),
 			'isNoUser' => $this->getIsNoUser(),
 		];
 	}
 	public function getIsNoUser(): bool {
-		return !($this->userManager->get($this->userId) instanceof IUser);
+		return !($this->userManager->get($this->getUserId()) instanceof IUser);
 	}
 }

--- a/lib/Db/EntityWithUser.php
+++ b/lib/Db/EntityWithUser.php
@@ -35,7 +35,6 @@ use OCP\IUserManager;
  */
 
 abstract class EntityWithUser extends Entity {
-
 	/** @var string $publicUserId */
 	protected $publicUserId = '';
 

--- a/lib/Db/EntityWithUser.php
+++ b/lib/Db/EntityWithUser.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * @copyright Copyright (c) 2017 Kai Schröer <git@schroeer.co>
+ *
+ * @author Kai Schröer <git@schroeer.co>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Polls\Db;
+
+use OCA\Polls\Exceptions\ShareNotFoundException;
+use OCA\Polls\Helper\Container;
+use OCP\AppFramework\Db\Entity;
+use OCP\IUser;
+use OCP\IUserManager;
+
+/**
+ * @method string getUserId()
+ * @method void setUserId(string $value)
+ */
+
+abstract class EntityWithUser extends Entity {
+
+	public function getIsNoUser(): bool {
+		return !(Container::queryClass(IUserManager::class)->get($this->getUserId()) instanceof IUser);
+	}
+
+	public function getDisplayName(): string {
+		if (!$this->getUserId()) {
+			return '';
+		}
+		if ($this->getIsNoUser()) {
+			// get displayName from share
+			try {
+				$share = Container::queryClass(ShareMapper::class)->findByPollAndUser($this->getPollId(), $this->getUserId());
+			} catch (ShareNotFoundException $e) {
+				// use fake share
+				$share = $e->getReplacement();
+			}
+			return $share->getDisplayName();
+		}
+
+		return Container::queryClass(IUserManager::class)->get($this->getUserId())->getDisplayName();
+	}
+
+	private function getPublicUserId() {
+		if (!$this->getUserId()) {
+			return '';
+		}
+
+		if ($this->publicUserId) {
+			return $this->publicUserId;
+		}
+
+		return $this->getUserId();
+	}
+
+	public function generateHashedUserId() {
+		$this->publicUserId = hash('md5', $this->getUserId());
+	}
+
+	public function getUser(): array {
+		return [
+			'userId' => $this->getPublicUserId(),
+			'displayName' => $this->getDisplayName(),
+			'isNoUser' => $this->getIsNoUser(),
+		];
+	}
+}

--- a/lib/Db/EntityWithUser.php
+++ b/lib/Db/EntityWithUser.php
@@ -31,10 +31,13 @@ use OCP\IUserManager;
 
 /**
  * @method string getUserId()
- * @method void setUserId(string $value)
+ * @method int getPollId()
  */
 
 abstract class EntityWithUser extends Entity {
+
+	/** @var string $publicUserId */
+	protected $publicUserId = '';
 
 	public function getIsNoUser(): bool {
 		return !(Container::queryClass(IUserManager::class)->get($this->getUserId()) instanceof IUser);
@@ -58,7 +61,7 @@ abstract class EntityWithUser extends Entity {
 		return Container::queryClass(IUserManager::class)->get($this->getUserId())->getDisplayName();
 	}
 
-	private function getPublicUserId() {
+	private function getPublicUserId(): string {
 		if (!$this->getUserId()) {
 			return '';
 		}
@@ -70,7 +73,7 @@ abstract class EntityWithUser extends Entity {
 		return $this->getUserId();
 	}
 
-	public function generateHashedUserId() {
+	public function generateHashedUserId(): void {
 		$this->publicUserId = hash('md5', $this->getUserId());
 	}
 

--- a/lib/Db/EntityWithUser.php
+++ b/lib/Db/EntityWithUser.php
@@ -51,8 +51,8 @@ abstract class EntityWithUser extends Entity {
 			try {
 				$share = Container::queryClass(ShareMapper::class)->findByPollAndUser($this->getPollId(), $this->getUserId());
 			} catch (ShareNotFoundException $e) {
-				// use fake share
-				$share = $e->getReplacement();
+				// User seems to be probaly deleted, use fake share
+				$share = Container::queryClass(ShareMapper::class)->getReplacement($this->getPollId(), $this->getUserId());
 			}
 			return $share->getDisplayName();
 		}

--- a/lib/Db/IEntityWithUser.php
+++ b/lib/Db/IEntityWithUser.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * @copyright Copyright (c) 2017 Kai Schröer <git@schroeer.co>
+ *
+ * @author Kai Schröer <git@schroeer.co>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Polls\Db;
+
+Interface IEntityWithUser {
+
+	/**
+	 * Is this object'suser or owner an internal user or external
+	 */
+	public function getUserId(): string;
+
+	/**
+	 * Returns the displayname of this object's user or owner
+	 */
+	public function getDisplayName(): string;
+
+	/**
+	 * Creates a hashed version of the userId
+	 */
+	public function generateHashedUserId(): void;
+
+	/**
+	 * Returns an array with user attributes for jsonSerialize()
+	 */
+	public function getUser(): array;
+}

--- a/lib/Db/IEntityWithUser.php
+++ b/lib/Db/IEntityWithUser.php
@@ -23,8 +23,7 @@
 
 namespace OCA\Polls\Db;
 
-Interface IEntityWithUser {
-
+interface IEntityWithUser {
 	/**
 	 * Is this object'suser or owner an internal user or external
 	 */

--- a/lib/Db/Option.php
+++ b/lib/Db/Option.php
@@ -175,9 +175,6 @@ class Option extends EntityWithUser implements JsonSerializable {
 		$this->setOwner($userId);
 	}
 
-	/**
-	 * @return false|int|string
-	 */
 	public function getDateStringLocalized(DateTimeZone $timeZone, IL10N $l10n) {
 		$mutableFrom = DateTime::createFromImmutable($this->getDateObjectFrom($timeZone));
 		$mutableTo = DateTime::createFromImmutable($this->getDateObjectTo($timeZone));

--- a/lib/Db/Option.php
+++ b/lib/Db/Option.php
@@ -61,9 +61,6 @@ class Option extends EntityWithUser implements JsonSerializable {
 	/** @var string $owner */
 	protected $owner;
 
-	/** @var string $publicUserId */
-	protected $publicUserId = '';
-
 	/** @var int $released */
 	protected $released;
 
@@ -178,6 +175,9 @@ class Option extends EntityWithUser implements JsonSerializable {
 		$this->setOwner($userId);
 	}
 
+	/**
+	 * @return false|int|string
+	 */
 	public function getDateStringLocalized(DateTimeZone $timeZone, IL10N $l10n) {
 		$mutableFrom = DateTime::createFromImmutable($this->getDateObjectFrom($timeZone));
 		$mutableTo = DateTime::createFromImmutable($this->getDateObjectTo($timeZone));

--- a/lib/Db/Poll.php
+++ b/lib/Db/Poll.php
@@ -27,11 +27,7 @@ namespace OCA\Polls\Db;
 
 use JsonSerializable;
 use OCA\Polls\Exceptions\NoDeadLineException;
-use OCA\Polls\Exceptions\ShareNotFoundException;
 use OCA\Polls\Helper\Container;
-use OCP\AppFramework\Db\Entity;
-use OCP\IUser;
-use OCP\IUserManager;
 use OCP\IURLGenerator;
 
 /**
@@ -112,9 +108,6 @@ class Poll extends EntityWithUser implements JsonSerializable {
 	/** @var string $owner */
 	protected $owner;
 
-	/** @var string $publicUserId */
-	protected $publicUserId = '';
-
 	/** @var int $created */
 	protected $created;
 
@@ -169,12 +162,6 @@ class Poll extends EntityWithUser implements JsonSerializable {
 	/** @var IURLGenerator */
 	private $urlGenerator;
 
-	// /** @var IUserManager */
-	// private $userManager;
-
-	// /** @var ShareMapper */
-	// private $shareMapper;
-
 	/** @var OptionMapper */
 	private $optionMapper;
 
@@ -192,10 +179,8 @@ class Poll extends EntityWithUser implements JsonSerializable {
 		$this->addType('important', 'int');
 		$this->addType('hideBookedUp', 'int');
 		$this->addType('useNo', 'int');
-		// $this->shareMapper = Container::queryClass(ShareMapper::class);
 		$this->optionMapper = Container::queryClass(OptionMapper::class);
 		$this->urlGenerator = Container::queryClass(IURLGenerator::class);
-		// $this->userManager = Container::queryClass(IUserManager::class);
 	}
 
 	/**
@@ -383,47 +368,4 @@ class Poll extends EntityWithUser implements JsonSerializable {
 		$miscSettings[$key] = $value;
 		$this->setMiscSettingsArray($miscSettings);
 	}
-
-	// public function getIsNoUser(): bool {
-	// 	return !($this->userManager->get($this->getUserId()) instanceof IUser);
-	// }
-
-	// public function getDisplayName(): string {
-	// 	if ($this->getIsNoUser()) {
-	// 		// get displayName from share
-	// 		try {
-	// 			$share = $this->shareMapper->findByPollAndUser($this->getPollId(), $this->getUserId());
-	// 		} catch (ShareNotFoundException $e) {
-	// 			// use fake share
-	// 			$share = $e->getReplacement();
-	// 		}
-	// 		return $share->getDisplayName();
-	// 	}
-
-	// 	return $this->userManager->get($this->getUserId())->getDisplayName();
-	// }
-
-	// private function getPublicUserId() {
-	// 	if (!$this->getUserId()) {
-	// 		return '';
-	// 	}
-
-	// 	if ($this->publicUserId) {
-	// 		return $this->publicUserId;
-	// 	}
-
-	// 	return $this->getUserId();
-	// }
-
-	// public function generateHashedUserId() {
-	// 	$this->publicUserId = hash('md5', $this->getUserId());
-	// }
-
-	// public function getUser(): array {
-	// 	return [
-	// 		'userId' => $this->getPublicUserId(),
-	// 		'displayName' => $this->getDisplayName(),
-	// 		'isNoUser' => $this->getIsNoUser(),
-	// 	];
-	// }
 }

--- a/lib/Db/Share.php
+++ b/lib/Db/Share.php
@@ -221,8 +221,12 @@ class Share extends Entity implements JsonSerializable {
 		$this->setMiscSettings(json_encode($value));
 	}
 
-	private function getMiscSettingsArray() : ?array {
-		return json_decode($this->getMiscSettings(), true);
+	private function getMiscSettingsArray() : array {
+		if ($this->getMiscSettings()) {
+			return json_decode($this->getMiscSettings(), true);
+		}
+		
+		return [];
 	}
 
 	/**

--- a/lib/Db/ShareMapper.php
+++ b/lib/Db/ShareMapper.php
@@ -104,10 +104,9 @@ class ShareMapper extends QBMapper {
 		   	$qb->expr()->eq('user_id', $qb->createNamedParameter($userId, IQueryBuilder::PARAM_STR))
 		   );
 
-	   try {
+		try {
 			return $this->findEntity($qb);
 		} catch (DoesNotExistException $e) {
-			// \OC::$server->getLogger()->error('foundByPollAndUser: ' . $userId);
 			throw new ShareNotFoundException("Share not found by userId and pollId", $userId, $pollId);
 		}
 	}
@@ -131,11 +130,10 @@ class ShareMapper extends QBMapper {
 			// Check, if token is a fake token
 			if ($exploded[1] === 'deleted' && $exploded[1] === 'share') {
 				$userId = $exploded[2];
-				$pollId = $exploded[3];
+				$pollId = intval($exploded[3]);
 			}
 			throw new ShareNotFoundException('Token ' . $token . ' does not exist', $userId, $pollId, $token);
 		}
-
 	}
 
 	public function deleteByPoll(int $pollId): void {

--- a/lib/Db/Vote.php
+++ b/lib/Db/Vote.php
@@ -44,7 +44,7 @@ use OCP\AppFramework\Db\Entity;
  * @method string getVoteAnswer()
  * @method void setVoteAnswer(string $value)
  */
-class Vote extends Entity implements JsonSerializable {
+class Vote extends EntityWithUser implements JsonSerializable {
 	public const TABLE = 'polls_votes';
 
 	/** @var int $pollId */
@@ -65,18 +65,18 @@ class Vote extends Entity implements JsonSerializable {
 	/** @var string $voteAnswer */
 	protected $voteAnswer;
 
-	/** @var IUserManager */
-	private $userManager;
+	// /** @var IUserManager */
+	// private $userManager;
 
-	/** @var ShareMapper */
-	private $shareMapper;
+	// /** @var ShareMapper */
+	// private $shareMapper;
 
 	public function __construct() {
 		$this->addType('id', 'int');
 		$this->addType('pollId', 'int');
 		$this->addType('voteOptionId', 'int');
-		$this->userManager = Container::queryClass(IUserManager::class);
-		$this->shareMapper = Container::queryClass(ShareMapper::class);
+		// $this->userManager = Container::queryClass(IUserManager::class);
+		// $this->shareMapper = Container::queryClass(ShareMapper::class);
 	}
 
 	/**
@@ -88,48 +88,51 @@ class Vote extends Entity implements JsonSerializable {
 			'pollId' => $this->getPollId(),
 			'optionText' => $this->getVoteOptionText(),
 			'answer' => $this->getVoteAnswer(),
-			'user' => [
-				'userId' => $this->getPublicUserId(),
-				'displayName' => $this->getDisplayName(),
-				'isNoUser' => $this->getIsNoUser()
-			],
+			'user' => $this->getUser(),
 		];
 	}
 
-	public function getDisplayName(): string {
-		if ($this->getIsNoUser()) {
-			// get displayName from share
-			try {
-				$share = $this->shareMapper->findByPollAndUser($this->getPollId(), $this->userId);
-			} catch (ShareNotFoundException $e) {
-				// use fake share
-				$share = $e->getReplacement();
-			}
-			return $share->getDisplayName();
-		}
+	// public function getIsNoUser(): bool {
+	// 	return !($this->userManager->get($this->userId) instanceof IUser);
+	// }
 
-		return $this->userManager->get($this->userId)->getDisplayName();
-	}
+	// public function getDisplayName(): string {
+	// 	if ($this->getIsNoUser()) {
+	// 		// get displayName from share
+	// 		try {
+	// 			$share = $this->shareMapper->findByPollAndUser($this->getPollId(), $this->userId);
+	// 		} catch (ShareNotFoundException $e) {
+	// 			// use fake share
+	// 			$share = $e->getReplacement();
+	// 		}
+	// 		return $share->getDisplayName();
+	// 	}
 
-	public function getIsNoUser(): bool {
-		return !($this->userManager->get($this->userId) instanceof IUser);
-	}
+	// 	return $this->userManager->get($this->userId)->getDisplayName();
+	// }
 
-	private function getPublicUserId() {
-		if (!$this->getUserId()) {
-			return '';
-		}
+	// private function getPublicUserId() {
+	// 	if (!$this->getUserId()) {
+	// 		return '';
+	// 	}
 
-		if ($this->publicUserId) {
-			return $this->publicUserId;
-		}
+	// 	if ($this->publicUserId) {
+	// 		return $this->publicUserId;
+	// 	}
 
-		return $this->getUserId();
-	}
+	// 	return $this->getUserId();
+	// }
 
-	public function generateHashedUserId() {
-		$this->publicUserId = hash('md5', $this->getUserId());
-	}
+	// public function generateHashedUserId() {
+	// 	$this->publicUserId = hash('md5', $this->getUserId());
+	// }
 
+	// public function getUser(): array {
+	// 	return [
+	// 		'userId' => $this->getPublicUserId(),
+	// 		'displayName' => $this->getDisplayName(),
+	// 		'isNoUser' => $this->getIsNoUser(),
+	// 	];
+	// }
 }
 

--- a/lib/Db/Vote.php
+++ b/lib/Db/Vote.php
@@ -26,11 +26,6 @@
 namespace OCA\Polls\Db;
 
 use JsonSerializable;
-use OCA\Polls\Exceptions\ShareNotFoundException;
-use OCA\Polls\Helper\Container;
-use OCP\IUser;
-use OCP\IUserManager;
-use OCP\AppFramework\Db\Entity;
 
 /**
  * @method int getPollId()
@@ -53,9 +48,6 @@ class Vote extends EntityWithUser implements JsonSerializable {
 	/** @var string $userId */
 	protected $userId;
 
-	/** @var string $publicUserId */
-	protected $publicUserId = '';
-
 	/** @var int $voteOptionId */
 	protected $voteOptionId;
 
@@ -65,18 +57,10 @@ class Vote extends EntityWithUser implements JsonSerializable {
 	/** @var string $voteAnswer */
 	protected $voteAnswer;
 
-	// /** @var IUserManager */
-	// private $userManager;
-
-	// /** @var ShareMapper */
-	// private $shareMapper;
-
 	public function __construct() {
 		$this->addType('id', 'int');
 		$this->addType('pollId', 'int');
 		$this->addType('voteOptionId', 'int');
-		// $this->userManager = Container::queryClass(IUserManager::class);
-		// $this->shareMapper = Container::queryClass(ShareMapper::class);
 	}
 
 	/**
@@ -91,48 +75,4 @@ class Vote extends EntityWithUser implements JsonSerializable {
 			'user' => $this->getUser(),
 		];
 	}
-
-	// public function getIsNoUser(): bool {
-	// 	return !($this->userManager->get($this->userId) instanceof IUser);
-	// }
-
-	// public function getDisplayName(): string {
-	// 	if ($this->getIsNoUser()) {
-	// 		// get displayName from share
-	// 		try {
-	// 			$share = $this->shareMapper->findByPollAndUser($this->getPollId(), $this->userId);
-	// 		} catch (ShareNotFoundException $e) {
-	// 			// use fake share
-	// 			$share = $e->getReplacement();
-	// 		}
-	// 		return $share->getDisplayName();
-	// 	}
-
-	// 	return $this->userManager->get($this->userId)->getDisplayName();
-	// }
-
-	// private function getPublicUserId() {
-	// 	if (!$this->getUserId()) {
-	// 		return '';
-	// 	}
-
-	// 	if ($this->publicUserId) {
-	// 		return $this->publicUserId;
-	// 	}
-
-	// 	return $this->getUserId();
-	// }
-
-	// public function generateHashedUserId() {
-	// 	$this->publicUserId = hash('md5', $this->getUserId());
-	// }
-
-	// public function getUser(): array {
-	// 	return [
-	// 		'userId' => $this->getPublicUserId(),
-	// 		'displayName' => $this->getDisplayName(),
-	// 		'isNoUser' => $this->getIsNoUser(),
-	// 	];
-	// }
 }
-

--- a/lib/Exceptions/ShareNotFoundException.php
+++ b/lib/Exceptions/ShareNotFoundException.php
@@ -25,7 +25,6 @@ namespace OCA\Polls\Exceptions;
 
 use OCA\Polls\Db\Share;
 use OCA\Polls\Model\UserBase;
-use OCP\AppFramework\Http;
 
 class ShareNotFoundException extends NotFoundException {
 	/** @var int $pollId */
@@ -65,5 +64,4 @@ class ShareNotFoundException extends NotFoundException {
 		$share->setDisplayName('Deleted User');
 		return $share;
 	}
-
 }

--- a/lib/Exceptions/ShareNotFoundException.php
+++ b/lib/Exceptions/ShareNotFoundException.php
@@ -23,9 +23,6 @@
 
 namespace OCA\Polls\Exceptions;
 
-use OCA\Polls\Db\Share;
-use OCA\Polls\Model\UserBase;
-
 class ShareNotFoundException extends NotFoundException {
 	public function __construct(
 		string $e = 'Share not found'

--- a/lib/Exceptions/ShareNotFoundException.php
+++ b/lib/Exceptions/ShareNotFoundException.php
@@ -27,41 +27,9 @@ use OCA\Polls\Db\Share;
 use OCA\Polls\Model\UserBase;
 
 class ShareNotFoundException extends NotFoundException {
-	/** @var int $pollId */
-	protected $pollId = 0;
-
-	/** @var string $userId */
-	protected $userId = '';
-
-	/** @var string $token */
-	protected $token = '';
-
 	public function __construct(
-		string $e = 'Share not found',
-		string $userId = '',
-		int $pollId = 0,
-		string $token = ''
+		string $e = 'Share not found'
 	) {
 		parent::__construct($e);
-		$this->userId = $userId;
-		$this->pollId = $pollId;
-		$this->token = $token;
-	}
-
-	/**
-	 * Returns a fake share in case of deleted shares
-	 */
-	public function getReplacement(): ?Share {
-		if (!$this->userId) {
-			return null;
-		}
-
-		$share = new Share;
-		$share->setUserId($this->userId);
-		$share->setPollId($this->pollId);
-		$share->setType(UserBase::TYPE_EXTERNAL);
-		$share->setToken('deleted_share_' . $this->userId . '_' . $this->pollId);
-		$share->setDisplayName('Deleted User');
-		return $share;
 	}
 }

--- a/lib/Exceptions/ShareNotFoundException.php
+++ b/lib/Exceptions/ShareNotFoundException.php
@@ -23,12 +23,47 @@
 
 namespace OCA\Polls\Exceptions;
 
+use OCA\Polls\Db\Share;
+use OCA\Polls\Model\UserBase;
 use OCP\AppFramework\Http;
 
-class NotFoundException extends Exception {
+class ShareNotFoundException extends NotFoundException {
+	/** @var int $pollId */
+	protected $pollId = 0;
+
+	/** @var string $userId */
+	protected $userId = '';
+
+	/** @var string $token */
+	protected $token = '';
+
 	public function __construct(
-		string $e = 'Not found'
+		string $e = 'Share not found',
+		string $userId = '',
+		int $pollId = 0,
+		string $token = ''
 	) {
-		parent::__construct($e, Http::STATUS_NOT_FOUND);
+		parent::__construct($e);
+		$this->userId = $userId;
+		$this->pollId = $pollId;
+		$this->token = $token;
 	}
+
+	/**
+	 * Returns a fake share in case of deleted shares
+	 */
+	public function getReplacement(): ?Share {
+		if (!$this->userId) {
+			return null;
+		}
+
+		$share = new Share;
+		$share->setUserId($this->userId);
+		$share->setPollId($this->pollId);
+		$share->setType(UserBase::TYPE_EXTERNAL);
+		$share->setToken('deleted_share_' . $this->userId . '_' . $this->pollId);
+		$share->setDisplayName('Deleted User');
+		return $share;
+	}
+
 }

--- a/lib/Model/Acl.php
+++ b/lib/Model/Acl.php
@@ -33,6 +33,7 @@ use OCA\Polls\Db\OptionMapper;
 use OCA\Polls\Db\PollMapper;
 use OCA\Polls\Db\VoteMapper;
 use OCA\Polls\Db\ShareMapper;
+use OCA\Polls\Exceptions\ShareNotFoundException;
 use OCP\IUserManager;
 use OCP\IUserSession;
 use OCP\IGroupManager;
@@ -130,7 +131,7 @@ class Acl implements JsonSerializable {
 			$this->poll = $this->pollMapper->find($this->share->getPollId());
 			$this->validateShareAccess();
 			$this->request($permission);
-		} catch (DoesNotExistException $e) {
+		} catch (ShareNotFoundException $e) {
 			throw new NotAuthorizedException('Error loading share ' . $token);
 		}
 

--- a/lib/Model/Mail/NotificationMail.php
+++ b/lib/Model/Mail/NotificationMail.php
@@ -108,6 +108,6 @@ class NotificationMail extends MailBase {
 			VoteEvent::SET => $this->l10n->t('%s has voted.', [$displayName]),
 		];
 
-		return $logStrings[$logItem->getMessageId()] ?? $logItem->getMessageId() . " (" . $displayName . ")";
+		return $logStrings[$logItem->getMessageId()] ?? $logItem->getMessageId() . ' (' . $displayName . ')';
 	}
 }

--- a/lib/Provider/ActivityProvider.php
+++ b/lib/Provider/ActivityProvider.php
@@ -34,6 +34,7 @@ use OCP\Activity\IEventMerger;
 use OCP\Activity\IEvent;
 use OCA\Polls\Service\ActivityService;
 use OCA\Polls\Db\ShareMapper;
+use OCA\Polls\Exceptions\ShareNotFoundException;
 
 class ActivityProvider implements IProvider {
 	/** @var IFactory */
@@ -110,7 +111,11 @@ class ActivityProvider implements IProvider {
 					'name' => $actor->getDisplayName(),
 				];
 			} else {
-				$share = $this->shareMapper->findByPollAndUser($event->getObjectId(), $event->getAuthor());
+				try {
+					$share = $this->shareMapper->findByPollAndUser($event->getObjectId(), $event->getAuthor());
+				} catch (ShareNotFoundException $e) {
+					$share = $e->getReplacement();
+				}
 				$parameters['actor'] = [
 					'type' => 'guest',
 					'id' => $share->getUserId(),

--- a/lib/Provider/ActivityProvider.php
+++ b/lib/Provider/ActivityProvider.php
@@ -114,7 +114,8 @@ class ActivityProvider implements IProvider {
 				try {
 					$share = $this->shareMapper->findByPollAndUser($event->getObjectId(), $event->getAuthor());
 				} catch (ShareNotFoundException $e) {
-					$share = $e->getReplacement();
+					// User seems to be probaly deleted, use fake share
+					$share = $this->shareMapper->getReplacement($event->getObjectId(), $event->getAuthor());
 				}
 				$parameters['actor'] = [
 					'type' => 'guest',

--- a/lib/Service/AnonymizeService.php
+++ b/lib/Service/AnonymizeService.php
@@ -28,7 +28,6 @@ use OCA\Polls\Db\Vote;
 use OCA\Polls\Db\VoteMapper;
 use OCA\Polls\Db\Comment;
 use OCA\Polls\Db\CommentMapper;
-use OCA\Polls\Db\Option;
 use OCA\Polls\Db\OptionMapper;
 use OCA\Polls\Db\Poll;
 
@@ -114,6 +113,10 @@ class AnonymizeService {
 
 	/**
 	 * Replaces userIds with displayName to avoid exposing usernames in public polls
+	 *
+	 * @param (Comment|Vote|\OCA\Polls\Db\Option)[]|Poll $arrayOrObject
+	 *
+	 * @psalm-param Poll|array<Comment|Vote|\OCA\Polls\Db\Option> $arrayOrObject
 	 */
 	public static function replaceUserId(&$arrayOrObject, string $userId) : void {
 		if (is_array($arrayOrObject)) {

--- a/lib/Service/AnonymizeService.php
+++ b/lib/Service/AnonymizeService.php
@@ -111,13 +111,6 @@ class AnonymizeService {
 		return;
 	}
 
-	/**
-	 * Replaces userIds with displayName to avoid exposing usernames in public polls
-	 *
-	 * @param (Comment|Vote|\OCA\Polls\Db\Option)[]|Poll $arrayOrObject
-	 *
-	 * @psalm-param Poll|array<Comment|Vote|\OCA\Polls\Db\Option> $arrayOrObject
-	 */
 	public static function replaceUserId(&$arrayOrObject, string $userId) : void {
 		if (is_array($arrayOrObject)) {
 			foreach ($arrayOrObject as $item) {

--- a/lib/Service/AnonymizeService.php
+++ b/lib/Service/AnonymizeService.php
@@ -121,12 +121,7 @@ class AnonymizeService {
 				if ($item->getUserId() === $userId) {
 					continue;
 				}
-				if ($item instanceof Comment || $item instanceof Vote) {
-					$item->setUserId($item->getDisplayName());
-				}
-				if ($item instanceof Option || $item instanceof Poll) {
-					$item->setOwner($item->getDisplayName());
-				}
+				$item->generateHashedUserId();
 			}
 			return;
 		}
@@ -135,13 +130,7 @@ class AnonymizeService {
 			return;
 		}
 
-		if ($arrayOrObject instanceof Option || $arrayOrObject instanceof Poll) {
-			$arrayOrObject->setOwner($arrayOrObject->getDisplayName());
-		}
-
-		if ($arrayOrObject instanceof Comment || $arrayOrObject instanceof Vote) {
-			$arrayOrObject->setUserId($arrayOrObject->getDisplayName());
-		}
+		$arrayOrObject->generateHashedUserId();
 
 		return;
 	}

--- a/lib/Service/PollService.php
+++ b/lib/Service/PollService.php
@@ -208,8 +208,12 @@ class PollService {
 
 	/**
 	 * get poll configuration
+	 *
+	 * @return (\OCA\Polls\Db\Comment|\OCA\Polls\Db\Option|\OCA\Polls\Db\Vote)[]|Poll
+	 *
+	 * @psalm-return Poll|array<\OCA\Polls\Db\Comment|\OCA\Polls\Db\Option|\OCA\Polls\Db\Vote>
 	 */
-	public function get(int $pollId) : Poll {
+	public function get(int $pollId)  {
 		$this->acl->setPollId($pollId);
 		$this->poll = $this->pollMapper->find($pollId);
 

--- a/lib/Service/PollService.php
+++ b/lib/Service/PollService.php
@@ -213,7 +213,7 @@ class PollService {
 	 *
 	 * @psalm-return Poll|array<\OCA\Polls\Db\Comment|\OCA\Polls\Db\Option|\OCA\Polls\Db\Vote>
 	 */
-	public function get(int $pollId)  {
+	public function get(int $pollId) {
 		$this->acl->setPollId($pollId);
 		$this->poll = $this->pollMapper->find($pollId);
 

--- a/lib/Service/ShareService.php
+++ b/lib/Service/ShareService.php
@@ -37,6 +37,7 @@ use OCA\Polls\Exceptions\InvalidShareTypeException;
 use OCA\Polls\Exceptions\ShareAlreadyExistsException;
 use OCA\Polls\Exceptions\NotFoundException;
 use OCA\Polls\Exceptions\InvalidUsernameException;
+use OCA\Polls\Exceptions\ShareNotFoundException;
 use OCA\Polls\Model\Acl;
 use OCA\Polls\Model\UserBase;
 use OCP\AppFramework\Db\DoesNotExistException;
@@ -144,13 +145,9 @@ class ShareService {
 	 * Get share by token for accessing the poll
 	 */
 	public function get(string $token, bool $validateShareType = false): Share {
-		try {
-			$this->share = $this->shareMapper->findByToken($token);
-			if ($validateShareType) {
-				$this->validateShareType();
-			}
-		} catch (DoesNotExistException $e) {
-			throw new NotFoundException('Token ' . $token . ' does not exist');
+		$this->share = $this->shareMapper->findByToken($token);
+		if ($validateShareType) {
+			$this->validateShareType();
 		}
 
 		// Exception: logged in user accesses the poll via public share link
@@ -184,15 +181,10 @@ class ShareService {
 	 * Change share type
 	 */
 	public function setType(string $token, string $type): Share {
-		try {
-			$this->share = $this->shareMapper->findByToken($token);
-			$this->acl->setPollId($this->share->getPollId(), Acl::PERMISSION_POLL_EDIT);
-			$this->share->setType($type);
-			$this->share = $this->shareMapper->update($this->share);
-		} catch (DoesNotExistException $e) {
-			throw new NotFoundException('Token ' . $token . ' does not exist');
-		}
-
+		$this->share = $this->shareMapper->findByToken($token);
+		$this->acl->setPollId($this->share->getPollId(), Acl::PERMISSION_POLL_EDIT);
+		$this->share->setType($type);
+		$this->share = $this->shareMapper->update($this->share);
 		$this->eventDispatcher->dispatchTyped(new ShareTypeChangedEvent($this->share));
 
 		return $this->share;
@@ -207,7 +199,7 @@ class ShareService {
 			$this->acl->setPollId($this->share->getPollId(), Acl::PERMISSION_POLL_EDIT);
 			$this->share->setPublicPollEmail($value);
 			$this->share = $this->shareMapper->update($this->share);
-		} catch (DoesNotExistException $e) {
+		} catch (ShareNotFoundException $e) {
 			throw new NotFoundException('Token ' . $token . ' does not exist');
 		}
 		$this->eventDispatcher->dispatchTyped(new ShareChangedRegistrationConstraintEvent($this->share));
@@ -338,7 +330,7 @@ class ShareService {
 			$this->share = $this->shareMapper->findByToken($token);
 			$this->acl->setPollId($this->share->getPollId(), Acl::PERMISSION_POLL_EDIT);
 			$this->shareMapper->delete($this->share);
-		} catch (DoesNotExistException $e) {
+		} catch (ShareNotFoundException $e) {
 			// silently catch
 		}
 
@@ -431,7 +423,7 @@ class ShareService {
 				throw new ShareAlreadyExistsException;
 			} catch (MultipleObjectsReturnedException $e) {
 				throw new ShareAlreadyExistsException;
-			} catch (DoesNotExistException $e) {
+			} catch (ShareNotFoundException $e) {
 				// continue
 			}
 		}

--- a/lib/Service/UserService.php
+++ b/lib/Service/UserService.php
@@ -128,7 +128,8 @@ class UserService {
 		try {
 			$share = $this->shareMapper->findByPollAndUser($pollId, $userId);
 		} catch (ShareNotFoundException $e) {
-			$share = $e->getReplacement();
+			// User seems to be probaly deleted, use fake share
+			$share = $this->shareMapper->getReplacement($pollId, $userId);
 		}
 
 		return $this->getUserFromShare($share);

--- a/lib/Service/UserService.php
+++ b/lib/Service/UserService.php
@@ -26,8 +26,8 @@ namespace OCA\Polls\Service;
 use OCA\Polls\Db\Share;
 use OCA\Polls\Db\ShareMapper;
 use OCA\Polls\Db\VoteMapper;
-use OCA\Polls\Exceptions\Exception;
 use OCA\Polls\Exceptions\InvalidShareTypeException;
+use OCA\Polls\Exceptions\ShareNotFoundException;
 use OCA\Polls\Model\User\Admin;
 use OCA\Polls\Model\Group\Circle;
 use OCA\Polls\Model\Group\ContactGroup;
@@ -127,10 +127,11 @@ class UserService {
 		// Otherwise get it from a share that belongs to the poll and return the share user
 		try {
 			$share = $this->shareMapper->findByPollAndUser($pollId, $userId);
-			return $this->getUserFromShare($share);
-		} catch (Exception $e) {
+		} catch (ShareNotFoundException $e) {
 			return null;
 		}
+
+		return $this->getUserFromShare($share);
 	}
 
 	/**

--- a/lib/Service/UserService.php
+++ b/lib/Service/UserService.php
@@ -128,7 +128,7 @@ class UserService {
 		try {
 			$share = $this->shareMapper->findByPollAndUser($pollId, $userId);
 		} catch (ShareNotFoundException $e) {
-			return null;
+			$share = $e->getReplacement();
 		}
 
 		return $this->getUserFromShare($share);


### PR DESCRIPTION
* Generally change name of unidentifyable users to 'Deleted User'
* Hash userId instead of replacing with displayname in public polls

fixes #2636