### PR TITLE
revoke shares instead of deleting

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -98,6 +98,8 @@ return [
 		['name' => 'share#admin_to_user', 'url' => '/share/{token}/user', 'verb' => 'PUT'],
 		['name' => 'share#set_label', 'url' => '/share/{token}/setlabel', 'verb' => 'PUT'],
 		['name' => 'share#set_public_poll_email', 'url' => '/share/{token}/publicpollemail/{value}', 'verb' => 'PUT'],
+		['name' => 'share#revoke', 'url' => '/share/{token}/revoke', 'verb' => 'PUT'],
+		['name' => 'share#re_revoke', 'url' => '/share/{token}/rerevoke', 'verb' => 'PUT'],
 
 		['name' => 'settings#getAppSettings', 'url' => '/settings/app', 'verb' => 'GET'],
 		['name' => 'settings#writeAppSettings', 'url' => '/settings/app', 'verb' => 'POST'],
@@ -150,6 +152,8 @@ return [
 		['name' => 'share_api#add', 'url' => '/api/v1.0/poll/{pollId}/share/{type}', 'verb' => 'POST'],
 		['name' => 'share_api#delete', 'url' => '/api/v1.0/share/{token}', 'verb' => 'DELETE'],
 		['name' => 'share_api#sendInvitation', 'url' => '/api/v1.0/share/send/{token}', 'verb' => 'PUT'],
+		['name' => 'share_api#revoke', 'url' => '/api/v1.0/share/revoke/{token}', 'verb' => 'PUT'],
+		['name' => 'share_api#re_revoke', 'url' => '/api/v1.0/share/rerevoke/{token}', 'verb' => 'PUT'],
 
 		['name' => 'subscription_api#get', 'url' => '/api/v1.0/poll/{pollId}/subscription', 'verb' => 'GET'],
 		['name' => 'subscription_api#subscribe', 'url' => '/api/v1.0/poll/{pollId}/subscription', 'verb' => 'PUT'],

--- a/lib/Controller/ShareController.php
+++ b/lib/Controller/ShareController.php
@@ -114,6 +114,24 @@ class ShareController extends BaseController {
 	}
 
 	/**
+	 * Delete share
+	 * @NoAdminRequired
+	 */
+
+	public function revoke(string $token): JSONResponse {
+		return $this->responseDeleteTolerant(fn () => ['share' => $this->shareService->revoke(token: $token)]);
+	}
+
+	/**
+	 * Delete share
+	 * @NoAdminRequired
+	 */
+
+	public function reRevoke(string $token): JSONResponse {
+		return $this->responseDeleteTolerant(fn () => ['share' => $this->shareService->reRevoke(token: $token)]);
+	}
+
+	/**
 	 * Send invitation mails for a share
 	 * Additionally send notification via notifications
 	 * @NoAdminRequired

--- a/lib/Db/Share.php
+++ b/lib/Db/Share.php
@@ -47,10 +47,14 @@ use OCP\IURLGenerator;
  * @method void setInvitationSent(integer $value)
  * @method int getReminderSent()
  * @method void setReminderSent(integer $value)
+ * @method int getRevoked()
+ * @method void setRevoked(integer $value)
  * @method string getDisplayName()
  * @method void setDisplayName(string $value)
  * @method string getMiscSettings()
  * @method void setMiscSettings(string $value)
+ * @method int getVoted()
+ * @method void setVoted(int $value)
  */
 class Share extends Entity implements JsonSerializable {
 	public const TABLE = 'polls_share';
@@ -75,6 +79,23 @@ class Share extends Entity implements JsonSerializable {
 	// no direct Access
 	public const TYPE_CIRCLE = 'circle';
 	public const TYPE_CONTACTGROUP = 'contactGroup';
+
+
+	// Share types, that are allowed for public access (without login)
+	public const SHARE_PUBLIC_ACCESS_ALLOWED = [
+		self::TYPE_PUBLIC,
+		self::TYPE_CONTACT,
+		self::TYPE_EMAIL,
+		self::TYPE_EXTERNAL,
+	];
+
+	// Share types, that are allowed for authenticated access (with login)
+	public const SHARE_AUTH_ACCESS_ALLOWED = [
+		self::TYPE_PUBLIC,
+		self::TYPE_ADMIN,
+		self::TYPE_GROUP,
+		self::TYPE_USER,
+	];
 
 	public const TYPE_SORT_ARRAY = [
 		self::TYPE_PUBLIC,
@@ -102,12 +123,15 @@ class Share extends Entity implements JsonSerializable {
 	protected ?string $emailAddress = null;
 	protected int $invitationSent = 0;
 	protected int $reminderSent = 0;
+	protected int $revoked = 0;
 	protected ?string $displayName = null;
 	protected ?string $miscSettings = '';
+	protected int $voted = 0;
 
 	public function __construct() {
 		$this->addType('pollId', 'int');
 		$this->addType('invitationSent', 'int');
+		$this->addType('Revoked', 'int');
 		$this->addType('reminderSent', 'int');
 		$this->urlGenerator = Container::queryClass(IURLGenerator::class);
 		$this->appSettings = new AppSettings;
@@ -126,11 +150,13 @@ class Share extends Entity implements JsonSerializable {
 			'emailAddress' => $this->getEmailAddress(),
 			'invitationSent' => $this->getInvitationSent(),
 			'reminderSent' => $this->getReminderSent(),
+			'revoked' => $this->getRevoked(),
 			'displayName' => $this->getDisplayName(),
 			'isNoUser' => !(in_array($this->getType(), [self::TYPE_USER, self::TYPE_ADMIN], true)),
 			'URL' => $this->getURL(),
 			'showLogin' => $this->appSettings->getBooleanSetting(AppSettings::SETTING_SHOW_LOGIN),
 			'publicPollEmail' => $this->getPublicPollEmail(),
+			'voted' => $this->getVoted(),
 		];
 	}
 
@@ -200,6 +226,10 @@ class Share extends Entity implements JsonSerializable {
 
 	private function setMiscSettingsArray(array $value): void {
 		$this->setMiscSettings(json_encode($value));
+	}
+
+	private function getVoteCount(): int {
+		return 0;
 	}
 
 	private function getMiscSettingsArray(): array {

--- a/lib/Db/ShareMapper.php
+++ b/lib/Db/ShareMapper.php
@@ -25,10 +25,12 @@
 namespace OCA\Polls\Db;
 
 use OCA\Polls\Exceptions\ShareNotFoundException;
+use OCA\Polls\Migration\TableSchema;
 use OCA\Polls\Model\UserBase;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Db\QBMapper;
 use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IConfig;
 use OCP\IDBConnection;
 
 /**
@@ -37,7 +39,10 @@ use OCP\IDBConnection;
 class ShareMapper extends QBMapper {
 	public const TABLE = Share::TABLE;
 
-	public function __construct(IDBConnection $db) {
+	public function __construct(
+		IDBConnection $db,
+		private IConfig $config,
+	) {
 		parent::__construct($db, Share::TABLE, Share::class);
 	}
 
@@ -47,16 +52,41 @@ class ShareMapper extends QBMapper {
 	 * @psalm-return array<array-key, Share>
 	 */
 	public function findByPoll(int $pollId): array {
+
 		$qb = $this->db->getQueryBuilder();
 
-		$qb->select('*')
-		   ->from($this->getTableName())
+		// get all column names from TableSchema
+		foreach (TableSchema::TABLES[Share::TABLE] as $column => $values) {
+			$selectColumns[] = 'p.' . $column;
+		}		
+		// add vote counter
+		$selectColumns[] = $qb->func()->count('c1.id', 'voted');
+
+		// Build the following select (MySQL)
+		// 
+		// SELECT p.*, COUNT(c1.user_id) as voted
+		// FROM oc_polls_share p 
+		// LEFT JOIN oc_polls_votes c1 
+		//   ON p.poll_id = c1.poll_id AND
+		// 	    p.user_id = c1.user_id
+		// GROUP BY p.poll_id, p.user_id
+		// 
+		$qb->select($selectColumns)
+		   ->from($this->getTableName(), 'p')
 		   ->where(
-		   	$qb->expr()->eq('poll_id', $qb->createNamedParameter($pollId, IQueryBuilder::PARAM_INT))
-		   );
+			$qb->expr()->eq('p.poll_id', $qb->createNamedParameter($pollId, IQueryBuilder::PARAM_INT))
+		   )
+		   ->leftJoin('p', VOTE::TABLE, 'c1', 
+				$qb->expr()->andX(
+					$qb->expr()->eq('p.poll_id', 'c1.poll_id'),
+					$qb->expr()->eq('p.user_id', 'c1.user_id'),
+				)
+			)
+			->groupBy('poll_id', 'user_id');
 
 		return $this->findEntities($qb);
 	}
+
 	/**
 	 * @throws \OCP\AppFramework\Db\DoesNotExistException if not found
 	 * @return Share[]
@@ -74,6 +104,18 @@ class ShareMapper extends QBMapper {
 
 		return $this->findEntities($qb);
 	}
+
+	public function countVotesByShare(Share $share): int {
+		$qb = $this->db->getQueryBuilder();
+
+		$qb->select('*')
+			->from($this->config->getSystemValue('dbtableprefix', 'oc_') . Vote::TABLE)
+			->where($qb->expr()->eq('poll_id', $qb->createNamedParameter($share->getPollId(), IQueryBuilder::PARAM_INT)))
+			->andWhere($qb->expr()->eq('user_id', $qb->createNamedParameter($share->getUserId(), IQueryBuilder::PARAM_STR)));
+
+		return count($this->findEntities($qb));
+	}
+
 	/**
 	 * @throws \OCP\AppFramework\Db\DoesNotExistException if not found
 	 * @return Share[]

--- a/lib/Event/ShareRevokedEvent.php
+++ b/lib/Event/ShareRevokedEvent.php
@@ -24,32 +24,10 @@
 namespace OCA\Polls\Event;
 
 use OCA\Polls\Db\Share;
-use OCA\Polls\Model\UserBase;
 
-abstract class ShareEvent extends BaseEvent {
-	public const ADD = 'share_add';
-	public const ADD_PUBLIC = 'share_add_public';
-	public const CHANGE_EMAIL = 'share_change_email';
-	public const CHANGE_DISPLAY_NAME = 'share_change_display_name';
-	public const CHANGE_TYPE = 'share_change_type';
-	public const CHANGE_REG_CONSTR = 'share_change_reg_const';
-	public const REGISTRATION = 'share_registration';
-	public const DELETE = 'share_delete';
-	public const REVOKED = 'share_revoked';
-
-	private Share $share;
-	// protected UserBase $sharee = null;
-
+class ShareRevokedEvent extends ShareEvent {
 	public function __construct(Share $share) {
 		parent::__construct($share);
-		$this->activityObjectType = 'poll';
-		$this->log = false;
-		$this->share = $share;
-		$this->activitySubjectParams['shareType'] = $this->share->getRichObjectString();
-		$this->activitySubjectParams['sharee'] = $this->getSharee()->getRichObjectString();
-	}
-
-	protected function getSharee() : UserBase {
-		return $this->userService->getUserFromShare($this->share);
+		$this->eventId = self::REVOKED;
 	}
 }

--- a/lib/Exceptions/InvalidMethodCallException.php
+++ b/lib/Exceptions/InvalidMethodCallException.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * @copyright Copyright (c) 2020 René Gieling <github@dartcafe.de>
+ *
+ * @author René Gieling <github@dartcafe.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Polls\Exceptions;
+
+use OCP\AppFramework\Http;
+
+class InvalidMethodCallException extends Exception {
+	public function __construct(
+		string $e = 'Method is used illegally'
+	) {
+		parent::__construct($e, Http::STATUS_CONFLICT);
+	}
+}

--- a/lib/Migration/TableSchema.php
+++ b/lib/Migration/TableSchema.php
@@ -151,6 +151,9 @@ abstract class TableSchema {
 
 	/**
 	 * define table structure
+	 * 
+	 * IMPORTANT: After adding or deletion check queries in ShareMapper
+	 * 
 	 */
 	public const TABLES = [
 		Poll::TABLE => [
@@ -215,6 +218,7 @@ abstract class TableSchema {
 			'display_name' => ['type' => Types::STRING, 'options' => ['notnull' => false, 'default' => null, 'length' => 256]],
 			'email_address' => ['type' => Types::STRING, 'options' => ['notnull' => false, 'default' => null, 'length' => 256]],
 			'invitation_sent' => ['type' => Types::BIGINT, 'options' => ['notnull' => true, 'default' => 0, 'length' => 20]],
+			'revoked' => ['type' => Types::BIGINT, 'options' => ['notnull' => true, 'default' => 0, 'length' => 20]],
 			'reminder_sent' => ['type' => Types::BIGINT, 'options' => ['notnull' => true, 'default' => 0, 'length' => 20]],
 			'misc_settings' => ['type' => Types::TEXT, 'options' => ['notnull' => false, 'default' => null, 'length' => 65535]],
 		],

--- a/lib/Service/PollService.php
+++ b/lib/Service/PollService.php
@@ -83,7 +83,7 @@ class PollService {
 			
 			foreach ($polls as $poll) {
 				try {
-					$this->acl->setPollId($poll->getId());
+					$this->acl->setPoll($poll);
 					// TODO: Not the elegant way. Improvement neccessary
 					$relevantThreshold = max(
 						$poll->getCreated(),

--- a/src/js/Api/modules/shares.js
+++ b/src/js/Api/modules/shares.js
@@ -95,6 +95,22 @@ const shares = {
 		})
 	},
 
+	revokeShare(shareToken) {
+		return httpInstance.request({
+			method: 'PUT',
+			url: `share/${shareToken}/revoke`,
+			cancelToken: cancelTokenHandlerObject[this.revokeShare.name].handleRequestCancellation().token,
+		})
+	},
+
+	reRevokeShare(shareToken) {
+		return httpInstance.request({
+			method: 'PUT',
+			url: `share/${shareToken}/rerevoke`,
+			cancelToken: cancelTokenHandlerObject[this.reRevokeShare.name].handleRequestCancellation().token,
+		})
+	},
+
 	inviteAll(pollId) {
 		return httpInstance.request({
 			method: 'PUT',

--- a/src/js/App.vue
+++ b/src/js/App.vue
@@ -24,7 +24,7 @@
 	<NcContent app-name="polls" :class="appClass">
 		<router-view v-if="getCurrentUser()" name="navigation" />
 		<router-view />
-		<router-view v-show="sideBar.open" name="sidebar" />
+		<router-view v-show="sideBar.open && (poll.acl.allowEdit || poll.acl.allowComment)" name="sidebar" />
 		<LoadingOverlay v-if="loading" />
 		<UserSettingsDlg />
 	</NcContent>
@@ -120,7 +120,7 @@ export default {
 		})
 
 		subscribe('polls:sidebar:toggle', (payload) => {
-			emit('polls:sidebar:changeTab', { activeTab: payload.activeTab })
+			emit('polls:sidebar:changeTab', { activeTab: payload?.activeTab })
 			this.sideBar.open = payload?.open ?? !this.sideBar.open
 		})
 	},

--- a/src/js/components/Actions/modules/ActionDelete.vue
+++ b/src/js/components/Actions/modules/ActionDelete.vue
@@ -29,6 +29,9 @@
 				<UndoIcon v-if="deleteTimeout"
 					:size="iconSize"
 					@click="cancelDelete()" />
+				<RevokeIcon v-else-if="revoke"
+					:size="iconSize"
+					@click="deleteItem()" />
 				<DeleteIcon v-else
 					:size="iconSize"
 					@click="deleteItem()" />
@@ -40,12 +43,14 @@
 <script>
 import { NcButton } from '@nextcloud/vue'
 import DeleteIcon from 'vue-material-design-icons/Delete.vue'
+import RevokeIcon from 'vue-material-design-icons/Close.vue'
 import UndoIcon from 'vue-material-design-icons/ArrowULeftTop.vue'
 
 export default {
 	name: 'ActionDelete',
 	components: {
 		DeleteIcon,
+		RevokeIcon,
 		UndoIcon,
 		NcButton,
 	},
@@ -63,6 +68,10 @@ export default {
 		iconSize: {
 			type: Number,
 			default: 20,
+		},
+		revoke: {
+			type: Boolean,
+			default: false,
 		},
 	},
 
@@ -85,6 +94,12 @@ export default {
 
 	methods: {
 		deleteItem() {
+			// delete immediately
+			if (this.timeout === 0) {
+				this.$emit('delete')
+				return
+			}
+
 			this.countDown = this.timeout
 			this.deleteInterval = setInterval(() => {
 				this.countdown -= 1

--- a/src/js/components/Poll/PollHeaderButtons.vue
+++ b/src/js/components/Poll/PollHeaderButtons.vue
@@ -66,7 +66,7 @@ export default {
 
 	computed: {
 		...mapState({
-			allowComment: (state) => state.poll.allowComment,
+			allowComment: (state) => state.poll.acl.allowComment,
 			allowEdit: (state) => state.poll.acl.allowEdit,
 			allowVote: (state) => state.poll.acl.allowVote,
 			allowPollDownload: (state) => state.poll.acl.allowPollDownload,

--- a/src/js/components/Shares/SharesList.vue
+++ b/src/js/components/Shares/SharesList.vue
@@ -30,9 +30,9 @@
 		<ShareItemAllUsers v-if="allowAllAccess" />
 		<SharePublicAdd v-if="allowPublicShares" />
 
-		<div v-if="invitationShares.length" class="shares-list shared">
+		<div v-if="activeShares.length" class="shares-list shared">
 			<TransitionGroup :css="false" tag="div">
-				<ShareItem v-for="(share) in invitationShares"
+				<ShareItem v-for="(share) in activeShares"
 					:key="share.id"
 					:share="share"
 					@show-qr-code="openQrModal(share)" />
@@ -94,7 +94,7 @@ export default {
 			pollDescription: (state) => state.poll.description,
 		}),
 		...mapGetters({
-			invitationShares: 'shares/invitation',
+			activeShares: 'shares/active',
 		}),
 	},
 

--- a/src/js/components/Shares/SharesListRevoked.vue
+++ b/src/js/components/Shares/SharesListRevoked.vue
@@ -1,0 +1,68 @@
+<!--
+  - @copyright Copyright (c) 2018 René Gieling <github@dartcafe.de>
+  -
+  - @author René Gieling <github@dartcafe.de>
+  -
+  - @license GNU AGPL version 3 or any later version
+  -
+  - This program is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU Affero General Public License as
+  - published by the Free Software Foundation, either version 3 of the
+  - License, or (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  - GNU Affero General Public License for more details.
+  -
+  - You should have received a copy of the GNU Affero General Public License
+  - along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -
+  -->
+
+<template>
+	<ConfigBox v-if="revokedShares.length" :title="t('polls', 'Revoked shares')">
+		<template #icon>
+			<DeletedIcon />
+		</template>
+		<TransitionGroup :css="false" tag="div" class="shares-list">
+			<ShareItem v-for="(share) in revokedShares"
+				:key="share.id"
+				:share="share" />
+		</TransitionGroup>
+	</ConfigBox>
+</template>
+
+<script>
+import { mapGetters, mapActions, mapState } from 'vuex'
+import { ConfigBox } from '../Base/index.js'
+import DeletedIcon from 'vue-material-design-icons/Delete.vue'
+import ShareItem from './ShareItem.vue'
+
+export default {
+	name: 'SharesListRevoked',
+
+	components: {
+		DeletedIcon,
+		ConfigBox,
+		ShareItem,
+	},
+
+	computed: {
+		...mapState({
+			pollId: (state) => state.poll.id,
+		}),
+
+		...mapGetters({
+			revokedShares: 'shares/revoked',
+		}),
+	},
+
+	methods: {
+		...mapActions({
+			removeShare: 'shares/delete',
+			inviteAll: 'shares/inviteAll',
+		}),
+	},
+}
+</script>

--- a/src/js/components/SideBar/SideBarTabShare.vue
+++ b/src/js/components/SideBar/SideBarTabShare.vue
@@ -24,6 +24,7 @@
 	<div class="sidebar-share">
 		<SharesListUnsent class="shares unsent" />
 		<SharesList class="shares effective" />
+		<SharesListRevoked class="shares" />
 	</div>
 </template>
 
@@ -31,6 +32,7 @@
 import { mapState } from 'vuex'
 import SharesList from '../Shares/SharesList.vue'
 import SharesListUnsent from '../Shares/SharesListUnsent.vue'
+import SharesListRevoked from '../Shares/SharesListRevoked.vue'
 
 export default {
 	name: 'SideBarTabShare',
@@ -38,6 +40,7 @@ export default {
 	components: {
 		SharesList,
 		SharesListUnsent,
+		SharesListRevoked,
 	},
 
 	computed: {

--- a/src/js/components/User/UserItem.vue
+++ b/src/js/components/User/UserItem.vue
@@ -31,7 +31,8 @@
 			:show-user-status="showUserStatus"
 			:user="avatarUserId"
 			:display-name="name"
-			:is-no-user="isNoUser">
+			:is-no-user="isNoUser"
+			@click="showMenu()">
 			<template v-if="useIconSlot" #icon>
 				<LinkIcon v-if="type==='public'" :size="mdIconSize" />
 				<InternalLinkIcon v-if="type==='internalAccess'" :size="mdIconSize" />
@@ -124,6 +125,10 @@ export default {
 			type: String,
 			default: '',
 		},
+		forcedDescription: {
+			type: String,
+			default: null,
+		},
 		type: {
 			type: String,
 			default: 'user',
@@ -178,6 +183,7 @@ export default {
 			return !['user', 'admin'].includes(this.type)
 		},
 		description() {
+			if (this.forcedDescription) return this.forcedDescription
 			if (this.type === 'admin') return t('polls', 'Is granted admin rights for this poll')
 			if (this.displayEmailAddress) return this.displayEmailAddress
 			return ''

--- a/src/js/store/modules/share.js
+++ b/src/js/store/modules/share.js
@@ -27,6 +27,7 @@ const defaultShares = () => ({
 	displayName: '',
 	id: null,
 	invitationSent: 0,
+	revoked: 0,
 	pollId: null,
 	token: '',
 	type: '',

--- a/src/js/store/modules/votes.js
+++ b/src/js/store/modules/votes.js
@@ -60,7 +60,6 @@ const getters = {
 	relevant: (state, getters, rootState) => state.list.filter((vote) => rootState.options.list.some((option) => option.pollId === vote.pollId && option.text === vote.optionText)),
 	countVotes: (state, getters, rootState) => (answer) => getters.relevant.filter((vote) => vote.user.userId === rootState.poll.acl.userId && vote.answer === answer).length,
 	countAllVotes: (state, getters) => (answer) => getters.relevant.filter((vote) => vote.answer === answer).length,
-	hasVoted: (state) => (userId) => state.list.findIndex((vote) => vote.user.userId === userId) > -1,
 	hasVotes: (state) => state.list.length > 0,
 
 	getVote: (state) => (payload) => {


### PR DESCRIPTION
Changed the deletion of shares
* shares without votes get deleted imediately (without the timer)
* shares with votes can be revoked, so that the sharee is still able to view the results, but any other interaction is denied.
* revoked shares can bew reactivated
* admin rights are also withdrawn, if a share with admin rights for the poll gets revoked
* deleting revoked shares will also remove the sharees vots

todo: 
* [] delete votes when deleting revoked shares