### PR TITLE
Fix deleteComment url

### DIFF
--- a/src/js/Api/public.js
+++ b/src/js/Api/public.js
@@ -116,7 +116,7 @@ const publicPoll = {
 	deleteComment(shareToken, commentId) {
 		return httpInstance.request({
 			method: 'DELETE',
-			url: `s/${shareToken}/${commentId}`,
+			url: `s/${shareToken}/comment/${commentId}`,
 			params: { time: +new Date() },
 
 			cancelToken: cancelTokenHandlerObject[this.deleteComment.name].handleRequestCancellation().token,


### PR DESCRIPTION
Deleting comments in the public URL does not work now.