### PR TITLE
improve validatePublicUsername() performance

### DIFF
--- a/lib/Service/SystemService.php
+++ b/lib/Service/SystemService.php
@@ -145,8 +145,9 @@ class SystemService {
 			throw new InvalidUsernameException;
 		}
 
-		// get all groups
-		foreach (Group::search() as $group) {
+		// get all groups, that include the requested username in their gid
+		// or displayname and check if any match completely
+		foreach (Group::search($userName) as $group) {
 			if ($userName === strtolower(trim($group->getId()))
 				|| $userName === strtolower(trim($group->getDisplayName()))) {
 				throw new InvalidUsernameException;


### PR DESCRIPTION
On Instances with many groups the validatePublicUsername endpoint ends with a timeout, because the code checking if the anonymous users chosen userName matches any group on the server is quite inefficient. It does not utilize the search parameter of the Group::search() function and therefore loads all groups from all group backends from the database into RAM, creates a php entity for every one of them and calls two functions on every one of those entities.

I created a performance profile of a simple call of the /check/username endpoint on an instance with ~12k groups (which is certainly a lot, but I assure you every one of those has an important role on our instance and other apps have no problems working with this amount of groups):

In total this request took 71.6 seconds, causing the connection to the client to drop during the request with a timeout (the php process still runs to completion).

In the performance profile you can see, that most time (73%) is spent in the nextcloud core just fetching the data from the database and putting it into php entities.

![image](https://github.com/nextcloud/polls/assets/28999431/84194384-f689-4beb-b8e2-9c4eb0d15d6f)

In total this one request causes 54 THOUSAND requests to QueryBuilder->execute(), which AFAIK is below the cache layer and that means every one of those is a sql query to  the database. I hope we can all agree that kind of amplification from one request is not great.

But the current implementation makes sense looking at the timeline: The first usage of this empty search parameter I could track down through various refactors is the initial implementation of Public Pages back in 2019 in #664 .
This was before the default database group backend started searching by display names in 2020 (introduced in https://github.com/nextcloud/server/pull/21358), so it makes sense a custom search was implemented on this high level. But now we can use the MUCH faster filtering on the database query level :partying_face: .

It is still true, that every group backend decides for itself, how it handles the search parameter and theoretically a group backend could decide only to search by gid, but I think it is reasonable to assume, that any group backend, that uses DisplayNames (ours with the 12k groups does not) follows the core implementation and also searches display names.

On our instance this small 9 characters of code patch brought the request time of the /check/username endpoint to 714 ms down from 71.6 seconds, a 10200% performance improvement :partying_face: .
![image](https://github.com/nextcloud/polls/assets/28999431/62dbdae4-2c14-4ea7-9e1a-4d1cbb6b7962)
