### PR TITLE
perf: Determine participant status more efficiently

### DIFF
--- a/lib/Db/VoteMapper.php
+++ b/lib/Db/VoteMapper.php
@@ -136,6 +136,21 @@ class VoteMapper extends QBMapper {
 		return $this->findEntities($qb);
 	}
 
+	/**
+	 * @return int
+	 */
+	public function countParticipantsVotes(int $pollId, string $userId): ?int {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select($qb->func()->count('poll_id'))
+			->from($this->getTableName())
+			->where($qb->expr()->eq('poll_id', $qb->createNamedParameter($pollId, IQueryBuilder::PARAM_INT)))
+			->andWhere($qb->expr()->eq('user_id', $qb->createNamedParameter($userId, IQueryBuilder::PARAM_STR)));
+		$result = $qb->executeQuery();
+		$count = $result->fetchOne();
+		$result->closeCursor();
+		return $count;
+	}
+
 	public function deleteByPollAndUserId(int $pollId, string $userId): void {
 		$qb = $this->db->getQueryBuilder();
 		$qb->delete($this->getTableName())

--- a/lib/Model/Acl.php
+++ b/lib/Model/Acl.php
@@ -323,9 +323,7 @@ class Acl implements JsonSerializable {
 	 * Returns true, if the current user is already a particitipant of the current poll.
 	 */
 	private function getIsParticipant(): bool {
-		return count(
-			$this->voteMapper->findParticipantsVotes($this->getPollId(), $this->getUserId())
-		) > 0;
+		return $this->voteMapper->countParticipantsVotes($this->getPollId(), $this->getUserId()) > 0;
 	}
 
 	/**


### PR DESCRIPTION
This makes one of the N+1 queries of https://github.com/nextcloud/polls/issues/3362 more efficient.

Before: load all votes of the poll, create entity objects and then do a count
After: count in the database