### PR TITLE
Fix WatchService accessing pollId 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## [6.1.2] - tbd
 ### Fix
  - Fixing bug, when an internal user tries to enter a poll using a public share a second time
+ - Fix error message of watchpoll, trying to access pollId 0
 ## [6.1.1] - 2024-02-16
 ### Changes
  - Consolidated migration to avoid double database validation

--- a/lib/Service/WatchService.php
+++ b/lib/Service/WatchService.php
@@ -54,8 +54,10 @@ class WatchService {
 	/**
 	 * Watch poll for updates
 	 */
-	public function watchUpdates(?int $pollId = null, ?int $offset = null): array {
-		$this->acl->setPollId($pollId);
+	public function watchUpdates(int $pollId = 0, ?int $offset = null): array {
+		if ($pollId !== 0) {
+			$this->acl->setPollId($pollId);
+		}
 
 		$start = time();
 		$timeout = 30;
@@ -64,10 +66,10 @@ class WatchService {
 		if ($this->appSettings->getUpdateType() === AppSettings::SETTING_UPDATE_TYPE_LONG_POLLING) {
 			while (empty($updates) && time() <= $start + $timeout) {
 				sleep(1);
-				$updates = $this->getUpdates($this->acl->getPollId(), $offset);
+				$updates = $this->getUpdates($pollId, $offset);
 			}
 		} else {
-			$updates = $this->getUpdates($this->acl->getPollId(), $offset);
+			$updates = $this->getUpdates($pollId, $offset);
 		}
 
 		if (empty($updates)) {


### PR DESCRIPTION
When entering poll lists, the WatchService tried to access a pollId 0
fixes #3330