### PR TITLE
temporarily fix redirect

### DIFF
--- a/src/js/components/Poll/PublicRegisterModal.vue
+++ b/src/js/components/Poll/PublicRegisterModal.vue
@@ -175,10 +175,13 @@ export default {
 				params: { token: this.$route.params.token },
 			}).href
 
-			return generateUrl(
-				'/login',
-				{ redirect_url: redirectUrl },
-			)
+			return `${generateUrl('/login')}?redirect_url=${redirectUrl}`
+
+			// TODO: broken?
+			// return generateUrl(
+			// 	'/login',
+			// 	{ redirect_url: redirectUrl },
+			// )
 		},
 
 		userNameHint() {

--- a/src/js/components/Poll/PublicRegisterModal.vue
+++ b/src/js/components/Poll/PublicRegisterModal.vue
@@ -178,10 +178,7 @@ export default {
 			return `${generateUrl('/login')}?redirect_url=${redirectUrl}`
 
 			// TODO: broken?
-			// return generateUrl(
-			// 	'/login',
-			// 	{ redirect_url: redirectUrl },
-			// )
+			// return generateUrl('/login', { redirect_url: redirectUrl })
 		},
 
 		userNameHint() {


### PR DESCRIPTION
`generateUrl()` from nextcloud/nextcloud-router ignores parameters.

fix #2812