### PR TITLE
Not null violation error in migrations

### DIFF
--- a/lib/Migration/TableSchema.php
+++ b/lib/Migration/TableSchema.php
@@ -242,7 +242,7 @@ abstract class TableSchema {
 			'poll_id' => ['type' => Types::BIGINT, 'options' => ['notnull' => true, 'default' => 0, 'length' => 20]],
 			'table' => ['type' => Types::STRING, 'options' => ['notnull' => true, 'default' => '', 'length' => 64]],
 			'updated' => ['type' => Types::BIGINT, 'options' => ['notnull' => true, 'default' => 0, 'length' => 20]],
-			'session_id' => ['type' => Types::STRING, 'options' => ['notnull' => true, 'default' => null]],
+			'session_id' => ['type' => Types::STRING, 'options' => ['notnull' => false, 'default' => null]],
 		],
 		Preferences::TABLE => [
 			'id' => ['type' => Types::BIGINT, 'options' => ['autoincrement' => true, 'notnull' => true, 'length' => 20]],

--- a/lib/Migration/TableSchema.php
+++ b/lib/Migration/TableSchema.php
@@ -40,7 +40,7 @@ use OCP\DB\Types;
 /**
  * Database definition for installing and migrations
  * These definitions contain the base database layout
- * used for initial migration to version 3.x from all prior versoins
+ * used for initial migration to version 3.x from all prior versions
  */
 
 abstract class TableSchema {
@@ -125,7 +125,7 @@ abstract class TableSchema {
 		'polls_txts', // dropped in 0.9
 		'polls_particip', // dropped in 0.9
 		'polls_particip_text', // dropped in 0.9
-		'polls_test', // invalid table, accidentially introduced in an old beta version
+		'polls_test', // invalid table, accidentally introduced in an old beta version
 	];
 
 	/**


### PR DESCRIPTION
A bug has been introduced with https://github.com/nextcloud/polls/commit/3da60e4457c5100ccf9184a721a16317bffe1447 which is causing migration errors when you try to upgrade the app.

```
Database error when running migration 050100Date20230515083001 for app polls

An exception occurred while executing a query: SQLSTATE[23502]: Not null violation: 7 ERROR:  column "session_id" contains null values
```

Having a non-nullable column with the default value of `null` is definitely not right. likely introduced by mistake with the refactoring of the class.

In this PR, I have made the `session_id` column nullable which is the intended behavior.

I have also reviewed all other combinations on the file and found no other non-nullable columns with a default value of `null`.

This is not being reflected with the new installations of the app, as the database handles the error seamlessly. However, as mentioned earlier, an error is thrown when upgrading older versions of the app.