### PR TITLE
Change handling of objects which refer to deleted shares (#2640)

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -109,7 +109,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres
+        image: postgres:14.5-bullseye
         ports:
           - 4444:5432/tcp
         env:

--- a/lib/Db/Comment.php
+++ b/lib/Db/Comment.php
@@ -27,12 +27,6 @@ namespace OCA\Polls\Db;
 
 use JsonSerializable;
 
-use OCA\Polls\Helper\Container;
-use OCP\IUser;
-use OCP\IUserManager;
-use OCP\AppFramework\Db\Entity;
-use OCP\AppFramework\Db\DoesNotExistException;
-
 /**
  * @method int getId()
  * @method void setId(integer $value)
@@ -45,7 +39,7 @@ use OCP\AppFramework\Db\DoesNotExistException;
  * @method int getTimestamp()
  * @method void setTimestamp(integer $value)
  */
-class Comment extends Entity implements JsonSerializable {
+class Comment extends EntityWithUser implements JsonSerializable {
 	public const TABLE = 'polls_comments';
 
 	/** @var array $subComments */
@@ -63,17 +57,9 @@ class Comment extends Entity implements JsonSerializable {
 	/** @var string $comment */
 	protected $comment = '';
 
-	/** @var IUserManager */
-	private $userManager;
-
-	/** @var ShareMapper */
-	private $shareMapper;
-
 	public function __construct() {
 		$this->addType('pollId', 'int');
 		$this->addType('timestamp', 'int');
-		$this->userManager = Container::queryClass(IUserManager::class);
-		$this->shareMapper = Container::queryClass(ShareMapper::class);
 	}
 
 	/**
@@ -100,33 +86,5 @@ class Comment extends Entity implements JsonSerializable {
 
 	public function getSubComments(): array {
 		return $this->subComments;
-	}
-
-	public function getDisplayName(): string {
-		if (!strncmp($this->userId, 'deleted_', 8)) {
-			return 'Deleted User';
-		}
-
-		if ($this->getIsNoUser()) {
-			// get displayName from share
-			try {
-				$share = $this->shareMapper->findByPollAndUser($this->getPollId(), $this->userId);
-				return $share->getDisplayName();
-			} catch (DoesNotExistException $e) {
-				return $this->userId;
-			}
-		}
-		return $this->userManager->get($this->userId)->getDisplayName();
-	}
-
-	public function getUser(): array {
-		return [
-			'userId' => $this->getUserId(),
-			'displayName' => $this->getDisplayName(),
-			'isNoUser' => $this->getIsNoUser(),
-		];
-	}
-	public function getIsNoUser(): bool {
-		return !($this->userManager->get($this->userId) instanceof IUser);
 	}
 }

--- a/lib/Db/EntityWithUser.php
+++ b/lib/Db/EntityWithUser.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * @copyright Copyright (c) 2017 Kai Schröer <git@schroeer.co>
+ *
+ * @author Kai Schröer <git@schroeer.co>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Polls\Db;
+
+use OCA\Polls\Exceptions\ShareNotFoundException;
+use OCA\Polls\Helper\Container;
+use OCP\AppFramework\Db\Entity;
+use OCP\IUser;
+use OCP\IUserManager;
+
+/**
+ * @method string getUserId()
+ * @method int getPollId()
+ */
+
+abstract class EntityWithUser extends Entity {
+	/** @var string $publicUserId */
+	protected $publicUserId = '';
+
+	public function getIsNoUser(): bool {
+		return !(Container::queryClass(IUserManager::class)->get($this->getUserId()) instanceof IUser);
+	}
+
+	public function getDisplayName(): string {
+		if (!$this->getUserId()) {
+			return '';
+		}
+		if ($this->getIsNoUser()) {
+			// get displayName from share
+			try {
+				$share = Container::queryClass(ShareMapper::class)->findByPollAndUser($this->getPollId(), $this->getUserId());
+			} catch (ShareNotFoundException $e) {
+				// User seems to be probaly deleted, use fake share
+				$share = Container::queryClass(ShareMapper::class)->getReplacement($this->getPollId(), $this->getUserId());
+			}
+			return $share->getDisplayName();
+		}
+
+		return Container::queryClass(IUserManager::class)->get($this->getUserId())->getDisplayName();
+	}
+
+	private function getPublicUserId(): string {
+		if (!$this->getUserId()) {
+			return '';
+		}
+
+		if ($this->publicUserId) {
+			return $this->publicUserId;
+		}
+
+		return $this->getUserId();
+	}
+
+	public function generateHashedUserId(): void {
+		$this->publicUserId = hash('md5', $this->getUserId());
+	}
+
+	public function getUser(): array {
+		return [
+			'userId' => $this->getPublicUserId(),
+			'displayName' => $this->getDisplayName(),
+			'isNoUser' => $this->getIsNoUser(),
+		];
+	}
+}

--- a/lib/Db/IEntityWithUser.php
+++ b/lib/Db/IEntityWithUser.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * @copyright Copyright (c) 2020 René Gieling <github@dartcafe.de>
+ * @copyright Copyright (c) 2017 Kai Schröer <git@schroeer.co>
  *
- * @author René Gieling <github@dartcafe.de>
+ * @author Kai Schröer <git@schroeer.co>
  *
  * @license GNU AGPL version 3 or any later version
  *
@@ -21,14 +21,26 @@
  *
  */
 
-namespace OCA\Polls\Exceptions;
+namespace OCA\Polls\Db;
 
-use OCP\AppFramework\Http;
+interface IEntityWithUser {
+	/**
+	 * Is this object'suser or owner an internal user or external
+	 */
+	public function getUserId(): string;
 
-class NotFoundException extends Exception {
-	public function __construct(
-		string $e = 'Not found'
-	) {
-		parent::__construct($e, Http::STATUS_NOT_FOUND);
-	}
+	/**
+	 * Returns the displayname of this object's user or owner
+	 */
+	public function getDisplayName(): string;
+
+	/**
+	 * Creates a hashed version of the userId
+	 */
+	public function generateHashedUserId(): void;
+
+	/**
+	 * Returns an array with user attributes for jsonSerialize()
+	 */
+	public function getUser(): array;
 }

--- a/lib/Db/Share.php
+++ b/lib/Db/Share.php
@@ -221,8 +221,12 @@ class Share extends Entity implements JsonSerializable {
 		$this->setMiscSettings(json_encode($value));
 	}
 
-	private function getMiscSettingsArray() : ?array {
-		return json_decode($this->getMiscSettings(), true);
+	private function getMiscSettingsArray() : array {
+		if ($this->getMiscSettings()) {
+			return json_decode($this->getMiscSettings(), true);
+		}
+		
+		return [];
 	}
 
 	/**

--- a/lib/Exceptions/ShareNotFoundException.php
+++ b/lib/Exceptions/ShareNotFoundException.php
@@ -23,12 +23,10 @@
 
 namespace OCA\Polls\Exceptions;
 
-use OCP\AppFramework\Http;
-
-class NotFoundException extends Exception {
+class ShareNotFoundException extends NotFoundException {
 	public function __construct(
-		string $e = 'Not found'
+		string $e = 'Share not found'
 	) {
-		parent::__construct($e, Http::STATUS_NOT_FOUND);
+		parent::__construct($e);
 	}
 }

--- a/lib/Model/Acl.php
+++ b/lib/Model/Acl.php
@@ -33,6 +33,7 @@ use OCA\Polls\Db\OptionMapper;
 use OCA\Polls\Db\PollMapper;
 use OCA\Polls\Db\VoteMapper;
 use OCA\Polls\Db\ShareMapper;
+use OCA\Polls\Exceptions\ShareNotFoundException;
 use OCP\IUserManager;
 use OCP\IUserSession;
 use OCP\IGroupManager;
@@ -130,7 +131,7 @@ class Acl implements JsonSerializable {
 			$this->poll = $this->pollMapper->find($this->share->getPollId());
 			$this->validateShareAccess();
 			$this->request($permission);
-		} catch (DoesNotExistException $e) {
+		} catch (ShareNotFoundException $e) {
 			throw new NotAuthorizedException('Error loading share ' . $token);
 		}
 

--- a/lib/Model/Mail/NotificationMail.php
+++ b/lib/Model/Mail/NotificationMail.php
@@ -108,6 +108,6 @@ class NotificationMail extends MailBase {
 			VoteEvent::SET => $this->l10n->t('%s has voted.', [$displayName]),
 		];
 
-		return $logStrings[$logItem->getMessageId()] ?? $logItem->getMessageId() . " (" . $displayName . ")";
+		return $logStrings[$logItem->getMessageId()] ?? $logItem->getMessageId() . ' (' . $displayName . ')';
 	}
 }

--- a/lib/Service/AnonymizeService.php
+++ b/lib/Service/AnonymizeService.php
@@ -28,7 +28,6 @@ use OCA\Polls\Db\Vote;
 use OCA\Polls\Db\VoteMapper;
 use OCA\Polls\Db\Comment;
 use OCA\Polls\Db\CommentMapper;
-use OCA\Polls\Db\Option;
 use OCA\Polls\Db\OptionMapper;
 use OCA\Polls\Db\Poll;
 
@@ -112,21 +111,13 @@ class AnonymizeService {
 		return;
 	}
 
-	/**
-	 * Replaces userIds with displayName to avoid exposing usernames in public polls
-	 */
 	public static function replaceUserId(&$arrayOrObject, string $userId) : void {
 		if (is_array($arrayOrObject)) {
 			foreach ($arrayOrObject as $item) {
 				if ($item->getUserId() === $userId) {
 					continue;
 				}
-				if ($item instanceof Comment || $item instanceof Vote) {
-					$item->setUserId($item->getDisplayName());
-				}
-				if ($item instanceof Option || $item instanceof Poll) {
-					$item->setOwner($item->getDisplayName());
-				}
+				$item->generateHashedUserId();
 			}
 			return;
 		}
@@ -135,13 +126,7 @@ class AnonymizeService {
 			return;
 		}
 
-		if ($arrayOrObject instanceof Option || $arrayOrObject instanceof Poll) {
-			$arrayOrObject->setOwner($arrayOrObject->getDisplayName());
-		}
-
-		if ($arrayOrObject instanceof Comment || $arrayOrObject instanceof Vote) {
-			$arrayOrObject->setUserId($arrayOrObject->getDisplayName());
-		}
+		$arrayOrObject->generateHashedUserId();
 
 		return;
 	}

--- a/lib/Service/PollService.php
+++ b/lib/Service/PollService.php
@@ -203,8 +203,12 @@ class PollService {
 
 	/**
 	 * get poll configuration
+	 *
+	 * @return (\OCA\Polls\Db\Comment|\OCA\Polls\Db\Option|\OCA\Polls\Db\Vote)[]|Poll
+	 *
+	 * @psalm-return Poll|array<\OCA\Polls\Db\Comment|\OCA\Polls\Db\Option|\OCA\Polls\Db\Vote>
 	 */
-	public function get(int $pollId) : Poll {
+	public function get(int $pollId) {
 		$this->acl->setPollId($pollId);
 		$this->poll = $this->pollMapper->find($pollId);
 

--- a/lib/Service/UserService.php
+++ b/lib/Service/UserService.php
@@ -26,8 +26,8 @@ namespace OCA\Polls\Service;
 use OCA\Polls\Db\Share;
 use OCA\Polls\Db\ShareMapper;
 use OCA\Polls\Db\VoteMapper;
-use OCA\Polls\Exceptions\Exception;
 use OCA\Polls\Exceptions\InvalidShareTypeException;
+use OCA\Polls\Exceptions\ShareNotFoundException;
 use OCA\Polls\Model\User\Admin;
 use OCA\Polls\Model\Group\Circle;
 use OCA\Polls\Model\Group\ContactGroup;
@@ -132,10 +132,12 @@ class UserService {
 		// Otherwise get it from a share that belongs to the poll and return the share user
 		try {
 			$share = $this->shareMapper->findByPollAndUser($pollId, $userId);
-			return $this->getUserFromShare($share);
-		} catch (Exception $e) {
-			return null;
+		} catch (ShareNotFoundException $e) {
+			// User seems to be probaly deleted, use fake share
+			$share = $this->shareMapper->getReplacement($pollId, $userId);
 		}
+
+		return $this->getUserFromShare($share);
 	}
 
 	/**


### PR DESCRIPTION
* Generally change name of unidentifyable users to 'Deleted User'
* Hash userId instead of replacing with displayname in public polls

Backport of #2640 instead of #2643
fixes #2636