### PR TITLE
Enh/revoke-shares-follow-up

### DIFF
--- a/src/js/components/Poll/PollHeaderButtons.vue
+++ b/src/js/components/Poll/PollHeaderButtons.vue
@@ -35,8 +35,8 @@
 			</template>
 			<PollInformation />
 		</NcPopover>
-		<ExportPoll v-if="allowPollDownload" />
-		<ActionToggleSidebar v-if="allowEdit || allowComment" />
+		<ExportPoll v-if="acl.allowPollDownload" />
+		<ActionToggleSidebar v-if="acl.allowEdit || acl.allowComment" />
 	</div>
 </template>
 
@@ -66,14 +66,11 @@ export default {
 
 	computed: {
 		...mapState({
-			allowComment: (state) => state.poll.acl.allowComment,
-			allowEdit: (state) => state.poll.acl.allowEdit,
-			allowVote: (state) => state.poll.acl.allowVote,
-			allowPollDownload: (state) => state.poll.acl.allowPollDownload,
+			acl: (state) => state.poll.acl,
 		}),
 
 		showUserMenu() {
-			return this.$route.name !== 'publicVote' || this.allowVote
+			return this.$route.name !== 'publicVote' || this.acl.allowVote || this.acl.allowSubscribe
 		},
 	},
 

--- a/src/js/components/User/UserMenu.vue
+++ b/src/js/components/User/UserMenu.vue
@@ -42,7 +42,7 @@
 			</template>
 			{{ t('polls', 'Edit Email Address') }}
 		</NcActionInput>
-		<NcActionInput v-if="$route.name === 'publicVote'"
+		<NcActionInput v-if="$route.name === 'publicVote' && acl.allowVote"
 			v-bind="userName.inputProps"
 			:value.sync="userName.inputValue"
 			@update:value="validateDisplayName"
@@ -81,7 +81,7 @@
 			</template>
 			{{ t('polls', 'Copy list of email addresses to clipboard') }}
 		</NcActionButton>
-		<NcActionButton @click="resetVotes()">
+		<NcActionButton v-if="acl.allowVote" @click="resetVotes()">
 			<template #icon>
 				<ResetVotesIcon />
 			</template>


### PR DESCRIPTION
Follow up to #3096 
* allow revoked shares to still enter the poll in read only mode 
* allow basic functions for subscriptions and email settings
* resolves #3099