### PR TITLE
Move and shift dates respecting client's timezone

### DIFF
--- a/lib/Controller/OptionController.php
+++ b/lib/Controller/OptionController.php
@@ -119,6 +119,6 @@ class OptionController extends BaseController {
 	 * @NoAdminRequired
 	 */
 	public function findCalendarEvents(int $optionId, string $tz): JSONResponse {
-		return $this->response(fn () => ['events' => $this->calendarService->getEvents($optionId, $tz)]);
+		return $this->response(fn () => ['events' => $this->calendarService->getEvents($optionId)]);
 	}
 }

--- a/lib/Db/Option.php
+++ b/lib/Db/Option.php
@@ -120,6 +120,10 @@ class Option extends EntityWithUser implements JsonSerializable {
 		return htmlspecialchars_decode($this->pollOptionText);
 	}
 
+	public function updatePollOptionText(): void {
+		$this->setPollOptionText($this->getPollOptionText());
+	}
+
 	public function getPollOptionTextEnd(): string {
 		if ($this->getTimestamp()) {
 			return date('c', $this->getTimestamp() + $this->getDuration());

--- a/lib/Db/OptionMapper.php
+++ b/lib/Db/OptionMapper.php
@@ -42,11 +42,19 @@ class OptionMapper extends QBMapper {
 	}
 
 	public function update(Entity $entity): Entity {
+		$entity->updatePollOptionText();
+		if ($entity->getTimestamp() > 0) {
+			$entity->setOrder($entity->getTimestamp());
+		}
 		$entity->setPollOptionHash(hash('md5', $entity->getPollId() . $entity->getPollOptionText() . $entity->getTimestamp()));
 		return parent::update($entity);
 	}
-
+	
 	public function insert(Entity $entity): Entity {
+		$entity->updatePollOptionText();
+		if ($entity->getTimestamp() > 0) {
+			$entity->setOrder($entity->getTimestamp());
+		}
 		$entity->setPollOptionHash(hash('md5', $entity->getPollId() . $entity->getPollOptionText() . $entity->getTimestamp()));
 		return parent::insert($entity);
 	}

--- a/lib/Middleware/RequestAttributesMiddleware.php
+++ b/lib/Middleware/RequestAttributesMiddleware.php
@@ -8,6 +8,7 @@ use OCP\ISession;
 
 class RequestAttributesMiddleware extends Middleware {
 	private const CLIENT_ID_KEY = 'Nc-Polls-Client-Id';
+	private const TIME_ZONE_KEY = 'Nc-Polls-Client-Time-Zone';
 
 	public function __construct(
 		protected IRequest $request,
@@ -17,6 +18,7 @@ class RequestAttributesMiddleware extends Middleware {
 
 	public function beforeController($controller, $methodName): void {
 		$clientId = $this->request->getHeader(self::CLIENT_ID_KEY);
+		$clientTimeZone = $this->request->getHeader(self::TIME_ZONE_KEY);
 
 		if (!$clientId) {
 			$clientId = $this->session->getId();
@@ -24,6 +26,9 @@ class RequestAttributesMiddleware extends Middleware {
 
 		if ($clientId) {
 			$this->session->set('ncPollsClientId', $clientId);
+		}
+		if ($clientTimeZone) {
+			$this->session->set('ncPollsClientTimeZone', $clientTimeZone);
 		}
 	}
 }

--- a/lib/Service/CalendarService.php
+++ b/lib/Service/CalendarService.php
@@ -35,6 +35,7 @@ use OCA\Polls\Model\CalendarEvent;
 use OCA\Polls\Model\User\CurrentUser;
 use OCP\Calendar\ICalendar;
 use OCP\Calendar\IManager as CalendarManager;
+use OCP\ISession;
 
 class CalendarService {
 	/** @var ICalendar[] */
@@ -43,6 +44,7 @@ class CalendarService {
 
 	public function __construct(
 		private CalendarManager $calendarManager,
+		private ISession $session,
 		private PreferencesService $preferencesService,
 		private OptionMapper $optionMapper,
 		private CurrentUser $currentUser,
@@ -112,8 +114,8 @@ class CalendarService {
 	 *
 	 * @psalm-return list<CalendarEvent|null>
 	 */
-	public function getEvents(int $optionId, string $tz): array {
-		$timezone = new DateTimeZone($tz);
+	public function getEvents(int $optionId): array {
+		$timezone = new DateTimeZone($this->session->get('ncPollsClientTimeZone'));
 		$timerange = $this->getTimerange($optionId, $timezone);
 
 		$events = [];

--- a/src/js/Api/HttpApi.js
+++ b/src/js/Api/HttpApi.js
@@ -30,6 +30,7 @@ const axiosConfig = {
 	headers: {
 		Accept: 'application/json',
 		'Nc-Polls-Client-Id': clientSessionId,
+		'Nc-Polls-Client-Time-Zone': Intl.DateTimeFormat().resolvedOptions().timeZone,
 	},
 }
 


### PR DESCRIPTION
Respect the client's timezone, when 
* creating a sequence of date options or
* when shifting all options

* added a http header to send the client's timezone
* mutate dates with the client's timezone

This will fix problems when mutating dates while crossing the daylight saving time borders

fixes #2625 
fixes #2850 