### PR TITLE
Partially fix email shares

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 ## [6.1.4] - tbd
 ### Fix
  - Fixing 404 error when using public share where the poll has hidden results
-
+ - Partially fix email shares
 ## [6.1.3] - 2024-02-21
 ### Fix
  - Fixing bug, when an internal user tries to enter a poll using a public share a second time

--- a/lib/Model/User/Email.php
+++ b/lib/Model/User/Email.php
@@ -49,4 +49,18 @@ class Email extends UserBase {
 	public function getDisplayName(): string {
 		return $this->displayName ? $this->displayName : $this->id;
 	}
+
+	public function jsonSerialize(): array {
+		if ($this->userMapper->getCurrentUserCached()->getIsLoggedIn()) {
+			return $this->getRichUserArray();
+		}
+		return $this->getSimpleUserArray();
+	}
+
+	public function getDescription(): string {
+		if ($this->getDisplayName()) {
+			return $this->getEmailAndDisplayName();
+		}
+		return $this->getEmailAddress();
+	}
 }

--- a/lib/Model/UserBase.php
+++ b/lib/Model/UserBase.php
@@ -201,6 +201,10 @@ class UserBase implements \JsonSerializable {
 		return $this->description;
 	}
 
+	public function getSubName(): string {
+		return $this->getDescription();
+	}
+
 	/**
 	 * @deprecated Not used anymore?
 	 */
@@ -358,7 +362,10 @@ class UserBase implements \JsonSerializable {
 			'userId' => $this->getId(),
 			'displayName' => $this->getDisplayName(),
 			'emailAddress' => $this->getEmailAddress(),
+			'subName' => $this->getSubName(),
+			'subtitle' => $this->getDescription(),
 			'isNoUser' => $this->getIsNoUser(),
+			'desc' => $this->getDescription(),
 			'type' => $this->getType(),
 			'id' => $this->getId(),
 			'user' => $this->getId(),
@@ -366,9 +373,6 @@ class UserBase implements \JsonSerializable {
 			'languageCode' => $this->getLanguageCode(),
 			'localeCode' => $this->getLocaleCode(),
 			'timeZone' => $this->getTimeZoneName(),
-			'desc' => $this->getDescription(),
-			'subname' => $this->getDescription(),
-			'subtitle' => $this->getDescription(),
 			'icon' => $this->getIcon(),
 			'categories' => $this->getCategories(),
 		];
@@ -384,7 +388,7 @@ class UserBase implements \JsonSerializable {
 	 *
 	 * @psalm-return array{id: string, userId: string, displayName: string, emailAddress: string, isNoUser: bool, type: string}
 	 */
-	private function getSimpleUserArray(): array {
+	protected function getSimpleUserArray(): array {
 		return	[
 			'id' => $this->getSafeId(),
 			'userId' => $this->getSafeId(),
@@ -441,6 +445,7 @@ class UserBase implements \JsonSerializable {
 
 		return '';
 	}
+
 	public function getOrganisation(): string {
 		return $this->organisation;
 	}

--- a/lib/Model/UserBase.php
+++ b/lib/Model/UserBase.php
@@ -353,9 +353,10 @@ class UserBase implements \JsonSerializable {
 	/**
 	 * Full user array for poll owners, delegated poll admins and the current user himself
 	 * without obfuscating/anonymizing
+	 *
 	 * @return (bool|string|string[])[]
 	 *
-	 * @psalm-return array{userId: string, displayName: string, emailAddress: string, isNoUser: bool, type: string, id: string, user: string, organisation: string, languageCode: string, localeCode: string, timeZone: string, desc: string, subname: string, subtitle: string, icon: string, categories: array<string>}
+	 * @psalm-return array{userId: string, displayName: string, emailAddress: string, subName: string, subtitle: string, isNoUser: bool, desc: string, type: string, id: string, user: string, organisation: string, languageCode: string, localeCode: string, timeZone: string, icon: string, categories: array<string>}
 	 */
 	public function getRichUserArray(): array {
 		return	[

--- a/src/js/components/User/UserSearch.vue
+++ b/src/js/components/User/UserSearch.vue
@@ -22,15 +22,7 @@
 
 <template>
 	<NcSelect id="ajax"
-		:aria-label-combobox="t('polls', 'Add shares')"
-		:options="users"
-		:multiple="false"
-		:user-select="true"
-		:tag-width="80"
-		:limit="30"
-		:loading="isLoading"
-		:searchable="true"
-		:placeholder="placeholder"
+		v-model="selectProps"
 		label="displayName"
 		@option:selected="clickAdd"
 		@search="loadUsersAsync">
@@ -62,6 +54,23 @@ export default {
 			isLoading: false,
 			placeholder: t('polls', 'Type to add an individual share'),
 		}
+	},
+
+	computed: {
+		selectProps() {
+			return {
+				ariaLabelCombobox: t('polls', 'Add shares'),
+				options: this.users,
+				multiple: false,
+				userSelect: true,
+				// tagWidth: 80,
+				limit: 30,
+				loading: this.isLoading,
+				searchable: true,
+				placeholder: this.placeholder,
+				closeOnSelect: false,
+			}
+		},
 	},
 
 	methods: {


### PR DESCRIPTION
This partially fixes #3335 for plain mail addresses. 

Email notations like "John \<john@foo.com>" is still broken. Wait for the outcome of https://github.com/nextcloud-libraries/nextcloud-vue/issues/5293