### PR TITLE
Remove old polls from relevant list

### DIFF
--- a/lib/Db/OptionMapper.php
+++ b/lib/Db/OptionMapper.php
@@ -154,6 +154,28 @@ class OptionMapper extends QBMapper {
 		$qb->executeStatement();
 	}
 
+	public function findDateBoundaries(int $pollId) {
+		$qb = $this->db->getQueryBuilder();
+
+		$qb->select('timestamp')
+			->from($this->getTableName())
+			->where($qb->expr()->eq('poll_id', $qb->createNamedParameter($pollId, IQueryBuilder::PARAM_INT)));
+
+		$results = $qb->executeQuery()->fetchAll(\PDO::FETCH_COLUMN);
+		
+		try {
+			return [
+				'min' => min($results),
+				'max' => max($results), 
+			];
+		} catch (\Throwable $th) {
+			return [
+				'min' => 0,
+				'max' => 0,
+			];
+		}
+	}
+
 	/**
 	 * @return Option[]
 	 */

--- a/lib/Db/OptionMapper.php
+++ b/lib/Db/OptionMapper.php
@@ -154,7 +154,12 @@ class OptionMapper extends QBMapper {
 		$qb->executeStatement();
 	}
 
-	public function findDateBoundaries(int $pollId) {
+	/**
+	 * @return (int|mixed)[]
+	 *
+	 * @psalm-return array{min: 0|mixed, max: 0|mixed}
+	 */
+	public function findDateBoundaries(int $pollId): array {
 		$qb = $this->db->getQueryBuilder();
 
 		$qb->select('timestamp')
@@ -166,7 +171,7 @@ class OptionMapper extends QBMapper {
 		try {
 			return [
 				'min' => min($results),
-				'max' => max($results), 
+				'max' => max($results),
 			];
 		} catch (\Throwable $th) {
 			return [

--- a/lib/Db/Poll.php
+++ b/lib/Db/Poll.php
@@ -223,7 +223,7 @@ class Poll extends EntityWithUser implements JsonSerializable {
 
 	public function setAutoReminder(bool $value) : void {
 		$this->setMiscSettingsByKey('autoReminder', $value);
-	}	
+	}
 
 	public function getAutoReminder(): bool {
 		return $this->getMiscSettingsArray()['autoReminder'] ?? false;

--- a/lib/Db/Poll.php
+++ b/lib/Db/Poll.php
@@ -73,6 +73,8 @@ use OCP\IURLGenerator;
  * @method void setHideBookedUp(integer $value)
  * @method int getUseNo()
  * @method void setUseNo(integer $value)
+ * @method int getLastInteraction()
+ * @method void setLastInteraction(integer $value)
  * @method string getMiscSettings()
  * @method void setMiscSettings(string $value)
  */
@@ -122,6 +124,7 @@ class Poll extends EntityWithUser implements JsonSerializable {
 	protected int $allowComment = 0;
 	protected int $hideBookedUp = 0;
 	protected int $useNo = 0;
+	protected int $lastInteraction = 0;
 	protected ?string $miscSettings = '';
 
 	public function __construct() {
@@ -138,6 +141,7 @@ class Poll extends EntityWithUser implements JsonSerializable {
 		$this->addType('important', 'int');
 		$this->addType('hideBookedUp', 'int');
 		$this->addType('useNo', 'int');
+		$this->addType('lastInteraction', 'int');
 		$this->optionMapper = Container::queryClass(OptionMapper::class);
 		$this->urlGenerator = Container::queryClass(IURLGenerator::class);
 	}
@@ -170,6 +174,7 @@ class Poll extends EntityWithUser implements JsonSerializable {
 			'type' => $this->getType(),
 			'useNo' => $this->getUseNo(),
 			'voteLimit' => $this->getVoteLimit(),
+			'lastInteraction' => $this->getLastInteraction(),
 		];
 	}
 
@@ -218,7 +223,7 @@ class Poll extends EntityWithUser implements JsonSerializable {
 
 	public function setAutoReminder(bool $value) : void {
 		$this->setMiscSettingsByKey('autoReminder', $value);
-	}
+	}	
 
 	public function getAutoReminder(): bool {
 		return $this->getMiscSettingsArray()['autoReminder'] ?? false;
@@ -260,13 +265,10 @@ class Poll extends EntityWithUser implements JsonSerializable {
 		return $this->description ?? '';
 	}
 
-	public function getTitle(): string {
-		return $this-> title;
-	}
-
 	public function getDescriptionSafe(): string {
 		return htmlspecialchars($this->getDescription());
 	}
+
 
 	private function setMiscSettingsArray(array $value) : void {
 		$this->setMiscSettings(json_encode($value));
@@ -310,8 +312,7 @@ class Poll extends EntityWithUser implements JsonSerializable {
 
 		if ($this->getType() === Poll::TYPE_DATE) {
 			// use first date option as reminder deadline
-			$options = $this->optionMapper->findByPoll($this->getId());
-			return $options[0]->getTimestamp();
+			return $this->optionMapper->findDateBoundaries($this->getId())['min'];
 		}
 		throw new NoDeadLineException();
 	}

--- a/lib/Db/PollMapper.php
+++ b/lib/Db/PollMapper.php
@@ -29,8 +29,6 @@ use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
 use OCP\Search\ISearchQuery;
 
-use function OCP\Log\logger;
-
 /**
  * @template-extends QBMapper<Poll>
  */

--- a/lib/Db/Preferences.php
+++ b/lib/Db/Preferences.php
@@ -48,7 +48,8 @@ class Preferences extends Entity implements JsonSerializable {
 		'defaultViewTextPoll' => 'table-view',
 		'defaultViewDatePoll' => 'table-view',
 		'performanceThreshold' => 1000,
-		'pollCombo' => []
+		'pollCombo' => [],
+		'relevantOffset' => 30,
 	];
 
 	public $id = 0;
@@ -59,17 +60,38 @@ class Preferences extends Entity implements JsonSerializable {
 	public function __construct() {
 		$this->addType('timestamp', 'int');
 	}
-	
+
+	public function getPreferences_decoded() {
+		return json_decode($this->getPreferences());
+	}
+
+	/**
+	 * getRelevantOffset - Offset for relevant polls in days
+	 */
+	public function getRelevantOffset(): int {
+		if (isset($this->getPreferences_decoded()->relevantOffset)) {
+			return intval($this->getPreferences_decoded()->relevantOffset);
+		}
+		return 30;
+	}
+
+	/**
+	 * getRelevantOffsetTimestamp - Offset for relevant polls in seconds (unix timestamp)
+	 */
+	public function getRelevantOffsetTimestamp(): int {
+		return $this->getRelevantOffset() * 24 * 60 * 60;
+	}
+
 	public function getCheckCalendarsBefore(): int {
-		if (isset(json_decode($this->getPreferences())->checkCalendarsBefore)) {
-			return intval(json_decode($this->getPreferences())->checkCalendarsBefore);
+		if (isset($this->getPreferences_decoded()->checkCalendarsBefore)) {
+			return intval($this->getPreferences_decoded()->checkCalendarsBefore);
 		}
 		return 0;
 	}
 	
 	public function getCheckCalendarsAfter(): int {
-		if (isset(json_decode($this->getPreferences())->checkCalendarsAfter)) {
-			return intval(json_decode($this->getPreferences())->checkCalendarsAfter);
+		if (isset($this->getPreferences_decoded()->checkCalendarsAfter)) {
+			return intval($this->getPreferences_decoded()->checkCalendarsAfter);
 		}
 		return 0;
 	}

--- a/lib/Db/TableManager.php
+++ b/lib/Db/TableManager.php
@@ -61,8 +61,9 @@ class TableManager {
 		$this->connection->migrateToSchema($this->schema);
 	}
 
-	public function refreshSchema(): void {
+	public function refreshSchema(): Schema {
 		$this->schema = $this->connection->createSchema();
+		return $this->schema;
 	}
 
 	/**
@@ -301,6 +302,17 @@ class TableManager {
 			}
 		}
 		return $messages;
+
+	}
+
+	public function resetLastInteraction(?int $timestamp): void {
+		$timestamp = $timestamp ?? time();
+		$query = $this->connection->getQueryBuilder();
+
+		$query->update(Poll::TABLE)
+			->set('last_interaction', $query->createNamedParameter($timestamp))
+			->where($query->expr()->eq('last_interaction', $query->createNamedParameter(0)));
+		$query->executeStatement();
 
 	}
 

--- a/lib/Db/TableManager.php
+++ b/lib/Db/TableManager.php
@@ -287,7 +287,12 @@ class TableManager {
 		}
 	}
 
-	public function deleteAllDuplicates(?IOutput $output = null) {
+	/**
+	 * @return string[]
+	 *
+	 * @psalm-return list<string>
+	 */
+	public function deleteAllDuplicates(?IOutput $output = null): array {
 		$messages = [];
 		foreach (TableSchema::UNIQUE_INDICES as $tableName => $index) {
 			$count = $this->deleteDuplicates($tableName, $index['columns']);

--- a/lib/Listener/BaseListener.php
+++ b/lib/Listener/BaseListener.php
@@ -110,7 +110,7 @@ abstract class BaseListener implements IEventListener {
 		throw new InvalidClassException('child class must be checked in child class');
 	}
 
-	protected function updateLastInteraction() {
+	protected function updateLastInteraction(): void {
 		// Update last interaction, exept event is one of the of excluded events
 		if (
 			!($this->event instanceof PollTakeoverEvent)
@@ -160,6 +160,7 @@ abstract class BaseListener implements IEventListener {
 		if (($this->event instanceof BaseEvent)) {
 			return $this->event->getPollId();
 		}
+		return 0;
 	}
 
 	/**

--- a/lib/Migration/TableSchema.php
+++ b/lib/Migration/TableSchema.php
@@ -113,6 +113,7 @@ abstract class TableSchema {
 		'041000Date20221221070000',
 		'040101Date20230119080000',
 		'040102Date20230123072601',
+		'050005Date20230506203301',
 	];
 
 	/**
@@ -175,6 +176,7 @@ abstract class TableSchema {
 			'use_no' => ['type' => Types::BIGINT, 'options' => ['notnull' => true, 'default' => 1, 'length' => 20]],
 			'proposals_expire' => ['type' => Types::BIGINT, 'options' => ['notnull' => true, 'default' => 0, 'length' => 20]],
 			'misc_settings' => ['type' => Types::TEXT, 'options' => ['notnull' => false, 'default' => null, 'length' => 65535]],
+			'last_interaction' => ['type' => Types::BIGINT, 'options' => ['notnull' => true, 'default' => 0, 'length' => 20]],
 		],
 		Option::TABLE => [
 			'id' => ['type' => Types::BIGINT, 'options' => ['autoincrement' => true, 'notnull' => true, 'length' => 20]],

--- a/lib/Migration/Version050100Date20230515083001.php
+++ b/lib/Migration/Version050100Date20230515083001.php
@@ -57,6 +57,9 @@ class Version050100Date20230515083001 extends SimpleMigrationStep {
 		return null;
 	}
 
+	/**
+	 * @return void
+	 */
 	public function postSchemaChange(IOutput $output, \Closure $schemaClosure, array $options) {
 		$now = time();
 		$query = $this->db->getQueryBuilder();

--- a/lib/Migration/Version050100Date20230515083001.php
+++ b/lib/Migration/Version050100Date20230515083001.php
@@ -23,10 +23,8 @@
 
 namespace OCA\Polls\Migration;
 
-use OCA\Polls\Db\IndexManager;
+use OCA\Polls\Db\Poll;
 use OCA\Polls\Db\TableManager;
-use OCP\DB\ISchemaWrapper;
-use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
@@ -37,13 +35,10 @@ use OCP\Migration\SimpleMigrationStep;
  * Changed class naming: Version[jjmmpp]Date[YYYYMMDDHHMMSS]
  * Version: jj = major version, mm = minor, pp = patch
  */
-class Version050005Date20230506203301 extends SimpleMigrationStep {
+class Version050100Date20230515083001 extends SimpleMigrationStep {
 	public function __construct(
-		private IDBConnection $connection,
-		private IConfig $config,
-		private FixVotes $fixVotes,
-		private IndexManager $indexManager,
-		private TableManager $tableManager
+		private TableManager $tableManager,
+		private IDBConnection $db,
 	) {
 	}
 
@@ -51,15 +46,23 @@ class Version050005Date20230506203301 extends SimpleMigrationStep {
 	 * $schemaClosure The `\Closure` returns a `ISchemaWrapper`
 	 */
 	public function changeSchema(IOutput $output, \Closure $schemaClosure, array $options) {
-		/** @var ISchemaWrapper $schema */
-		$schema = $schemaClosure();
-		
 		// Create tables, as defined in TableSchema or fix column definitions
-		foreach ($this->tableManager->createTables() as $message) {
-			$output->info('Polls - ' . $message);
-		};
+		$messages = $this->tableManager->createTables();
 		$this->tableManager->migrate();
 
-		return $schema;
+		foreach ($messages as $message) {
+			$output->info('Polls - ' . $message);
+		};
+
+		return null;
+	}
+
+	public function postSchemaChange(IOutput $output, \Closure $schemaClosure, array $options) {
+		$now = time();
+		$query = $this->db->getQueryBuilder();
+		$query->update(Poll::TABLE)
+			->set('last_interaction', $query->createNamedParameter($now))
+			->where($query->expr()->eq('last_interaction', $query->createNamedParameter(0)));
+		$query->executeStatement();
 	}
 }

--- a/lib/Service/PollService.php
+++ b/lib/Service/PollService.php
@@ -91,7 +91,7 @@ class PollService {
 						$poll->getLastInteraction(),
 						$poll->getExpire(),
 						$this->optionMapper->findDateBoundaries($poll->getId())['max'],
-						) + ($this->preferences->getRelevantOffsetTimestamp());
+					) + ($this->preferences->getRelevantOffsetTimestamp());
 						
 					// mix poll settings, acl and relevantThreshold into one array
 					$pollList[] = (object) array_merge(

--- a/lib/Service/PollService.php
+++ b/lib/Service/PollService.php
@@ -23,8 +23,11 @@
 
 namespace OCA\Polls\Service;
 
+use OCA\Polls\Db\OptionMapper;
 use OCA\Polls\Db\Poll;
 use OCA\Polls\Db\PollMapper;
+use OCA\Polls\Db\Preferences;
+use OCA\Polls\Db\PreferencesMapper;
 use OCA\Polls\Db\VoteMapper;
 use OCA\Polls\Event\PollArchivedEvent;
 use OCA\Polls\Event\PollCreatedEvent;
@@ -51,7 +54,7 @@ use OCP\Search\ISearchQuery;
 
 class PollService {
 	private string $userId;
-
+	
 	public function __construct(
 		private Acl $acl,
 		private AppSettings $appSettings,
@@ -60,28 +63,41 @@ class PollService {
 		private IUserManager $userManager,
 		private IUserSession $userSession,
 		private MailService $mailService,
+		private OptionMapper $optionMapper,
 		private Poll $poll,
 		private PollMapper $pollMapper,
-		private VoteMapper $voteMapper
+		private Preferences $preferences,
+		private PreferencesMapper $preferencesMapper,
+		private VoteMapper $voteMapper,
 	) {
 		$this->userId = $this->userSession->getUser()?->getUID() ?? '';
+		$this->preferences = $this->preferencesMapper->find($this->userId);
 	}
 
 	/**
-	 * Get list of polls
+	 * Get list of polls including acl and Threshold for "relevant polls"
 	 */
 	public function list(): array {
 		$pollList = [];
 		try {
 			$polls = $this->pollMapper->findForMe($this->userId);
-
+			
 			foreach ($polls as $poll) {
 				try {
 					$this->acl->setPollId($poll->getId());
 					// TODO: Not the elegant way. Improvement neccessary
+					$relevantThreshold = max(
+						$poll->getCreated(),
+						$poll->getLastInteraction(),
+						$poll->getExpire(),
+						$this->optionMapper->findDateBoundaries($poll->getId())['max'],
+						) + ($this->preferences->getRelevantOffsetTimestamp());
+						
+					// mix poll settings, acl and relevantThreshold into one array
 					$pollList[] = (object) array_merge(
 						(array) json_decode(json_encode($poll)),
-						(array) json_decode(json_encode($this->acl))
+						(array) json_decode(json_encode($this->acl)),
+						['relevantThreshold' => $relevantThreshold],
 					);
 				} catch (ForbiddenException $e) {
 					continue;
@@ -219,6 +235,7 @@ class PollService {
 		$this->poll->setDeleted(0);
 		$this->poll->setAdminAccess(0);
 		$this->poll->setImportant(0);
+		$this->poll->setLastInteraction(time());
 		$this->poll = $this->pollMapper->insert($this->poll);
 
 		$this->eventDispatcher->dispatchTyped(new PollCreatedEvent($this->poll));
@@ -266,6 +283,15 @@ class PollService {
 		$this->eventDispatcher->dispatchTyped(new PollUpdatedEvent($this->poll));
 
 		return $this->poll;
+	}
+
+	/**
+	 * Update timestamp for last interaction with polls
+	 */
+	public function setLastInteraction(int $pollId): void {
+		if ($pollId) {
+			$this->pollMapper->setLastInteraction($pollId);
+		}
 	}
 
 

--- a/src/js/components/Settings/UserSettings/FeatureSettings.vue
+++ b/src/js/components/Settings/UserSettings/FeatureSettings.vue
@@ -39,12 +39,21 @@
 				{{ t('polls', 'Check this, if you prefer to display date poll in a vertical view rather than in the grid view. The initial default is grid view.') }}
 			</div>
 		</div>
+
+		<div class="user_settings">
+			<InputDiv v-model="relevantOffset"
+				type="number"
+				inputmode="numeric"
+				use-num-modifiers
+				:label="t('polls', 'Enter the amount of days, polls without activity stay in the relevant list:')" />
+		</div>
 	</div>
 </template>
 
 <script>
 
 import { mapState } from 'vuex'
+import InputDiv from '../../Base/InputDiv.vue'
 import { NcCheckboxRadioSwitch } from '@nextcloud/vue'
 
 export default {
@@ -52,12 +61,23 @@ export default {
 
 	components: {
 		NcCheckboxRadioSwitch,
+		InputDiv,
 	},
 
 	computed: {
 		...mapState({
 			settings: (state) => state.settings.user,
 		}),
+
+		relevantOffset: {
+			get() {
+				return this.settings.relevantOffset
+			},
+			set(value) {
+				value = value < 1 ? 1 : value
+				this.writeValue({ relevantOffset: value })
+			},
+		},
 
 		defaultViewTextPoll: {
 			get() {

--- a/src/js/store/modules/polls.js
+++ b/src/js/store/modules/polls.js
@@ -41,17 +41,17 @@ const state = {
 			id: 'relevant',
 			title: t('polls', 'Relevant'),
 			titleExt: t('polls', 'Relevant polls'),
-			description: t('polls', 'All polls which are relevant or important to you, because you are a participant or the owner or you are invited to. Without polls closed more than five days ago.'),
+			description: t('polls', 'All polls which are relevant or important to you, because you are a participant or the owner or you are invited to.'),
 			pinned: false,
 			createDependent: false,
 			filterCondition(poll) {
 				return !poll.deleted
-                && !(poll.expire > 0 && moment.unix(poll.expire).diff(moment(), 'days') < -4)
-                && (poll.important
-                    || poll.userHasVoted
-                    || poll.isOwner
-                    || (poll.allowView && poll.access !== 'open')
-                )
+					&& (poll.relevantThreshold > (moment().unix()))
+					&& (poll.important
+						|| poll.userHasVoted
+						|| poll.isOwner
+						|| (poll.allowView && poll.access !== 'open')
+					)
 			},
 		},
 		{

--- a/src/js/store/modules/settings.js
+++ b/src/js/store/modules/settings.js
@@ -35,6 +35,7 @@ const defaultSettings = () => ({
 		defaultViewDatePoll: 'table-view',
 		performanceThreshold: 1000,
 		pollCombo: [],
+		relevantOffset: 30,
 	},
 	session: {
 		manualViewDatePoll: '',


### PR DESCRIPTION
resolves #2909

* remove polls without recent interactions from relevant list
* let the user configure the offset for removal in days
* calculate threshold from creation date, expiry date, last interaction and latest date option 