### PR TITLE
Use the color-primary-element* variables

### DIFF
--- a/src/js/assets/scss/hacks.scss
+++ b/src/js/assets/scss/hacks.scss
@@ -20,7 +20,7 @@
 }
 
 .mx-input-wrapper .button-vue--vue-primary .material-design-icon__svg {
-	fill: var(--color-primary-text);
+	fill: var(--color-primary-element-text);
 }
 
 .mx-datepicker-main .checkbox-radio-switch--checked svg {

--- a/src/js/components/Base/BadgeDiv.vue
+++ b/src/js/components/Base/BadgeDiv.vue
@@ -64,13 +64,13 @@ export default {
 		&.error {
 			border-color: var(--color-error);
 			background-color: var(--color-error);
-			color: var(--color-primary-text) !important;
+			color: var(--color-primary-element-text) !important;
 		}
 
 		&.success {
 			border-color: var(--color-success);
 			background-color: var(--color-success);
-			color: var(--color-primary-text) !important;
+			color: var(--color-primary-element-text) !important;
 		}
 	}
 

--- a/src/js/components/Comments/CommentItem.vue
+++ b/src/js/components/Comments/CommentItem.vue
@@ -156,7 +156,7 @@ export default {
 		.comment-item__content {
 			border: solid 1px var(--color-primary-element-light);
 			border-radius: var(--border-radius-large);
-			background-color: var(--color-primary-light);
+			background-color: var(--color-primary-element-light);
 			box-shadow: 2px 2px 6px var(--color-box-shadow);
 			padding-left: 8px;
 			padding-bottom: 10px;
@@ -165,8 +165,8 @@ export default {
 				margin-right: 4px;
 
 				&:hover {
-					background: var(--color-primary-hover);
-					color: var(--color-primary-light-hover);
+					background: var(--color-primary-element-hover);
+					color: var(--color-primary-element-light-hover);
 					margin-left: -4px;
 					padding-left: 4px;
 					border-radius: var(--border-radius-large);

--- a/src/js/components/Options/OptionsText.vue
+++ b/src/js/components/Options/OptionsText.vue
@@ -167,7 +167,7 @@ export default {
 
 	.ghost {
 		opacity: 0.5;
-		background: var(--color-primary-hover);
+		background: var(--color-primary-element-hover);
 	}
 
 	.submit-option {

--- a/src/js/components/PollList/PollItem.vue
+++ b/src/js/components/PollList/PollItem.vue
@@ -285,7 +285,7 @@ export default {
 			display: flex;
 		}
 		&.active {
-			background-color: var(--color-primary-light);
+			background-color: var(--color-primary-element-light);
 		}
 		&:hover {
 			background-color: var(--color-background-hover);

--- a/src/js/views/Dashboard.vue
+++ b/src/js/views/Dashboard.vue
@@ -117,7 +117,7 @@ export default {
 		padding: 4px 0;
 
 		&.active {
-			background-color: var(--color-primary-light);
+			background-color: var(--color-primary-element-light);
 		}
 
 		&:hover {


### PR DESCRIPTION
Explanation: the color-primary variables are not to be used in components because the introduce problems with high-contrast primary colors. Fix this by using the primary-element variables instead.