### PR TITLE
perf: Cache \OCA\Polls\Model\Acl::getIsInvolved

### DIFF
--- a/lib/Model/Acl.php
+++ b/lib/Model/Acl.php
@@ -65,7 +65,9 @@ class Acl implements JsonSerializable {
 	public const PERMISSION_PUBLIC_SHARES = 'publicShares';
 	public const PERMISSION_ALL_ACCESS = 'allAccess';
 
-	
+	private $cachedIsInvolved = null;
+
+
 	public function __construct(
 		private IUserManager $userManager,
 		private IUserSession $userSession,
@@ -174,6 +176,7 @@ class Acl implements JsonSerializable {
 	 */
 	public function setPoll(Poll $poll, string $permission = self::PERMISSION_POLL_VIEW): Acl {
 		$this->poll = $poll;
+		$this->cachedIsInvolved = null;
 		$this->loadShare();
 		$this->request($permission);
 		return $this;
@@ -311,11 +314,15 @@ class Acl implements JsonSerializable {
 	 * as a participant or as the poll owner.
 	 */
 	private function getIsInvolved(): bool {
-		return (
-			$this->getIsOwner()
-			|| $this->getIsParticipant()
-			|| $this->getIsInvitedViaGroupShare()
-			|| $this->getIsPersonallyInvited());
+		if ($this->cachedIsInvolved === null) {
+			$this->cachedIsInvolved = (
+				$this->getIsOwner()
+				|| $this->getIsParticipant()
+				|| $this->getIsInvitedViaGroupShare()
+				|| $this->getIsPersonallyInvited());
+		}
+
+		return $this->cachedIsInvolved;
 	}
 
 	/**


### PR DESCRIPTION
![image](https://github.com/nextcloud/polls/assets/1374172/df8caab8-c177-4382-b660-e1b19f929527)

Two polls with one share cause 32 requests for the share recipient. Caching the result of `\OCA\Polls\Model\Acl::getIsInvolved` in memory cuts these to 18 requests.