### PR TITLE
Handle userid being null in NotificationService

### DIFF
--- a/lib/Service/NotificationService.php
+++ b/lib/Service/NotificationService.php
@@ -46,6 +46,9 @@ class NotificationService {
 
 	public function removeNotification(int $pollId): void {
 		$notification = $this->notificationManager->createNotification();
+		if (!$this->userId) {
+			return;
+		}
 		$notification->setApp(self::APP_ID)
 			->setObject('poll', strval($pollId))
 			->setUser($this->userId);


### PR DESCRIPTION
I have an issue very similar to https://github.com/nextcloud/polls/issues/2133 in 3.8.3.

Since we're in a cron job the `$UserId` constructor argument isn't provided with a value, and can't be used.

Side note: The `$UserId` auto-injection is now deprecated in favor of `$userId` https://github.com/nextcloud/server/pull/34929

```
TypeError: Argument 1 passed to OC\Notification\Notification::setUser() must be of the type string, null given, called in /var/www/nextcloud/apps/polls/lib/Service/NotificationService.php on line 51 and defined in /var/www/nextcloud/lib/private/Notification/Notification.php:154
Stack trace:
#0 /var/www/nextcloud/apps/polls/lib/Service/NotificationService.php(51): OC\Notification\Notification->setUser()
#1 /var/www/nextcloud/apps/polls/lib/Notification/Notifier.php(121): OCA\Polls\Service\NotificationService->removeNotification()
#2 /var/www/nextcloud/lib/private/Notification/Manager.php(376): OCA\Polls\Notification\Notifier->prepare()
#3 /var/www/nextcloud/apps/notifications/lib/MailNotifications.php(198): OC\Notification\Manager->prepare()
#4 /var/www/nextcloud/apps/notifications/lib/MailNotifications.php(168): OCA\Notifications\MailNotifications->sendEmailToUser()
#5 /var/www/nextcloud/apps/notifications/lib/BackgroundJob/SendNotificationMails.php(49): OCA\Notifications\MailNotifications->sendEmails()
#6 /var/www/nextcloud/lib/public/BackgroundJob/Job.php(79): OCA\Notifications\BackgroundJob\SendNotificationMails->run()
#7 /var/www/nextcloud/lib/public/BackgroundJob/TimedJob.php(95): OCP\BackgroundJob\Job->execute()
#8 /var/www/nextcloud/cron.php(151): OCP\BackgroundJob\TimedJob->execute()
#9 {main}
```