### PR TITLE
Release/5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 ##
-## [5.0.0] - tbd
+## [5.0.0] - 2023-04-07
  ### New
  - Added qr code for public shares
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,24 @@ All notable changes to this project will be documented in this file.
  - Added qr code for public shares
 ### Changes
  - PHP 8.0 as minimum requirement
- - Shorten public tokens to 8 characters (lower and upper characters and digits)
- 
-## [4.1.5] - 2023-02-25
+ - Shorten public tokens to 8 characters (lower and upper characters and digits) 
+
+## [4.1.8] - 2023-03-03
+### Fix
+ - Fix Error on poll creation `General error: 1364 The field 'description' has no default value.`
+
+## [4.1.7] - 2023-03-02
+### Fix
+ - Fix invitation mails for guest users
+
+## [4.1.6] - 2023-02-27
+### Fix
+ - Removed trailing comma in rebuild command## [4.1.5] - 2023-02-25
 ### Fix
  - Fix disappeared option add button after change in the nextcloud-vue lib
  ### Changes
  - Changed option owner column to notnull
+
 ## [4.1.4] - 2023-02-23
 ### Fix
  - Fix infinite updates call, if no polling type for watches were set (avoid server spamming) (v4.1.3)

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -4,7 +4,7 @@
     <name>Polls</name>
     <summary>A polls app, similar to Doodle/Dudle with the possibility to restrict access.</summary>
     <description>A polls app, similar to Doodle/Dudle with the possibility to restrict access (members, certain groups/users, hidden and public).</description>
-    <version>5.0.0-rc2</version>
+    <version>5.0.0</version>
     <licence>agpl</licence>
     <author>Vinzenz Rosenkranz</author>
     <author>René Gieling</author>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "polls",
-	"version": "5.0.0-rc2",
+	"version": "5.0.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "polls",
-			"version": "5.0.0-rc2",
+			"version": "5.0.0",
 			"license": "AGPL-3.0",
 			"dependencies": {
 				"@nextcloud/auth": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "polls",
 	"description": "Polls app for nextcloud",
-	"version": "5.0.0-rc2",
+	"version": "5.0.0",
 	"authors": [
 		{
 			"name": "Vinzenz Rosenkranz",


### PR DESCRIPTION
## [5.0.0] - 2023-04-07
 ### New
 - Added qr code for public shares
### Changes
 - PHP 8.0 as minimum requirement
 - Shorten public tokens to 8 characters (lower and upper characters and digits)
 