### PR TITLE
[stable6] Backport of stable 6 for Nextcloud 26

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         php-versions: ['8.0']
-        server-versions: ['master']
+        server-versions: ['stable26']
 
     name: SQLite
 
@@ -56,7 +56,7 @@ jobs:
       fail-fast: false
       matrix:
         php-versions: ['8.1']
-        server-versions: ['master']
+        server-versions: ['stable26']
 
     name: MySQL
 
@@ -99,7 +99,7 @@ jobs:
       fail-fast: false
       matrix:
         php-versions: ['8.2']
-        server-versions: ['master']
+        server-versions: ['stable26']
 
     name: PostgreSQL
 

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ocp-version: ['master']
+        ocp-version: ['stable26']
         php-versions: ['8.0', '8.1', '8.2']
 
     name: Psalm

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -23,7 +23,7 @@
   <screenshot>https://raw.githubusercontent.com/nextcloud/polls/master/screenshots/edit-poll.png</screenshot>
   <dependencies>
     <php min-version="8.0"/>
-    <nextcloud min-version="28" max-version="28"/>
+    <nextcloud min-version="26" max-version="28"/>
   </dependencies>
   <activity>
     <providers>

--- a/composer.json
+++ b/composer.json
@@ -35,11 +35,11 @@
 		}
 	},
 	"require-dev": {
+		"doctrine/dbal": "^3.6",
 		"league/factory-muffin": "^3.0",
 		"league/factory-muffin-faker": "^2.0",
 		"nextcloud/coding-standard": "^1.0",
-		"nextcloud/ocp": "dev-stable27",
-		"doctrine/dbal": "^3.6"
+		"nextcloud/ocp": "dev-stable26"
 	},
 	"scripts": {
 		"cs:check": "php-cs-fixer fix --dry-run --diff",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,10 @@
 		"autoloader-suffix": "Polls",
 		"platform": {
         "php": "8.0"
-      }
+      },
+		"allow-plugins": {
+			"bamarni/composer-bin-plugin": true
+		}
     },
 	"autoload": {
 		"psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e0df7b7aa1b1a99be92fcddebc226176",
+    "content-hash": "fe7685b3d6c9b219254d39619780c806",
     "packages": [
         {
             "name": "dflydev/dot-access-data",
@@ -1259,29 +1259,28 @@
         },
         {
             "name": "nextcloud/ocp",
-            "version": "dev-stable27",
+            "version": "dev-stable26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "3beb4e9456fd71c91c299ee416e142ad89901deb"
+                "reference": "692e8fb9d10e591600048723c6ed5f7d33fa4275"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/3beb4e9456fd71c91c299ee416e142ad89901deb",
-                "reference": "3beb4e9456fd71c91c299ee416e142ad89901deb",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/692e8fb9d10e591600048723c6ed5f7d33fa4275",
+                "reference": "692e8fb9d10e591600048723c6ed5f7d33fa4275",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.4 || ~8.0 || ~8.1",
-                "psr/clock": "^1.0",
-                "psr/container": "^2.0.2",
+                "psr/container": "^1.1.1",
                 "psr/event-dispatcher": "^1.0",
-                "psr/log": "^1.1.4"
+                "psr/log": "^1.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-stable27": "27.0.0-dev"
+                    "dev-master": "26.0.0-dev"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1297,9 +1296,9 @@
             "description": "Composer package containing Nextcloud's public API (classes, interfaces)",
             "support": {
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
-                "source": "https://github.com/nextcloud-deps/ocp/tree/stable27"
+                "source": "https://github.com/nextcloud-deps/ocp/tree/stable26"
             },
-            "time": "2024-03-05T00:31:26+00:00"
+            "time": "2024-01-03T00:33:21+00:00"
         },
         {
             "name": "php-cs-fixer/shim",
@@ -1403,76 +1402,23 @@
             "time": "2021-02-03T23:26:27+00:00"
         },
         {
-            "name": "psr/clock",
-            "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/clock.git",
-                "reference": "e41a24703d4560fd0acb709162f73b8adfc3aa0d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/clock/zipball/e41a24703d4560fd0acb709162f73b8adfc3aa0d",
-                "reference": "e41a24703d4560fd0acb709162f73b8adfc3aa0d",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.0 || ^8.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Clock\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interface for reading the clock.",
-            "homepage": "https://github.com/php-fig/clock",
-            "keywords": [
-                "clock",
-                "now",
-                "psr",
-                "psr-20",
-                "time"
-            ],
-            "support": {
-                "issues": "https://github.com/php-fig/clock/issues",
-                "source": "https://github.com/php-fig/clock/tree/1.0.0"
-            },
-            "time": "2022-11-25T14:36:26+00:00"
-        },
-        {
             "name": "psr/container",
-            "version": "2.0.2",
+            "version": "1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/container.git",
-                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963"
+                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/c71ecc56dfe541dbd90c5360474fbc405f8d5963",
-                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/513e0666f7216c7459170d56df27dfcefe1689ea",
+                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.4.0"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Psr\\Container\\": "src/"
@@ -1499,9 +1445,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-fig/container/issues",
-                "source": "https://github.com/php-fig/container/tree/2.0.2"
+                "source": "https://github.com/php-fig/container/tree/1.1.2"
             },
-            "time": "2021-11-05T16:47:00+00:00"
+            "time": "2021-11-05T16:50:12+00:00"
         },
         {
             "name": "psr/log",
@@ -1566,5 +1512,5 @@
     "platform-overrides": {
         "php": "8.0"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/lib/Controller/AdminController.php
+++ b/lib/Controller/AdminController.php
@@ -28,7 +28,6 @@ namespace OCA\Polls\Controller;
 use OCA\Polls\AppConstants;
 use OCA\Polls\Db\UserMapper;
 use OCA\Polls\Service\PollService;
-use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\Collaboration\Resources\LoadAdditionalScriptsEvent;
@@ -52,7 +51,9 @@ class AdminController extends BaseController {
 		parent::__construct($appName, $request);
 	}
 
-	#[NoCSRFRequired]
+	/**
+	 * @NoCSRFRequired
+	 */
 	public function index(): TemplateResponse {
 		Util::addScript(AppConstants::APP_ID, 'polls-main');
 		$this->eventDispatcher->dispatchTyped(new LoadAdditionalScriptsEvent());

--- a/lib/Controller/BaseApiController.php
+++ b/lib/Controller/BaseApiController.php
@@ -50,8 +50,8 @@ class BaseApiController extends ApiController {
 
 	/**
 	 * response
+	 * @NoAdminRequired
 	 */
-	#[NoAdminRequired]
 	protected function response(Closure $callback): JSONResponse {
 		try {
 			return new JSONResponse($callback(), Http::STATUS_OK);
@@ -62,8 +62,8 @@ class BaseApiController extends ApiController {
 
 	/**
 	 * response
+	 * @NoAdminRequired
 	 */
-	#[NoAdminRequired]
 	protected function responseLong(Closure $callback): JSONResponse {
 		try {
 			return new JSONResponse($callback(), Http::STATUS_OK);
@@ -74,8 +74,8 @@ class BaseApiController extends ApiController {
 
 	/**
 	 * responseCreate
+	 * @NoAdminRequired
 	 */
-	#[NoAdminRequired]
 	protected function responseCreate(Closure $callback): JSONResponse {
 		try {
 			return new JSONResponse($callback(), Http::STATUS_CREATED);

--- a/lib/Controller/BaseController.php
+++ b/lib/Controller/BaseController.php
@@ -48,8 +48,8 @@ class BaseController extends Controller {
 
 	/**
 	 * response
+	 * @NoAdminRequired
 	 */
-	#[NoAdminRequired]
 	protected function response(Closure $callback): JSONResponse {
 		try {
 			return new JSONResponse($callback(), Http::STATUS_OK);
@@ -60,8 +60,8 @@ class BaseController extends Controller {
 
 	/**
 	 * response
+	 * @NoAdminRequired
 	 */
-	#[NoAdminRequired]
 	protected function responseLong(Closure $callback): JSONResponse {
 		try {
 			return new JSONResponse($callback(), Http::STATUS_OK);
@@ -72,8 +72,8 @@ class BaseController extends Controller {
 
 	/**
 	 * responseCreate
+	 * @NoAdminRequired
 	 */
-	#[NoAdminRequired]
 	protected function responseCreate(Closure $callback): JSONResponse {
 		try {
 			return new JSONResponse($callback(), Http::STATUS_CREATED);
@@ -84,8 +84,8 @@ class BaseController extends Controller {
 
 	/**
 	 * responseDeleteTolerant
+	 * @NoAdminRequired
 	 */
-	#[NoAdminRequired]
 	protected function responseDeleteTolerant(Closure $callback): JSONResponse {
 		try {
 			return new JSONResponse($callback(), Http::STATUS_OK);

--- a/lib/Controller/BasePublicController.php
+++ b/lib/Controller/BasePublicController.php
@@ -32,7 +32,6 @@ use OCA\Polls\Exceptions\NoUpdatesException;
 use OCA\Polls\Model\Acl;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
-use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 use OCP\ISession;
@@ -52,8 +51,8 @@ class BasePublicController extends Controller {
 
 	/**
 	 * response
+	 * @NoAdminRequired
 	 */
-	#[NoAdminRequired]
 	protected function response(Closure $callback, string $token): JSONResponse {
 		$this->updateSessionToken($token);
 
@@ -66,8 +65,8 @@ class BasePublicController extends Controller {
 
 	/**
 	 * response
+	 * @NoAdminRequired
 	 */
-	#[NoAdminRequired]
 	protected function responseLong(Closure $callback, string $token): JSONResponse {
 		$this->updateSessionToken($token);
 
@@ -79,8 +78,8 @@ class BasePublicController extends Controller {
 	}
 	/**
 	 * responseCreate
+	 * @NoAdminRequired
 	 */
-	#[NoAdminRequired]
 	protected function responseCreate(Closure $callback, string $token): JSONResponse {
 		$this->updateSessionToken($token);
 

--- a/lib/Controller/CommentApiController.php
+++ b/lib/Controller/CommentApiController.php
@@ -26,9 +26,6 @@ declare(strict_types=1);
 namespace OCA\Polls\Controller;
 
 use OCA\Polls\Service\CommentService;
-use OCP\AppFramework\Http\Attribute\CORS;
-use OCP\AppFramework\Http\Attribute\NoAdminRequired;
-use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 
@@ -46,10 +43,10 @@ class CommentApiController extends BaseApiController {
 
 	/**
 	 * Read all comments of a poll based on the poll id and return list as array
+	 * @NoAdminRequired
+	 * @CORS
+	 * @NoCSRFRequired
 	 */
-	#[CORS]
-	#[NoAdminRequired]
-	#[NoCSRFRequired]
 	public function list(int $pollId): JSONResponse {
 		return $this->response(fn () => [
 			'comments' => $this->commentService->list($pollId)
@@ -58,10 +55,10 @@ class CommentApiController extends BaseApiController {
 
 	/**
 	 * Add comment
+	 * @NoAdminRequired
+	 * @CORS
+	 * @NoCSRFRequired
 	 */
-	#[CORS]
-	#[NoAdminRequired]
-	#[NoCSRFRequired]
 	public function add(int $pollId, string $comment): JSONResponse {
 		return $this->response(fn () => [
 			'comment' => $this->commentService->add($comment, $pollId)
@@ -70,10 +67,10 @@ class CommentApiController extends BaseApiController {
 
 	/**
 	 * Delete comment
+	 * @NoAdminRequired
+	 * @CORS
+	 * @NoCSRFRequired
 	 */
-	#[CORS]
-	#[NoAdminRequired]
-	#[NoCSRFRequired]
 	public function delete(int $commentId): JSONResponse {
 		$comment = $this->commentService->get($commentId);
 
@@ -83,10 +80,10 @@ class CommentApiController extends BaseApiController {
 
 	/**
 	 * Restore comment
+	 * @NoAdminRequired
+	 * @CORS
+	 * @NoCSRFRequired
 	 */
-	#[CORS]
-	#[NoAdminRequired]
-	#[NoCSRFRequired]
 	public function restore(int $commentId): JSONResponse {
 		$comment = $this->commentService->get($commentId);
 

--- a/lib/Controller/CommentController.php
+++ b/lib/Controller/CommentController.php
@@ -26,7 +26,6 @@ declare(strict_types=1);
 namespace OCA\Polls\Controller;
 
 use OCA\Polls\Service\CommentService;
-use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 
@@ -44,8 +43,8 @@ class CommentController extends BaseController {
 
 	/**
 	 * Write a new comment to the db and returns the new comment as array
+	 * @NoAdminRequired
 	 */
-	#[NoAdminRequired]
 	public function list(int $pollId): JSONResponse {
 		return $this->response(fn () => [
 			'comments' => $this->commentService->list($pollId)
@@ -54,8 +53,8 @@ class CommentController extends BaseController {
 
 	/**
 	 * Write a new comment to the db and returns the new comment as array
+	 * @NoAdminRequired
 	 */
-	#[NoAdminRequired]
 	public function add(int $pollId, string $message): JSONResponse {
 		return $this->response(fn () => [
 			'comment' => $this->commentService->add($message, $pollId)
@@ -64,8 +63,8 @@ class CommentController extends BaseController {
 
 	/**
 	 * Delete Comment
+	 * @NoAdminRequired
 	 */
-	#[NoAdminRequired]
 	public function delete(int $commentId): JSONResponse {
 		$comment = $this->commentService->get($commentId);
 
@@ -76,8 +75,8 @@ class CommentController extends BaseController {
 
 	/**
 	 * Restore deleted Comment
+	 * @NoAdminRequired
 	 */
-	#[NoAdminRequired]
 	public function restore(int $commentId): JSONResponse {
 		$comment = $this->commentService->get($commentId);
 

--- a/lib/Controller/OptionApiController.php
+++ b/lib/Controller/OptionApiController.php
@@ -26,9 +26,6 @@ declare(strict_types=1);
 namespace OCA\Polls\Controller;
 
 use OCA\Polls\Service\OptionService;
-use OCP\AppFramework\Http\Attribute\CORS;
-use OCP\AppFramework\Http\Attribute\NoAdminRequired;
-use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 
@@ -46,20 +43,20 @@ class OptionApiController extends BaseApiController {
 
 	/**
 	 * Get all options of given poll
+	 * @NoAdminRequired
+	 * @CORS
+	 * @NoCSRFRequired
 	 */
-	#[CORS]
-	#[NoAdminRequired]
-	#[NoCSRFRequired]
 	public function list(int $pollId): JSONResponse {
 		return $this->response(fn () => ['options' => $this->optionService->list($pollId)]);
 	}
 
 	/**
 	 * Add a new option
+	 * @NoAdminRequired
+	 * @CORS
+	 * @NoCSRFRequired
 	 */
-	#[CORS]
-	#[NoAdminRequired]
-	#[NoCSRFRequired]
 	public function add(int $pollId, int $timestamp = 0, string $pollOptionText = '', int $duration = 0): JSONResponse {
 		return $this->responseCreate(fn () => ['option' => $this->optionService->add($pollId, $timestamp, $pollOptionText, $duration)]);
 	}
@@ -67,50 +64,50 @@ class OptionApiController extends BaseApiController {
 
 	/**
 	 * Update option
+	 * @NoAdminRequired
+	 * @CORS
+	 * @NoCSRFRequired
 	 */
-	#[CORS]
-	#[NoAdminRequired]
-	#[NoCSRFRequired]
 	public function update(int $optionId, int $timestamp = 0, string $pollOptionText = '', int $duration = 0): JSONResponse {
 		return $this->response(fn () => ['option' => $this->optionService->update($optionId, $timestamp, $pollOptionText, $duration)]);
 	}
 
 	/**
 	 * Delete option
+	 * @NoAdminRequired
+	 * @CORS
+	 * @NoCSRFRequired
 	 */
-	#[CORS]
-	#[NoAdminRequired]
-	#[NoCSRFRequired]
 	public function delete(int $optionId): JSONResponse {
 		return $this->response(fn () => ['option' => $this->optionService->delete($optionId)]);
 	}
 
 	/**
 	 * Restore option
+	 * @NoAdminRequired
+	 * @CORS
+	 * @NoCSRFRequired
 	 */
-	#[CORS]
-	#[NoAdminRequired]
-	#[NoCSRFRequired]
 	public function restore(int $optionId): JSONResponse {
 		return $this->response(fn () => ['option' => $this->optionService->delete($optionId, true)]);
 	}
 
 	/**
 	 * Switch option confirmation
+	 * @NoAdminRequired
+	 * @CORS
+	 * @NoCSRFRequired
 	 */
-	#[CORS]
-	#[NoAdminRequired]
-	#[NoCSRFRequired]
 	public function confirm(int $optionId): JSONResponse {
 		return $this->response(fn () => ['option' => $this->optionService->confirm($optionId)]);
 	}
 
 	/**
 	 * Set order position for option
+	 * @NoAdminRequired
+	 * @CORS
+	 * @NoCSRFRequired
 	 */
-	#[CORS]
-	#[NoAdminRequired]
-	#[NoCSRFRequired]
 	public function setOrder(int $optionId, int $order): JSONResponse {
 		return $this->response(fn () => ['option' => $this->optionService->setOrder($optionId, $order)]);
 	}

--- a/lib/Controller/OptionController.php
+++ b/lib/Controller/OptionController.php
@@ -27,7 +27,6 @@ namespace OCA\Polls\Controller;
 
 use OCA\Polls\Service\CalendarService;
 use OCA\Polls\Service\OptionService;
-use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 
@@ -46,8 +45,8 @@ class OptionController extends BaseController {
 
 	/**
 	 * Get all options of given poll
+	 * @NoAdminRequired
 	 */
-	#[NoAdminRequired]
 	public function list(int $pollId): JSONResponse {
 		return $this->response(function () use ($pollId) {
 			return ['options' => $this->optionService->list($pollId)];
@@ -56,80 +55,80 @@ class OptionController extends BaseController {
 
 	/**
 	 * Add a new option
+	 * @NoAdminRequired
 	 */
-	#[NoAdminRequired]
 	public function add(int $pollId, int $timestamp = 0, string $text = '', int $duration = 0): JSONResponse {
 		return $this->responseCreate(fn () => ['option' => $this->optionService->add($pollId, $timestamp, $text, $duration)]);
 	}
 	
 	/**
 	 * Add mulitple new option
+	 * @NoAdminRequired
 	 */
-	#[NoAdminRequired]
 	public function addBulk(int $pollId, string $text = ''): JSONResponse {
 		return $this->responseCreate(fn () => ['options' => $this->optionService->addBulk($pollId, $text)]);
 	}
 
 	/**
 	 * Update option
+	 * @NoAdminRequired
 	 */
-	#[NoAdminRequired]
 	public function update(int $optionId, int $timestamp, string $text, int $duration): JSONResponse {
 		return $this->response(fn () => ['option' => $this->optionService->update($optionId, $timestamp, $text, $duration)]);
 	}
 
 	/**
 	 * Delete option
+	 * @NoAdminRequired
 	 */
-	#[NoAdminRequired]
 	public function delete(int $optionId): JSONResponse {
 		return $this->response(fn () => ['option' => $this->optionService->delete($optionId)]);
 	}
 
 	/**
 	 * Restore option
+	 * @NoAdminRequired
 	 */
-	#[NoAdminRequired]
 	public function restore(int $optionId): JSONResponse {
 		return $this->response(fn () => ['option' => $this->optionService->delete($optionId, true)]);
 	}
 
 	/**
 	 * Switch option confirmation
+	 * @NoAdminRequired
 	 */
-	#[NoAdminRequired]
 	public function confirm(int $optionId): JSONResponse {
 		return $this->response(fn () => ['option' => $this->optionService->confirm($optionId)]);
 	}
 
 	/**
 	 * Reorder options
+	 * @NoAdminRequired
 	 */
-	#[NoAdminRequired]
 	public function reorder(int $pollId, array $options): JSONResponse {
 		return $this->response(fn () => ['options' => $this->optionService->reorder($pollId, $options)]);
 	}
 
 	/**
 	 * Reorder options
+	 * @NoAdminRequired
 	 */
-	#[NoAdminRequired]
 	public function sequence(int $optionId, int $step, string $unit, int $amount): JSONResponse {
 		return $this->response(fn () => ['options' => $this->optionService->sequence($optionId, $step, $unit, $amount)]);
 	}
 
 	/**
 	 * Reorder options
+	 * @NoAdminRequired
 	 */
-	#[NoAdminRequired]
 	public function shift(int $pollId, int $step, string $unit): JSONResponse {
 		return $this->response(fn () => ['options' => $this->optionService->shift($pollId, $step, $unit)]);
 	}
 
 	/**
 	 * findCalendarEvents
+	 * @NoAdminRequired
 	 */
-	#[NoAdminRequired]
 	public function findCalendarEvents(int $optionId, string $tz): JSONResponse {
 		return $this->response(fn () => ['events' => $this->calendarService->getEvents($optionId)]);
 	}

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -29,8 +29,6 @@ namespace OCA\Polls\Controller;
 use OCA\Polls\AppConstants;
 use OCA\Polls\Service\NotificationService;
 use OCP\AppFramework\Controller;
-use OCP\AppFramework\Http\Attribute\NoAdminRequired;
-use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\Collaboration\Resources\LoadAdditionalScriptsEvent;
 use OCP\EventDispatcher\IEventDispatcher;
@@ -52,17 +50,20 @@ class PageController extends Controller {
 		parent::__construct($appName, $request);
 	}
 
-
-	#[NoAdminRequired]
-	#[NoCSRFRequired]
+	/**
+	 * @NoAdminRequired
+	 * @NoCSRFRequired
+	 */
 	public function index(): TemplateResponse {
 		Util::addScript(AppConstants::APP_ID, 'polls-main');
 		$this->eventDispatcher->dispatchTyped(new LoadAdditionalScriptsEvent());
 		return new TemplateResponse(AppConstants::APP_ID, 'main');
 	}
 
-	#[NoAdminRequired]
-	#[NoCSRFRequired]
+	/**
+	 * @NoAdminRequired
+	 * @NoCSRFRequired
+	 */
 	public function vote(int $id): TemplateResponse {
 		$this->notificationService->removeNotification($id);
 		Util::addScript(AppConstants::APP_ID, 'polls-main');

--- a/lib/Controller/PollApiController.php
+++ b/lib/Controller/PollApiController.php
@@ -31,9 +31,6 @@ use OCA\Polls\Model\Acl;
 use OCA\Polls\Service\PollService;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Http;
-use OCP\AppFramework\Http\Attribute\CORS;
-use OCP\AppFramework\Http\Attribute\NoAdminRequired;
-use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 
@@ -52,10 +49,10 @@ class PollApiController extends BaseApiController {
 
 	/**
 	 * Get list of polls
+	 * @NoAdminRequired
+	 * @CORS
+	 * @NoCSRFRequired
 	 */
-	#[CORS]
-	#[NoAdminRequired]
-	#[NoCSRFRequired]
 	public function list(): JSONResponse {
 		try {
 			return new JSONResponse([AppConstants::APP_ID => $this->pollService->list()], Http::STATUS_OK);
@@ -68,10 +65,10 @@ class PollApiController extends BaseApiController {
 
 	/**
 	 * get poll configuration
+	 * @NoAdminRequired
+	 * @CORS
+	 * @NoCSRFRequired
 	 */
-	#[CORS]
-	#[NoAdminRequired]
-	#[NoCSRFRequired]
 	public function get(int $pollId): JSONResponse {
 		try {
 			return new JSONResponse(['poll' => $this->pollService->get($pollId)], Http::STATUS_OK);
@@ -84,10 +81,10 @@ class PollApiController extends BaseApiController {
 
 	/**
 	 * Add poll
+	 * @NoAdminRequired
+	 * @NoCSRFRequired
+	 * @CORS
 	 */
-	#[CORS]
-	#[NoAdminRequired]
-	#[NoCSRFRequired]
 	public function add(string $type, string $title): JSONResponse {
 		try {
 			return new JSONResponse(['poll' => $this->pollService->add($type, $title)], Http::STATUS_CREATED);
@@ -98,10 +95,10 @@ class PollApiController extends BaseApiController {
 
 	/**
 	 * Update poll configuration
+	 * @NoAdminRequired
+	 * @CORS
+	 * @NoCSRFRequired
 	 */
-	#[CORS]
-	#[NoAdminRequired]
-	#[NoCSRFRequired]
 	public function update(int $pollId, array $poll): JSONResponse {
 		try {
 			$this->acl->setPollId($pollId, Acl::PERMISSION_POLL_EDIT);
@@ -119,10 +116,10 @@ class PollApiController extends BaseApiController {
 
 	/**
 	 * Switch deleted status (move to deleted polls)
+	 * @NoAdminRequired
+	 * @CORS
+	 * @NoCSRFRequired
 	 */
-	#[CORS]
-	#[NoAdminRequired]
-	#[NoCSRFRequired]
 	public function toggleArchive(int $pollId): JSONResponse {
 		try {
 			return new JSONResponse(['poll' => $this->pollService->toggleArchive($pollId)], Http::STATUS_OK);
@@ -135,10 +132,10 @@ class PollApiController extends BaseApiController {
 
 	/**
 	 * Close poll
+	 * @NoAdminRequired
+	 * @CORS
+	 * @NoCSRFRequired
 	 */
-	#[CORS]
-	#[NoAdminRequired]
-	#[NoCSRFRequired]
 	public function close(int $pollId): JSONResponse {
 		try {
 			return new JSONResponse(['poll' => $this->pollService->close($pollId)], Http::STATUS_OK);
@@ -151,10 +148,10 @@ class PollApiController extends BaseApiController {
 
 	/**
 	 * Reopen poll
+	 * @NoAdminRequired
+	 * @CORS
+	 * @NoCSRFRequired
 	 */
-	#[CORS]
-	#[NoAdminRequired]
-	#[NoCSRFRequired]
 	public function reopen(int $pollId): JSONResponse {
 		try {
 			return new JSONResponse(['poll' => $this->pollService->reopen($pollId)], Http::STATUS_OK);
@@ -167,10 +164,10 @@ class PollApiController extends BaseApiController {
 
 	/**
 	 * Delete poll
+	 * @NoAdminRequired
+	 * @CORS
+	 * @NoCSRFRequired
 	 */
-	#[CORS]
-	#[NoAdminRequired]
-	#[NoCSRFRequired]
 	public function delete(int $pollId): JSONResponse {
 		try {
 			return new JSONResponse(['poll' => $this->pollService->delete($pollId)], Http::STATUS_OK);
@@ -183,10 +180,10 @@ class PollApiController extends BaseApiController {
 
 	/**
 	 * Clone poll
+	 * @NoAdminRequired
+	 * @CORS
+	 * @NoCSRFRequired
 	 */
-	#[CORS]
-	#[NoAdminRequired]
-	#[NoCSRFRequired]
 	public function clone(int $pollId): JSONResponse {
 		try {
 			return new JSONResponse(['poll' => $this->pollService->clone($pollId)], Http::STATUS_CREATED);
@@ -199,11 +196,11 @@ class PollApiController extends BaseApiController {
 
 	/**
 	 * Transfer all polls from one user to another (change owner of poll)
+	 * @CORS
+	 * @NoCSRFRequired
 	 * @param string $sourceUser User to transfer polls from
 	 * @param string $destinationUser User to transfer polls to
 	 */
-	#[CORS]
-	#[NoCSRFRequired]
 	public function transferPolls(string $sourceUser, string $destinationUser): JSONResponse {
 		try {
 			return new JSONResponse(['transferred' => $this->pollService->transferPolls($sourceUser, $destinationUser)], Http::STATUS_CREATED);
@@ -214,11 +211,11 @@ class PollApiController extends BaseApiController {
 
 	/**
 	 * Transfer singe poll to another user (change owner of poll)
+	 * @CORS
+	 * @NoCSRFRequired
 	 * @param int $pollId Poll to transfer
 	 * @param string $destinationUser User to transfer the poll to
 	 */
-	#[CORS]
-	#[NoCSRFRequired]
 	public function transferPoll(int $pollId, string $destinationUser): JSONResponse {
 		try {
 			return new JSONResponse(['transferred' => $this->pollService->transferPoll($pollId, $destinationUser)], Http::STATUS_CREATED);
@@ -229,10 +226,10 @@ class PollApiController extends BaseApiController {
 
 	/**
 	 * Collect email addresses from particitipants
+	 * @NoAdminRequired
+	 * @CORS
+	 * @NoCSRFRequired
 	 */
-	#[CORS]
-	#[NoAdminRequired]
-	#[NoCSRFRequired]
 	public function getParticipantsEmailAddresses(int $pollId): JSONResponse {
 		try {
 			return new JSONResponse($this->pollService->getParticipantsEmailAddresses($pollId), Http::STATUS_OK);
@@ -245,10 +242,10 @@ class PollApiController extends BaseApiController {
 
 	/**
 	 * Get valid values for configuration options
+	 * @NoAdminRequired
+	 * @CORS
+	 * @NoCSRFRequired
 	 */
-	#[CORS]
-	#[NoAdminRequired]
-	#[NoCSRFRequired]
 	public function enum(): JSONResponse {
 		return new JSONResponse($this->pollService->getValidEnum(), Http::STATUS_OK);
 	}

--- a/lib/Controller/PollController.php
+++ b/lib/Controller/PollController.php
@@ -33,6 +33,7 @@ use OCA\Polls\Service\OptionService;
 use OCA\Polls\Service\PollService;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
+use OCP\Server;
 
 /**
  * @psalm-api
@@ -55,7 +56,7 @@ class PollController extends BaseController {
 	 */
 	public function list(): JSONResponse {
 		return $this->response(function () {
-			$appSettings = new AppSettings;
+			$appSettings = Server::get(AppSettings::class);
 			return [
 				'list' => $this->pollService->list(),
 				'pollCreationAllowed' => $appSettings->getPollCreationAllowed(),

--- a/lib/Controller/PollController.php
+++ b/lib/Controller/PollController.php
@@ -31,7 +31,6 @@ use OCA\Polls\Model\Settings\AppSettings;
 use OCA\Polls\Service\MailService;
 use OCA\Polls\Service\OptionService;
 use OCA\Polls\Service\PollService;
-use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 
@@ -52,8 +51,8 @@ class PollController extends BaseController {
 
 	/**
 	 * Get list of polls
+	 * @NoAdminRequired
 	 */
-	#[NoAdminRequired]
 	public function list(): JSONResponse {
 		return $this->response(function () {
 			$appSettings = new AppSettings;
@@ -67,8 +66,8 @@ class PollController extends BaseController {
 
 	/**
 	 * get complete poll
+	 * @NoAdminRequired
 	 */
-	#[NoAdminRequired]
 	public function get(int $pollId): JSONResponse {
 		$poll = $this->pollService->get($pollId);
 		$this->acl->setPollId($pollId);
@@ -80,16 +79,16 @@ class PollController extends BaseController {
 
 	/**
 	 * Add poll
+	 * @NoAdminRequired
 	 */
-	#[NoAdminRequired]
 	public function add(string $type, string $title): JSONResponse {
 		return $this->responseCreate(fn () => $this->pollService->add($type, $title));
 	}
 
 	/**
 	 * Update poll configuration
+	 * @NoAdminRequired
 	 */
-	#[NoAdminRequired]
 	public function update(int $pollId, array $poll): JSONResponse {
 		$this->acl->setPollId($pollId, Acl::PERMISSION_POLL_EDIT);
 		return $this->response(fn () => [
@@ -100,8 +99,8 @@ class PollController extends BaseController {
 
 	/**
 	 * Send confirmation mails
+	 * @NoAdminRequired
 	 */
-	#[NoAdminRequired]
 	public function sendConfirmation(int $pollId): JSONResponse {
 		$this->acl->setPollId($pollId, Acl::PERMISSION_POLL_EDIT);
 		return $this->response(fn () => [
@@ -111,16 +110,16 @@ class PollController extends BaseController {
 
 	/**
 	 * Switch deleted status (move to deleted polls)
+	 * @NoAdminRequired
 	 */
-	#[NoAdminRequired]
 	public function toggleArchive(int $pollId): JSONResponse {
 		return $this->response(fn () => $this->pollService->toggleArchive($pollId));
 	}
 
 	/**
 	 * Delete poll
+	 * @NoAdminRequired
 	 */
-	#[NoAdminRequired]
 
 	public function delete(int $pollId): JSONResponse {
 		return $this->responseDeleteTolerant(fn () => $this->pollService->delete($pollId));
@@ -128,8 +127,8 @@ class PollController extends BaseController {
 
 	/**
 	 * Close poll
+	 * @NoAdminRequired
 	 */
-	#[NoAdminRequired]
 	public function close(int $pollId): JSONResponse {
 		return $this->response(fn () => [
 			'poll' => $this->pollService->close($pollId),
@@ -139,8 +138,8 @@ class PollController extends BaseController {
 
 	/**
 	 * Reopen poll
+	 * @NoAdminRequired
 	 */
-	#[NoAdminRequired]
 	public function reopen(int $pollId): JSONResponse {
 		return $this->response(fn () => [
 			'poll' => $this->pollService->reopen($pollId),
@@ -150,8 +149,8 @@ class PollController extends BaseController {
 
 	/**
 	 * Clone poll
+	 * @NoAdminRequired
 	 */
-	#[NoAdminRequired]
 	public function clone(int $pollId): JSONResponse {
 		return $this->response(fn () => $this->clonePoll($pollId));
 	}
@@ -171,8 +170,8 @@ class PollController extends BaseController {
 
 	/**
 	 * Collect email addresses from particitipants
+	 * @NoAdminRequired
 	 */
-	#[NoAdminRequired]
 	public function getParticipantsEmailAddresses(int $pollId): JSONResponse {
 		return $this->response(fn () => $this->pollService->getParticipantsEmailAddresses($pollId));
 	}

--- a/lib/Controller/PreferencesController.php
+++ b/lib/Controller/PreferencesController.php
@@ -29,8 +29,6 @@ use OCA\Polls\Db\UserMapper;
 use OCA\Polls\Service\CalendarService;
 use OCA\Polls\Service\PreferencesService;
 use OCP\AppFramework\Http;
-use OCP\AppFramework\Http\Attribute\NoAdminRequired;
-use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 
@@ -50,17 +48,17 @@ class PreferencesController extends BaseController {
 
 	/**
 	 * Read all preferences
+	 * @NoAdminRequired
+	 * @NoCSRFRequired
 	 */
-	#[NoAdminRequired]
-	#[NoCSRFRequired]
 	public function get(): JSONResponse {
 		return $this->response(fn () => $this->preferencesService->get());
 	}
 
 	/**
 	 * Write preferences
+	 * @NoAdminRequired
 	 */
-	#[NoAdminRequired]
 	public function write(array $preferences): JSONResponse {
 		if (!$this->userMapper->getCurrentUser()->getIsLoggedIn()) {
 			return new JSONResponse([], Http::STATUS_OK);
@@ -70,9 +68,9 @@ class PreferencesController extends BaseController {
 
 	/**
 	 * Read all preferences
+	 * @NoAdminRequired
+	 * @NoCSRFRequired
 	 */
-	#[NoAdminRequired]
-	#[NoCSRFRequired]
 	public function getCalendars(): JSONResponse {
 		return new JSONResponse(['calendars' => $this->calendarService->getCalendars()], Http::STATUS_OK);
 	}

--- a/lib/Controller/PublicController.php
+++ b/lib/Controller/PublicController.php
@@ -35,8 +35,6 @@ use OCA\Polls\Service\SubscriptionService;
 use OCA\Polls\Service\SystemService;
 use OCA\Polls\Service\VoteService;
 use OCA\Polls\Service\WatchService;
-use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
-use OCP\AppFramework\Http\Attribute\PublicPage;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Http\Template\PublicTemplateResponse;
 use OCP\AppFramework\Http\TemplateResponse;
@@ -70,10 +68,10 @@ class PublicController extends BasePublicController {
 	}
 
 	/**
+	 * @NoCSRFRequired
+	 * @PublicPage
 	 * @return TemplateResponse|PublicTemplateResponse
 	 */
-	#[PublicPage]
-	#[NoCSRFRequired]
 	public function votePage(string $token) {
 		Util::addScript(AppConstants::APP_ID, 'polls-main');
 		if ($this->userSession->isLoggedIn()) {
@@ -87,8 +85,8 @@ class PublicController extends BasePublicController {
 
 	/**
 	 * get complete poll via token
+	 * @PublicPage
 	 */
-	#[PublicPage]
 	public function getPoll(string $token): JSONResponse {
 		$this->acl->request(Acl::PERMISSION_POLL_VIEW);
 
@@ -101,8 +99,8 @@ class PublicController extends BasePublicController {
 
 	/**
 	 * Watch poll for updates
+	 * @PublicPage
 	 */
-	#[PublicPage]
 	public function watchPoll(string $token, ?int $offset): JSONResponse {
 		return $this->responseLong(fn () => [
 			'updates' => $this->watchService->watchUpdates(offset: $offset)
@@ -111,8 +109,8 @@ class PublicController extends BasePublicController {
 
 	/**
 	 * Get share
+	 * @PublicPage
 	 */
-	#[PublicPage]
 	public function getShare(string $token): JSONResponse {
 		return $this->response(fn () => [
 			'share' => $this->shareService->request($token)
@@ -121,8 +119,8 @@ class PublicController extends BasePublicController {
 
 	/**
 	 * Get votes
+	 * @PublicPage
 	 */
-	#[PublicPage]
 	public function getVotes(string $token): JSONResponse {
 		return $this->response(fn () => [
 			'votes' => $this->voteService->list()
@@ -131,8 +129,8 @@ class PublicController extends BasePublicController {
 
 	/**
 	 * Delete current user's votes
+	 * @PublicPage
 	 */
-	#[PublicPage]
 	public function deleteUser(string $token): JSONResponse {
 		return $this->response(fn () => [
 			'deleted' => $this->voteService->delete()
@@ -141,8 +139,8 @@ class PublicController extends BasePublicController {
 
 	/**
 	 * Delete current user's orphaned votes
+	 * @PublicPage
 	 */
-	#[PublicPage]
 	public function deleteOrphanedVotes(string $token): JSONResponse {
 		return $this->response(fn () => [
 			'deleted' => $this->voteService->delete(deleteOnlyOrphaned: true)
@@ -151,8 +149,8 @@ class PublicController extends BasePublicController {
 
 	/**
 	 * Get options
+	 * @PublicPage
 	 */
-	#[PublicPage]
 	public function getOptions(string $token): JSONResponse {
 		return $this->response(fn () => [
 			'options' => $this->optionService->list()
@@ -161,8 +159,8 @@ class PublicController extends BasePublicController {
 
 	/**
 	 * Add options
+	 * @PublicPage
 	 */
-	#[PublicPage]
 	public function addOption(string $token, int $timestamp = 0, string $text = '', int $duration = 0): JSONResponse {
 		return $this->responseCreate(fn () => [
 			'option' => $this->optionService->add(
@@ -175,8 +173,8 @@ class PublicController extends BasePublicController {
 
 	/**
 	 * Delete option
+	 * @PublicPage
 	 */
-	#[PublicPage]
 	public function deleteOption(string $token, int $optionId): JSONResponse {
 		return $this->response(fn () => [
 			'option' => $this->optionService->delete($optionId)
@@ -185,8 +183,8 @@ class PublicController extends BasePublicController {
 
 	/**
 	 * Restore option
+	 * @PublicPage
 	 */
-	#[PublicPage]
 	public function restoreOption(string $token, int $optionId): JSONResponse {
 		return $this->response(fn () => [
 			'option' => $this->optionService->delete($optionId, true)
@@ -195,8 +193,8 @@ class PublicController extends BasePublicController {
 
 	/**
 	 * Set Vote
+	 * @PublicPage
 	 */
-	#[PublicPage]
 	public function setVote(int $optionId, string $setTo, string $token): JSONResponse {
 		return $this->response(fn () => [
 			'vote' => $this->voteService->set($optionId, $setTo)
@@ -205,8 +203,8 @@ class PublicController extends BasePublicController {
 
 	/**
 	 * Get Comments
+	 * @PublicPage
 	 */
-	#[PublicPage]
 	public function getComments(string $token): JSONResponse {
 		return $this->response(fn () => [
 			'comments' => $this->commentService->list()
@@ -215,8 +213,8 @@ class PublicController extends BasePublicController {
 
 	/**
 	 * Write a new comment to the db and returns the new comment as array
+	 * @PublicPage
 	 */
-	#[PublicPage]
 	public function addComment(string $token, string $message): JSONResponse {
 		return $this->response(fn () => [
 			'comment' => $this->commentService->add($message)
@@ -225,8 +223,8 @@ class PublicController extends BasePublicController {
 
 	/**
 	 * Delete Comment
+	 * @PublicPage
 	 */
-	#[PublicPage]
 	public function deleteComment(int $commentId, string $token): JSONResponse {
 		$comment = $this->commentService->get($commentId);
 		return $this->response(fn () => [
@@ -236,8 +234,8 @@ class PublicController extends BasePublicController {
 
 	/**
 	 * Restore deleted Comment
+	 * @PublicPage
 	 */
-	#[PublicPage]
 	public function restoreComment(int $commentId, string $token): JSONResponse {
 		$comment = $this->commentService->get($commentId);
 
@@ -248,8 +246,8 @@ class PublicController extends BasePublicController {
 
 	/**
 	 * Get subscription status
+	 * @PublicPage
 	 */
-	#[PublicPage]
 	public function getSubscription(string $token): JSONResponse {
 		return $this->response(fn () => [
 			'subscribed' => $this->subscriptionService->get()
@@ -258,8 +256,8 @@ class PublicController extends BasePublicController {
 
 	/**
 	 * subscribe
+	 * @PublicPage
 	 */
-	#[PublicPage]
 	public function subscribe(string $token): JSONResponse {
 		return $this->response(fn () => [
 			'subscribed' => $this->subscriptionService->set(true)
@@ -268,8 +266,8 @@ class PublicController extends BasePublicController {
 
 	/**
 	 * Unsubscribe
+	 * @PublicPage
 	 */
-	#[PublicPage]
 	public function unsubscribe(string $token): JSONResponse {
 		return $this->response(fn () => [
 			'subscribed' => $this->subscriptionService->set(false)
@@ -279,8 +277,8 @@ class PublicController extends BasePublicController {
 	/**
 	 * Validate it the user name is reserved
 	 * return false, if this username already exists as a user or as a participant of the poll
+	 * @PublicPage
 	 */
-	#[PublicPage]
 	public function validatePublicDisplayName(string $displayName, string $token): JSONResponse {
 		return $this->response(fn () => [
 			'name' => $this->systemService->validatePublicUsername($displayName, token: $token)
@@ -289,8 +287,8 @@ class PublicController extends BasePublicController {
 
 	/**
 	 * Validate email address (simple validation)
+	 * @PublicPage
 	 */
-	#[PublicPage]
 	public function validateEmailAddress(string $emailAddress, string $token = ''): JSONResponse {
 		return $this->response(fn () => [
 			'result' => MailService::validateEmailAddress($emailAddress), 'emailAddress' => $emailAddress
@@ -299,8 +297,8 @@ class PublicController extends BasePublicController {
 
 	/**
 	 * Change displayName
+	 * @PublicPage
 	 */
-	#[PublicPage]
 	public function setDisplayName(string $token, string $displayName): JSONResponse {
 		return $this->response(fn () => [
 			'share' => $this->shareService->setDisplayname($displayName, $token)
@@ -310,8 +308,8 @@ class PublicController extends BasePublicController {
 
 	/**
 	 * Set EmailAddress
+	 * @PublicPage
 	 */
-	#[PublicPage]
 	public function setEmailAddress(string $token, string $emailAddress = ''): JSONResponse {
 		return $this->response(fn () => [
 			'share' => $this->shareService->setEmailAddress($this->shareService->get($token), $emailAddress)
@@ -320,8 +318,8 @@ class PublicController extends BasePublicController {
 
 	/**
 	 * Set EmailAddress
+	 * @PublicPage
 	 */
-	#[PublicPage]
 	public function deleteEmailAddress(string $token): JSONResponse {
 		return $this->response(fn () => [
 			'share' => $this->shareService->deleteEmailAddress($this->shareService->get($token))
@@ -331,8 +329,8 @@ class PublicController extends BasePublicController {
 	/**
 	 * Create a personal share from a public share
 	 * or update an email share with the username
+	 * @PublicPage
 	 */
-	#[PublicPage]
 	public function register(string $token, string $displayName, string $emailAddress = '', string $timeZone = ''): JSONResponse {
 		return $this->responseCreate(fn () => [
 			'share' => $this->shareService->register($token, $displayName, $emailAddress, $timeZone),
@@ -342,8 +340,8 @@ class PublicController extends BasePublicController {
 	/**
 	 * Sent invitation mails for a share
 	 * Additionally send notification via notifications
+	 * @PublicPage
 	 */
-	#[PublicPage]
 	public function resendInvitation(string $token): JSONResponse {
 		$share = $this->shareService->get($token);
 		return $this->response(fn () => [

--- a/lib/Controller/PublicController.php
+++ b/lib/Controller/PublicController.php
@@ -45,6 +45,10 @@ use OCP\IUserSession;
 use OCP\Util;
 
 /**
+ * Always use parent's classe response* methods to make sure, the token gets set correctly.
+ * Requesting the token inside the controller is not possible, because the token is submitted
+ * as a paramter and not known while contruction time
+ * i.e. ACL requests are not valid before calling the response* method
  * @psalm-api
  */
 class PublicController extends BasePublicController {
@@ -88,13 +92,14 @@ class PublicController extends BasePublicController {
 	 * @PublicPage
 	 */
 	public function getPoll(string $token): JSONResponse {
-		$this->acl->request(Acl::PERMISSION_POLL_VIEW);
-
-		// load poll through acl
-		return $this->response(fn () => [
-			'acl' => $this->acl,
-			'poll' => $this->acl->getPoll(),
-		], $token);
+		return $this->response(function () {
+			$this->acl->request(Acl::PERMISSION_POLL_VIEW);
+			// load poll through acl
+			return [
+				'acl' => $this->acl,
+				'poll' => $this->acl->getPoll(),
+			];
+		}, $token);
 	}
 
 	/**

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -26,8 +26,6 @@ declare(strict_types=1);
 namespace OCA\Polls\Controller;
 
 use OCA\Polls\Service\SettingsService;
-use OCP\AppFramework\Http\Attribute\NoAdminRequired;
-use OCP\AppFramework\Http\Attribute\PublicPage;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 
@@ -45,9 +43,9 @@ class SettingsController extends BaseController {
 
 	/**
 	 * Read app settings
+	 * @PublicPage
+	 * @NoAdminRequired
 	 */
-	#[NoAdminRequired]
-	#[PublicPage]
 	public function getAppSettings(): JSONResponse {
 		return $this->response(fn () => ['appSettings' => $this->settingsService->getAppSettings()]);
 	}

--- a/lib/Controller/ShareApiController.php
+++ b/lib/Controller/ShareApiController.php
@@ -27,9 +27,6 @@ namespace OCA\Polls\Controller;
 
 use OCA\Polls\Service\MailService;
 use OCA\Polls\Service\ShareService;
-use OCP\AppFramework\Http\Attribute\CORS;
-use OCP\AppFramework\Http\Attribute\NoAdminRequired;
-use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 
@@ -48,80 +45,80 @@ class ShareApiController extends BaseApiController {
 
 	/**
 	 * Read all shares of a poll based on the poll id and return list as array
+	 * @NoAdminRequired
+	 * @CORS
+	 * @NoCSRFRequired
 	 */
-	#[CORS]
-	#[NoAdminRequired]
-	#[NoCSRFRequired]
 	public function list(int $pollId): JSONResponse {
 		return $this->response(fn () => ['shares' => $this->shareService->list($pollId)]);
 	}
 
 	/**
 	 * Get share by token
+	 * @NoAdminRequired
+	 * @CORS
+	 * @NoCSRFRequired
 	 */
-	#[CORS]
-	#[NoAdminRequired]
-	#[NoCSRFRequired]
 	public function get(string $token): JSONResponse {
 		return $this->response(fn () => ['share' => $this->shareService->get($token)]);
 	}
 
 	/**
 	 * Add share
+	 * @NoAdminRequired
+	 * @CORS
+	 * @NoCSRFRequired
 	 */
-	#[CORS]
-	#[NoAdminRequired]
-	#[NoCSRFRequired]
 	public function add(int $pollId, string $type, string $userId = ''): JSONResponse {
 		return $this->responseCreate(fn () => ['share' => $this->shareService->add($pollId, $type, $userId)]);
 	}
 
 	/**
 	 * Delete share
+	 * @NoAdminRequired
+	 * @CORS
+	 * @NoCSRFRequired
 	 */
-	#[CORS]
-	#[NoAdminRequired]
-	#[NoCSRFRequired]
 	public function delete(string $token): JSONResponse {
 		return $this->response(fn () => ['share' => $this->shareService->delete(token: $token)]);
 	}
 
 	/**
 	 * Delete share
+	 * @NoAdminRequired
+	 * @CORS
+	 * @NoCSRFRequired
 	 */
-	#[CORS]
-	#[NoAdminRequired]
-	#[NoCSRFRequired]
 	public function restore(string $token): JSONResponse {
 		return $this->response(fn () => ['share' => $this->shareService->delete(token: $token, restore: true)]);
 	}
 
 	/**
 	 * Lock share
+	 * @NoAdminRequired
+	 * @CORS
+	 * @NoCSRFRequired
 	 */
-	#[CORS]
-	#[NoAdminRequired]
-	#[NoCSRFRequired]
 	public function lock(string $token): JSONResponse {
 		return $this->response(fn () => ['share' => $this->shareService->lock(token: $token)]);
 	}
 
 	/**
 	 * Unlock share
+	 * @NoAdminRequired
+	 * @CORS
+	 * @NoCSRFRequired
 	 */
-	#[CORS]
-	#[NoAdminRequired]
-	#[NoCSRFRequired]
 	public function unlock(string $token): JSONResponse {
 		return $this->response(fn () => ['share' => $this->shareService->lock(token: $token, unlock: true)]);
 	}
 
 	/**
 	 * Sent invitation mails for a share
+	 * @NoAdminRequired
+	 * @CORS
+	 * @NoCSRFRequired
 	 */
-	#[CORS]
-	#[NoAdminRequired]
-	#[NoCSRFRequired]
 	public function sendInvitation(string $token): JSONResponse {
 		$share = $this->shareService->get($token);
 		return $this->response(fn () => [

--- a/lib/Controller/ShareController.php
+++ b/lib/Controller/ShareController.php
@@ -27,7 +27,7 @@ namespace OCA\Polls\Controller;
 
 use OCA\Polls\Db\Share;
 use OCA\Polls\Service\ShareService;
-use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCA\Polls\Service\UserService;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 
@@ -45,32 +45,34 @@ class ShareController extends BaseController {
 
 	/**
 	 * List shares
+	 * @NoAdminRequired
+	 *
+	 * @return JSONResponse
 	 */
-	#[NoAdminRequired]
 	public function list(int $pollId): JSONResponse {
 		return $this->response(fn () => ['shares' => $this->shareService->list($pollId)]);
 	}
 
 	/**
 	 * Add share
+	 * @NoAdminRequired
 	 */
-	#[NoAdminRequired]
 	public function add(int $pollId, string $type, string $userId = '', string $displayName = '', string $emailAddress = ''): JSONResponse {
 		return $this->responseCreate(fn () => ['share' => $this->shareService->add($pollId, $type, $userId, $displayName, $emailAddress)]);
 	}
 
 	/**
 	 * Change the contraints for email addresses in public polls
+	 * @NoAdminRequired
 	 */
-	#[NoAdminRequired]
 	public function setPublicPollEmail(string $token, string $value): JSONResponse {
 		return $this->response(fn () => ['share' => $this->shareService->setPublicPollEmail($token, $value)]);
 	}
 
 	/**
 	 * Change Label of a public share
+	 * @NoAdminRequired
 	 */
-	#[NoAdminRequired]
 	public function setLabel(string $token, string $label = ''): JSONResponse {
 		return $this->response(fn () => [
 			'share' => $this->shareService->setLabel($label, $token)
@@ -79,24 +81,24 @@ class ShareController extends BaseController {
 
 	/**
 	 * Convert poll admin to user
+	 * @NoAdminRequired
 	 */
-	#[NoAdminRequired]
 	public function adminToUser(string $token): JSONResponse {
 		return $this->responseCreate(fn () => ['share' => $this->shareService->setType($token, Share::TYPE_USER)]);
 	}
 
 	/**
 	 * Convert user to poll admin
+	 * @NoAdminRequired
 	 */
-	#[NoAdminRequired]
 	public function userToAdmin(string $token): JSONResponse {
 		return $this->responseCreate(fn () => ['share' => $this->shareService->setType($token, Share::TYPE_ADMIN)]);
 	}
 
 	/**
 	 * Set email address
+	 * @NoAdminRequired
 	 */
-	#[NoAdminRequired]
 	public function setEmailAddress(string $token, string $emailAddress = ''): JSONResponse {
 		return $this->response(fn () => [
 			'share' => $this->shareService->setEmailAddress($this->shareService->get($token),
@@ -106,32 +108,32 @@ class ShareController extends BaseController {
 
 	/**
 	 * Delete share
+	 * @NoAdminRequired
 	 */
-	#[NoAdminRequired]
 	public function delete(string $token): JSONResponse {
 		return $this->response(fn () => ['share' => $this->shareService->delete(token: $token)]);
 	}
 
 	/**
 	 * Delete share
+	 * @NoAdminRequired
 	 */
-	#[NoAdminRequired]
 	public function restore(string $token): JSONResponse {
 		return $this->response(fn () => ['share' => $this->shareService->delete(token: $token, restore: true)]);
 	}
 
 	/**
 	 * Delete or restore share
+	 * @NoAdminRequired
 	 */
-	#[NoAdminRequired]
 	public function lock(string $token): JSONResponse {
 		return $this->response(fn () => ['share' => $this->shareService->lock(token: $token)]);
 	}
 
 	/**
 	 * Lock or unlock share
+	 * @NoAdminRequired
 	 */
-	#[NoAdminRequired]
 	public function unlock(string $token): JSONResponse {
 		return $this->response(fn () => ['share' => $this->shareService->lock(token: $token, unlock: true)]);
 	}
@@ -139,8 +141,8 @@ class ShareController extends BaseController {
 	/**
 	 * Send invitation mails for a share
 	 * Additionally send notification via notifications
+	 * @NoAdminRequired
 	 */
-	#[NoAdminRequired]
 	public function sendInvitation(string $token): JSONResponse {
 		$share = $this->shareService->get($token);
 		return $this->response(fn () => [
@@ -152,8 +154,8 @@ class ShareController extends BaseController {
 	/**
 	 * Send all invitation mails for a share and resolve groups
 	 * Additionally send notification via notifications
+	 * @NoAdminRequired
 	 */
-	#[NoAdminRequired]
 	public function sendAllInvitations(int $pollId): JSONResponse {
 		return $this->response(fn () => [
 			'poll' => $pollId,
@@ -163,8 +165,8 @@ class ShareController extends BaseController {
 
 	/**
 	 * resolve contact group to individual shares
+	 * @NoAdminRequired
 	 */
-	#[NoAdminRequired]
 	public function resolveGroup(string $token): JSONResponse {
 		return $this->response(fn () => [
 			'shares' => $this->shareService->resolveGroup($token)

--- a/lib/Controller/ShareController.php
+++ b/lib/Controller/ShareController.php
@@ -27,7 +27,6 @@ namespace OCA\Polls\Controller;
 
 use OCA\Polls\Db\Share;
 use OCA\Polls\Service\ShareService;
-use OCA\Polls\Service\UserService;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 

--- a/lib/Controller/SubscriptionApiController.php
+++ b/lib/Controller/SubscriptionApiController.php
@@ -28,9 +28,6 @@ namespace OCA\Polls\Controller;
 use OCA\Polls\Exceptions\Exception;
 use OCA\Polls\Service\SubscriptionService;
 use OCP\AppFramework\Http;
-use OCP\AppFramework\Http\Attribute\CORS;
-use OCP\AppFramework\Http\Attribute\NoAdminRequired;
-use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 
@@ -48,10 +45,10 @@ class SubscriptionApiController extends BaseApiController {
 
 	/**
 	 * Get subscription status
+	 * @NoAdminRequired
+	 * @CORS
+	 * @NoCSRFRequired
 	 */
-	#[CORS]
-	#[NoAdminRequired]
-	#[NoCSRFRequired]
 	public function get(int $pollId): JSONResponse {
 		try {
 			return new JSONResponse([
@@ -65,10 +62,10 @@ class SubscriptionApiController extends BaseApiController {
 
 	/**
 	 * Subscribe to poll
+	 * @NoAdminRequired
+	 * @CORS
+	 * @NoCSRFRequired
 	 */
-	#[CORS]
-	#[NoAdminRequired]
-	#[NoCSRFRequired]
 	public function subscribe(int $pollId): JSONResponse {
 		try {
 			$this->subscriptionService->set(true, $pollId);
@@ -83,10 +80,10 @@ class SubscriptionApiController extends BaseApiController {
 
 	/**
 	 * Unsubscribe from poll
+	 * @NoAdminRequired
+	 * @CORS
+	 * @NoCSRFRequired
 	 */
-	#[CORS]
-	#[NoAdminRequired]
-	#[NoCSRFRequired]
 	public function unsubscribe(int $pollId): JSONResponse {
 		try {
 			$this->subscriptionService->set(false, $pollId);

--- a/lib/Controller/SubscriptionController.php
+++ b/lib/Controller/SubscriptionController.php
@@ -26,7 +26,6 @@ declare(strict_types=1);
 namespace OCA\Polls\Controller;
 
 use OCA\Polls\Service\SubscriptionService;
-use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 
@@ -44,8 +43,8 @@ class SubscriptionController extends BaseController {
 
 	/**
 	 * Get subscription status
+	 * @NoAdminRequired
 	 */
-	#[NoAdminRequired]
 	public function get(int $pollId): JSONResponse {
 		return $this->response(fn () => [
 			'subscribed' => $this->subscriptionService->get($pollId)
@@ -54,8 +53,8 @@ class SubscriptionController extends BaseController {
 
 	/**
 	 * subscribe
+	 * @NoAdminRequired
 	 */
-	#[NoAdminRequired]
 	public function subscribe(int $pollId): JSONResponse {
 		return $this->response(fn () => [
 			'subscribed' => $this->subscriptionService->set(true, $pollId)
@@ -64,8 +63,8 @@ class SubscriptionController extends BaseController {
 
 	/**
 	 * Unsubscribe
+	 * @NoAdminRequired
 	 */
-	#[NoAdminRequired]
 	public function unsubscribe(int $pollId): JSONResponse {
 		return $this->response(fn () => [
 			'subscribed' => $this->subscriptionService->set(false, $pollId)

--- a/lib/Controller/SystemController.php
+++ b/lib/Controller/SystemController.php
@@ -27,7 +27,6 @@ namespace OCA\Polls\Controller;
 
 use OCA\Polls\Service\SystemService;
 use OCP\AppFramework\Http;
-use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 
@@ -45,8 +44,8 @@ class SystemController extends BaseController {
 
 	/**
 	 * Get a combined list of NC users, groups and contacts
+	 * @NoAdminRequired
 	 */
-	#[NoAdminRequired]
 	public function userSearch(string $query = ''): JSONResponse {
 		return new JSONResponse(['siteusers' => $this->systemService->getSiteUsersAndGroups(
 			$query)], Http::STATUS_OK);

--- a/lib/Controller/VoteApiController.php
+++ b/lib/Controller/VoteApiController.php
@@ -29,9 +29,6 @@ use OCA\Polls\Exceptions\Exception;
 use OCA\Polls\Service\VoteService;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Http;
-use OCP\AppFramework\Http\Attribute\CORS;
-use OCP\AppFramework\Http\Attribute\NoAdminRequired;
-use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 
@@ -49,10 +46,10 @@ class VoteApiController extends BaseApiController {
 
 	/**
 	 * Read all votes of a poll based on the poll id and return list as array
+	 * @NoAdminRequired
+	 * @CORS
+	 * @NoCSRFRequired
 	 */
-	#[CORS]
-	#[NoAdminRequired]
-	#[NoCSRFRequired]
 	public function list(int $pollId): JSONResponse {
 		try {
 			return new JSONResponse(['votes' => $this->voteService->list($pollId)], Http::STATUS_OK);
@@ -65,10 +62,10 @@ class VoteApiController extends BaseApiController {
 
 	/**
 	 * Set vote answer
+	 * @NoAdminRequired
+	 * @CORS
+	 * @NoCSRFRequired
 	 */
-	#[CORS]
-	#[NoAdminRequired]
-	#[NoCSRFRequired]
 	public function set(int $optionId, string $answer): JSONResponse {
 		try {
 			return new JSONResponse(['vote' => $this->voteService->set($optionId, $answer)], Http::STATUS_OK);

--- a/lib/Controller/VoteController.php
+++ b/lib/Controller/VoteController.php
@@ -26,8 +26,6 @@ declare(strict_types=1);
 namespace OCA\Polls\Controller;
 
 use OCA\Polls\Service\VoteService;
-use OCP\AppFramework\Http\Attribute\NoAdminRequired;
-use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 
@@ -45,33 +43,33 @@ class VoteController extends BaseController {
 
 	/**
 	 * list votes per poll
+	 * @NoAdminRequired
+	 * @NoCSRFRequired
 	 */
-	#[NoAdminRequired]
-	#[NoCSRFRequired]
 	public function list(int $pollId): JSONResponse {
 		return $this->response(fn () => ['votes' => $this->voteService->list($pollId)]);
 	}
 
 	/**
 	 * set vote answer
+	 * @NoAdminRequired
+	 * @NoCSRFRequired
 	 */
-	#[NoAdminRequired]
-	#[NoCSRFRequired]
 	public function set(int $optionId, string $setTo): JSONResponse {
 		return $this->response(fn () => ['vote' => $this->voteService->set($optionId, $setTo)]);
 	}
 
 	/**
 	 * Remove user from poll
+	 * @NoAdminRequired
 	 */
-	#[NoAdminRequired]
 	public function delete(int $pollId, string $userId = ''): JSONResponse {
 		return $this->response(fn () => ['deleted' => $this->voteService->delete($pollId, $userId)]);
 	}
 	/**
 	 * Relete orphaned votes
+	 * @NoAdminRequired
 	 */
-	#[NoAdminRequired]
 	public function deleteOrphaned(int $pollId, string $userId = ''): JSONResponse {
 		return $this->response(fn () => ['deleted' => $this->voteService->delete($pollId, $userId, true)]);
 	}

--- a/lib/Controller/WatchController.php
+++ b/lib/Controller/WatchController.php
@@ -26,8 +26,6 @@ declare(strict_types=1);
 namespace OCA\Polls\Controller;
 
 use OCA\Polls\Service\WatchService;
-use OCP\AppFramework\Http\Attribute\NoAdminRequired;
-use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 
@@ -45,9 +43,9 @@ class WatchController extends BaseController {
 
 	/**
 	 * Watch poll for updates
+	 * @NoAdminRequired
+	 * @NoCSRFRequired
 	 */
-	#[NoAdminRequired]
-	#[NoCSRFRequired]
 	public function watchPoll(int $pollId, ?int $offset): JSONResponse {
 		return $this->responseLong(fn () => ['updates' => $this->watchService->watchUpdates($pollId, $offset)]);
 	}

--- a/lib/Cron/JanitorCron.php
+++ b/lib/Cron/JanitorCron.php
@@ -34,6 +34,7 @@ use OCA\Polls\Db\WatchMapper;
 use OCA\Polls\Model\Settings\AppSettings;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\TimedJob;
+use OCP\Server;
 
 /**
  * @psalm-api
@@ -52,10 +53,7 @@ class JanitorCron extends TimedJob {
 	) {
 		parent::__construct($time);
 		parent::setInterval(86400); // run once a day
-		$this->logMapper = $logMapper;
-		$this->pollMapper = $pollMapper;
-		$this->watchMapper = $watchMapper;
-		$this->appSettings = new AppSettings;
+		$this->appSettings = Server::get(AppSettings::class);
 	}
 
 	/**

--- a/lib/Db/Share.php
+++ b/lib/Db/Share.php
@@ -27,9 +27,9 @@ namespace OCA\Polls\Db;
 
 use JsonSerializable;
 use OCA\Polls\AppConstants;
-use OCA\Polls\Helper\Container;
 use OCA\Polls\Model\Settings\AppSettings;
 use OCP\IURLGenerator;
+use OCP\Server;
 
 /**
  * @method int getId()
@@ -145,8 +145,8 @@ class Share extends EntityWithUser implements JsonSerializable {
 		$this->addType('locked', 'int');
 		$this->addType('reminderSent', 'int');
 		$this->addType('deleted', 'int');
-		$this->urlGenerator = Container::queryClass(IURLGenerator::class);
-		$this->appSettings = new AppSettings;
+		$this->urlGenerator = Server::get(IURLGenerator::class);
+		$this->appSettings = Server::get(AppSettings::class);
 	}
 
 	/**

--- a/lib/Db/TableManager.php
+++ b/lib/Db/TableManager.php
@@ -179,14 +179,14 @@ class TableManager {
 		foreach ($columns as $columnName => $columnDefinition) {
 			if ($table->hasColumn($columnName)) {
 				$column = $table->getColumn($columnName);
-				if (Type::lookupName($column->getType()) !== $columnDefinition['type']) {
-					$messages[] = 'Migrated type of ' . $table->getName() . '[\'' . $columnName . '\'] from ' . Type::lookupName($column->getType()) . ' to ' . $columnDefinition['type'];
+				if ($column->getType()->getName() !== $columnDefinition['type']) {
+					$messages[] = 'Migrated type of ' . $table->getName() . '[\'' . $columnName . '\'] from ' . $column->getType()->getName() . ' to ' . $columnDefinition['type'];
 					$column->setType(Type::getType($columnDefinition['type']));
 				}
 				$column->setOptions($columnDefinition['options']);
 
 				// force change to current options definition
-				$table->modifyColumn($columnName, $columnDefinition['options']);
+				$table->changeColumn($columnName, $columnDefinition['options']);
 			} else {
 				$table->addColumn($columnName, $columnDefinition['type'], $columnDefinition['options']);
 				$messages[] = 'Added ' . $table->getName() . ', ' . $columnName . ' (' . $columnDefinition['type'] . ')';

--- a/lib/Db/UserMapper.php
+++ b/lib/Db/UserMapper.php
@@ -89,7 +89,7 @@ class UserMapper extends QBMapper {
 			$this->currentUser = $this->getUserFromUserBase($this->userSession->getUser()->getUID());
 		} else {
 			try {
-				$this->currentUser = $this->getUserFromShareToken($this->getToken());
+				$this->currentUser = $this->getUserFromShareToken($this->getSessionStoredShareToken());
 			} catch (DoesNotExistException $e) {
 				$this->logger->debug('no user found, returned fake user');
 				$this->currentUser = new GenericUser('', Share::TYPE_PUBLIC);
@@ -103,7 +103,7 @@ class UserMapper extends QBMapper {
 		return $this->currentUser ?? $this->getCurrentUser();
 	}
 
-	private function getToken(): string {
+	public function getSessionStoredShareToken(): string {
 		return (string) $this->session->get(AppConstants::SESSION_KEY_SHARE_TOKEN);
 	}
 

--- a/lib/Db/UserMapper.php
+++ b/lib/Db/UserMapper.php
@@ -89,7 +89,7 @@ class UserMapper extends QBMapper {
 			$this->currentUser = $this->getUserFromUserBase($this->userSession->getUser()->getUID());
 		} else {
 			try {
-				$this->currentUser = $this->getUserFromShareToken($this->getSessionStoredShareToken());
+				$this->currentUser = $this->getUserFromShareToken($this->getToken());
 			} catch (DoesNotExistException $e) {
 				$this->logger->debug('no user found, returned fake user');
 				$this->currentUser = new GenericUser('', Share::TYPE_PUBLIC);
@@ -103,7 +103,7 @@ class UserMapper extends QBMapper {
 		return $this->currentUser ?? $this->getCurrentUser();
 	}
 
-	public function getSessionStoredShareToken(): string {
+	private function getToken(): string {
 		return (string) $this->session->get(AppConstants::SESSION_KEY_SHARE_TOKEN);
 	}
 

--- a/lib/Db/VoteMapper.php
+++ b/lib/Db/VoteMapper.php
@@ -126,19 +126,6 @@ class VoteMapper extends QBMapperWithUser {
 		return $this->findEntities($qb);
 	}
 
-
-	/**
-	 * @throws \OCP\AppFramework\Db\DoesNotExistException if not found
-	 * @return Vote[]
-	 * @psalm-return array<array-key, Vote>
-	 */
-	public function findParticipantsVotes(int $pollId, string $userId): array {
-		$qb = $this->buildQuery();
-		$qb->andWhere($qb->expr()->eq(self::TABLE . '.poll_id', $qb->createNamedParameter($pollId, IQueryBuilder::PARAM_INT)))
-			->andWhere($qb->expr()->eq(self::TABLE . '.user_id', $qb->createNamedParameter($userId, IQueryBuilder::PARAM_STR)));
-		return $this->findEntities($qb);
-	}
-
 	public function deleteByPollAndUserId(int $pollId, string $userId): void {
 		$qb = $this->db->getQueryBuilder();
 		$qb->delete($this->getTableName())

--- a/lib/Helper/Container.php
+++ b/lib/Helper/Container.php
@@ -31,34 +31,27 @@ use OCA\Polls\Db\PollMapper;
 use OCA\Polls\Db\Share;
 use OCA\Polls\Db\ShareMapper;
 use OCP\App\IAppManager;
-use OCP\AppFramework\App;
 use OCP\IL10N;
 use OCP\L10N\IFactory;
-use Psr\Container\ContainerInterface;
+use OCP\Server;
 
 abstract class Container {
-	public static function getContainer(): ContainerInterface {
-		$app = new App(AppConstants::APP_ID);
-		return $app->getContainer();
-	}
-
 	public static function queryClass(string $class): mixed {
-		return self::getContainer()->get($class);
+		return Server::get($class);
 	}
 
 	public static function queryPoll(int $pollId): Poll {
-		return self::queryClass(PollMapper::class)->find($pollId);
+		return Server::get(PollMapper::class)->find($pollId);
 	}
 
 	public static function findShare(int $pollId, string $userId): Share {
-		return self::queryClass(ShareMapper::class)
-			->findByPollAndUser($pollId, $userId);
+		return Server::get(ShareMapper::class)->findByPollAndUser($pollId, $userId);
 	}
 
 	public static function getL10N(?string $lang = null): IL10N {
-		return self::queryClass(IFactory::class)->get(AppConstants::APP_ID, $lang);
+		return Server::get(IFactory::class)->get(AppConstants::APP_ID, $lang);
 	}
 	public static function isAppEnabled(string $app): bool {
-		return self::queryClass(IAppManager::class)->isEnabledForUser($app);
+		return Server::get(IAppManager::class)->isEnabledForUser($app);
 	}
 }

--- a/lib/Middleware/RequestAttributesMiddleware.php
+++ b/lib/Middleware/RequestAttributesMiddleware.php
@@ -3,7 +3,6 @@
 namespace OCA\Polls\Middleware;
 
 use OCA\Polls\AppConstants;
-use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\Attribute\PublicPage;
 use OCP\AppFramework\Middleware;
 use OCP\IRequest;

--- a/lib/Middleware/RequestAttributesMiddleware.php
+++ b/lib/Middleware/RequestAttributesMiddleware.php
@@ -24,7 +24,7 @@ class RequestAttributesMiddleware extends Middleware {
 	) {
 	}
 
-	public function beforeController(Controller $controller, string $methodName): void {
+	public function beforeController($controller, $methodName): void {
 		$reflectionMethod = new ReflectionMethod($controller, $methodName);
 		$clientId = $this->request->getHeader(self::CLIENT_ID_KEY);
 		$clientTimeZone = $this->request->getHeader(self::TIME_ZONE_KEY);

--- a/lib/Migration/TableSchema.php
+++ b/lib/Migration/TableSchema.php
@@ -283,13 +283,13 @@ abstract class TableSchema {
 				if ($table->hasColumn($columnName)) {
 					$column = $table->getColumn($columnName);
 					$column->setOptions($columnDefinition['options']);
-					if (Type::lookupName($column->getType()) !== $columnDefinition['type']) {
+					if ($column->getType()->getName() !== $columnDefinition['type']) {
 						$messages[] = 'Migrating type of ' . $tableName . ', ' . $columnName . ' to ' . $columnDefinition['type'];
 						$column->setType(Type::getType($columnDefinition['type']));
 					}
 
 					// force change to current options definition
-					$table->modifyColumn($columnName, $columnDefinition['options']);
+					$table->changeColumn($columnName, $columnDefinition['options']);
 				} else {
 					$table->addColumn($columnName, $columnDefinition['type'], $columnDefinition['options']);
 				}

--- a/lib/Migration/Version060100Date20240209073304.php
+++ b/lib/Migration/Version060100Date20240209073304.php
@@ -98,14 +98,14 @@ class Version060100Date20240209073304 extends SimpleMigrationStep {
 		foreach ($columns as $columnName => $columnDefinition) {
 			if ($table->hasColumn($columnName)) {
 				$column = $table->getColumn($columnName);
-				if (Type::lookupName($column->getType()) !== $columnDefinition['type']) {
-					$messages[] = 'Migrated type of ' . $table->getName() . '[\'' . $columnName . '\'] from ' . Type::lookupName($column->getType()) . ' to ' . $columnDefinition['type'];
+				if ($column->getType()->getName() !== $columnDefinition['type']) {
+					$messages[] = 'Migrated type of ' . $table->getName() . '[\'' . $columnName . '\'] from ' . $column->getType()->getName() . ' to ' . $columnDefinition['type'];
 					$column->setType(Type::getType($columnDefinition['type']));
 				}
 				$column->setOptions($columnDefinition['options']);
 
 				// force change to current options definition
-				$table->modifyColumn($columnName, $columnDefinition['options']);
+				$table->changeColumn($columnName, $columnDefinition['options']);
 			} else {
 				$table->addColumn($columnName, $columnDefinition['type'], $columnDefinition['options']);
 				$messages[] = 'Added ' . $table->getName() . ', ' . $columnName . ' (' . $columnDefinition['type'] . ')';

--- a/lib/Model/Acl.php
+++ b/lib/Model/Acl.php
@@ -70,6 +70,8 @@ class Acl implements JsonSerializable {
 	public const PERMISSION_ALL_ACCESS = 'allAccess';
 	private ?int $pollId = null;
 	private ?UserBase $currentUser = null;
+	// Cache whether the current poll has shares
+	private bool $noShare = false;
 
 
 	/**
@@ -148,8 +150,21 @@ class Acl implements JsonSerializable {
 		} else {
 			$this->pollId = $pollId;
 		}
-		
+
 		$this->loadPoll();
+		$this->request($permission);
+
+		return $this;
+	}
+
+	/**
+	 * Set poll id and load poll
+	 * @return $this
+	 */
+	public function setPoll(Poll $poll, string $permission = self::PERMISSION_POLL_VIEW): static {
+		$this->pollId = $poll->getId();
+		$this->poll = $poll;
+		$this->noShare = false;
 		$this->request($permission);
 
 		return $this;
@@ -173,7 +188,7 @@ class Acl implements JsonSerializable {
 
 		return $this->share;
 	}
-	
+
 	/**
 	 * load poll
 	 * @throws NotFoundException Thrown if poll not found
@@ -187,6 +202,7 @@ class Acl implements JsonSerializable {
 		try {
 			// otherwise load poll from db
 			$this->poll = $this->pollMapper->find((int) $this->pollId);
+			$this->noShare = false;
 		} catch (DoesNotExistException $e) {
 			throw new NotFoundException('Error loading poll with id ' . $this->pollId);
 		}
@@ -199,16 +215,26 @@ class Acl implements JsonSerializable {
 	 * and the pollId will get set to the share's pollId
 	 */
 	private function loadShare(): void {
+		if ($this->noShare) {
+			throw new ShareNotFoundException('No token was set for ACL');
+		}
+
 		// no token in session, try to find a user, who matches
 		if (!$this->getToken()) {
 			if ($this->getCurrentUser()->getIsLoggedIn()) {
 				// search for logged in user's share, load it and return
-				$this->share = $this->shareMapper->findByPollAndUser($this->getPollId(), $this->getUserId());
+				try {
+					$this->share = $this->shareMapper->findByPollAndUser($this->getPollId(), $this->getUserId());
+				} catch (\Throwable $ex) {
+					$this->noShare = true;
+					throw $ex;
+				}
 				// store share in session for further validations
 				// $this->session->set(AppConstants::SESSION_KEY_SHARE_TOKEN, $this->share->getToken());
 				return;
 			} else {
 				$this->share = new Share();
+				$this->noShare = true;
 				// must fail, if no token is present and not logged in
 				throw new ShareNotFoundException('No token was set for ACL');
 			}
@@ -502,7 +528,7 @@ class Acl implements JsonSerializable {
 	 * @return bool|null
 	 */
 	private function getAllowDeleteOption(?string $optionOwner, ?int $pollId) {
-		
+
 		if (!$pollId) {
 			$this->logger->warning('Poll id missing');
 			return false;
@@ -519,7 +545,7 @@ class Acl implements JsonSerializable {
 			$this->logger->warning('Option owner missing');
 			return false;
 		}
-		
+
 
 		if ($this->matchUser($optionOwner)) {
 			return true;

--- a/lib/Model/Acl.php
+++ b/lib/Model/Acl.php
@@ -140,8 +140,8 @@ class Acl implements JsonSerializable {
 	 * Set poll id and load poll
 	 */
 	public function setPollId(?int $pollId = null, string $permission = self::PERMISSION_POLL_VIEW): Acl {
-		if ($this->getSessionStoredShareToken() && $pollId !== $this->getShare()->getPollId()) {
-			$this->logger->warning('Ignoring requested pollId ' . $pollId . '. Keeping share pollId of share(' . $this->getSessionStoredShareToken() . '): ' . $this->getShare()->getPollId());
+		if ($this->getToken() && $pollId !== $this->getShare()->getPollId()) {
+			$this->logger->warning('Ignoring requested pollId ' . $pollId . '. Keeping share pollId of share(' . $this->getToken() . '): ' . $this->getShare()->getPollId());
 		} else {
 			$this->pollId = $pollId;
 		}
@@ -273,7 +273,7 @@ class Acl implements JsonSerializable {
 		return (int) $this->getPoll()->getId();
 	}
 
-	private function getSessionStoredShareToken(): ?string {
+	public function getToken(): ?string {
 		return $this->session->get(AppConstants::SESSION_KEY_SHARE_TOKEN);
 	}
 

--- a/lib/Model/Settings/AppSettings.php
+++ b/lib/Model/Settings/AppSettings.php
@@ -27,7 +27,6 @@ namespace OCA\Polls\Model\Settings;
 
 use JsonSerializable;
 use OCA\Polls\AppConstants;
-use OCA\Polls\Helper\Container;
 use OCA\Polls\Model\Group\Group;
 use OCP\IConfig;
 use OCP\IGroupManager;
@@ -64,16 +63,15 @@ class AppSettings implements JsonSerializable {
 	public const SETTING_UPDATE_TYPE_PERIODIC_POLLING = 'periodicPolling';
 	public const SETTING_UPDATE_TYPE_DEFAULT = self::SETTING_UPDATE_TYPE_NO_POLLING;
 
-	private IConfig $config;
-	private IGroupManager $groupManager;
-	private IUserSession $session;
 	private string $userId = '';
+	
+	public function __construct(
+		private IConfig $config,
+		private IGroupManager $groupManager,
+		private IUserSession $session,
 
-	public function __construct() {
-		$this->config = Container::queryClass(IConfig::class);
-		$this->session = Container::queryClass(IUserSession::class);
-		$this->userId = Container::queryClass(IUserSession::class)->getUser()?->getUId() ?? '';
-		$this->groupManager = Container::queryClass(IGroupManager::class);
+	) {
+		$this->userId = $this->session->getUser()?->getUId() ?? '';
 	}
 
 	// Getters

--- a/lib/Model/UserBase.php
+++ b/lib/Model/UserBase.php
@@ -43,6 +43,7 @@ use OCP\IDateTimeZone;
 use OCP\IGroupManager;
 use OCP\IL10N;
 use OCP\IUserSession;
+use OCP\Server;
 use OCP\Share\IShare;
 
 class UserBase implements \JsonSerializable {
@@ -89,11 +90,11 @@ class UserBase implements \JsonSerializable {
 	) {
 		$this->icon = 'icon-share';
 		$this->l10n = Container::getL10N();
-		$this->groupManager = Container::queryClass(IGroupManager::class);
-		$this->timeZone = Container::queryClass(IDateTimeZone::class);
-		$this->userMapper = Container::queryClass(UserMapper::class);
-		$this->userSession = Container::queryClass(IUserSession::class);
-		$this->appSettings = Container::queryClass(AppSettings::class);
+		$this->groupManager = Server::get(IGroupManager::class);
+		$this->timeZone = Server::get(IDateTimeZone::class);
+		$this->userMapper = Server::get(UserMapper::class);
+		$this->userSession = Server::get(IUserSession::class);
+		$this->appSettings = Server::get(AppSettings::class);
 	}
 
 	public function getId(): string {

--- a/lib/Service/PollService.php
+++ b/lib/Service/PollService.php
@@ -81,7 +81,7 @@ class PollService {
 			$this->preferences = $this->preferencesService->get();
 			foreach ($polls as $poll) {
 				try {
-					$this->acl->setPollId($poll->getId());
+					$this->acl->setPoll($poll);
 					$relevantThreshold = $poll->getRelevantThresholdNet() + $this->preferences->getRelevantOffsetTimestamp();
 
 					// mix poll settings, currentUser attributes, permissions and relevantThreshold into one array

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -28,13 +28,11 @@ namespace OCA\Polls\Service;
 use OCA\Polls\Model\Settings\AppSettings;
 
 class SettingsService {
-	private AppSettings $appSettings;
-
+	
 	/**
 	 * @psalm-suppress PossiblyUnusedMethod
 	 */
-	public function __construct() {
-		$this->appSettings = new AppSettings;
+	public function __construct(private AppSettings $appSettings) {
 	}
 
 	/**

--- a/lib/Service/WatchService.php
+++ b/lib/Service/WatchService.php
@@ -36,9 +36,7 @@ use OCP\DB\Exception;
 use OCP\ISession;
 
 class WatchService {
-	private AppSettings $appSettings;
-	private Watch $watch;
-
+	
 	/**
 	 * @psalm-suppress PossiblyUnusedMethod
 	 */
@@ -46,9 +44,9 @@ class WatchService {
 		private ISession $session,
 		private WatchMapper $watchMapper,
 		private Acl $acl,
+		private AppSettings $appSettings,
+		private Watch $watch,
 	) {
-		$this->appSettings = new AppSettings;
-		$this->watch = new Watch;
 	}
 
 	/**

--- a/src/js/router.js
+++ b/src/js/router.js
@@ -89,7 +89,7 @@ export default new Router({
 			redirect: {
 				name: 'list',
 				params: {
-					type: 'relevant',
+					type: 'my',
 				},
 			},
 		},

--- a/src/js/router.js
+++ b/src/js/router.js
@@ -89,7 +89,7 @@ export default new Router({
 			redirect: {
 				name: 'list',
 				params: {
-					type: 'my',
+					type: 'relevant',
 				},
 			},
 		},

--- a/src/js/store/modules/polls.js
+++ b/src/js/store/modules/polls.js
@@ -32,6 +32,7 @@ const state = {
 	isPollCreationAllowed: false,
 	isComboAllowed: false,
 	currentCategoryId: 'all',
+	pollsLoading: false,
 	sort: {
 		by: 'created',
 		reverse: true,
@@ -141,6 +142,10 @@ const mutations = {
 		Object.assign(state, payload)
 	},
 
+	setLoading(state, loading) {
+		state.pollsLoading = loading ?? true
+	},
+
 	setFilter(state, payload) {
 		state.currentCategoryId = payload.currentCategoryId
 	},
@@ -195,6 +200,7 @@ const actions = {
 	async list(context) {
 
 		try {
+			context.commit('setLoading')
 			const response = await PollsAPI.getPolls()
 			context.commit('set', { list: response.data.list })
 			context.commit('setPollCreationAllowed', { pollCreationAllowed: response.data.pollCreationAllowed })
@@ -203,6 +209,8 @@ const actions = {
 			if (e?.code === 'ERR_CANCELED') return
 			console.error('Error loading polls', { error: e.response })
 			throw e
+		} finally {
+			context.commit('setLoading', false)
 		}
 	},
 }

--- a/src/js/views/PollList.vue
+++ b/src/js/views/PollList.vue
@@ -30,7 +30,11 @@
 		</HeaderBar>
 
 		<div class="area__main">
-			<NcEmptyContent v-if="noPolls"
+			<NcEmptyContent v-if="noPolls && isLoading"
+				:name="t('polls', 'Loading polls…')">
+				<NcLoadingIcon slot="icon" :size="64" />
+			</NcEmptyContent>
+			<NcEmptyContent v-else-if="noPolls"
 				:name="t('polls', 'No polls found for this category')"
 				:description="t('polls', 'Add one or change category!')">
 				<template #icon>
@@ -38,8 +42,8 @@
 				</template>
 			</NcEmptyContent>
 
-			<TransitionGroup is="div"
-				v-else
+			<TransitionGroup v-else
+				tag="div"
 				name="list"
 				class="poll-list__list">
 				<PollItem key="0"
@@ -97,14 +101,13 @@
 				</PollItem>
 			</TransitionGroup>
 		</div>
-		<LoadingOverlay v-if="isLoading" />
 	</NcAppContent>
 </template>
 
 <script>
 import { mapGetters, mapState, mapActions } from 'vuex'
 import { showError } from '@nextcloud/dialogs'
-import { NcActions, NcActionButton, NcAppContent, NcEmptyContent } from '@nextcloud/vue'
+import { NcActions, NcActionButton, NcAppContent, NcEmptyContent, NcLoadingIcon } from '@nextcloud/vue'
 import { HeaderBar } from '../components/Base/index.js'
 import DeletePollIcon from 'vue-material-design-icons/Delete.vue'
 import ClonePollIcon from 'vue-material-design-icons/ContentCopy.vue'
@@ -120,26 +123,21 @@ export default {
 		NcActions,
 		NcActionButton,
 		NcEmptyContent,
+		NcLoadingIcon,
 		HeaderBar,
 		DeletePollIcon,
 		ClonePollIcon,
 		ArchivePollIcon,
 		RestorePollIcon,
 		PollsAppIcon,
-		LoadingOverlay: () => import('../components/Base/modules/LoadingOverlay.vue'),
 		PollItem: () => import('../components/PollList/PollItem.vue'),
-	},
-
-	data() {
-		return {
-			isLoading: false,
-		}
 	},
 
 	computed: {
 		...mapState({
 			pollCategories: (state) => state.polls.categories,
 			isPollCreationAllowed: (state) => state.polls.isPollCreationAllowed,
+			isLoading: (state) => state.polls.pollsLoading,
 		}),
 
 		...mapGetters({

--- a/tests/Unit/Db/CommentMapperTest.php
+++ b/tests/Unit/Db/CommentMapperTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 /**
  * @copyright Copyright (c) 2017 Kai Schröer <git@schroeer.co>
  *
@@ -24,19 +26,22 @@
 namespace OCA\Polls\Tests\Unit\Db;
 
 use League\FactoryMuffin\Faker\Facade as Faker;
-use OCP\IDBConnection;
-use OCA\Polls\Tests\Unit\UnitTestCase;
-
 use OCA\Polls\Db\Comment;
+
 use OCA\Polls\Db\CommentMapper;
+use OCA\Polls\Db\Poll;
 use OCA\Polls\Db\PollMapper;
+use OCA\Polls\Tests\Unit\UnitTestCase;
+use OCP\ISession;
 use OCP\Server;
 
 class CommentMapperTest extends UnitTestCase {
-	private IDBConnection $con;
+	private ISession $session;
 	private CommentMapper $commentMapper;
 	private PollMapper $pollMapper;
+	/** @var Poll[] $polls */
 	private array $polls = [];
+	/** @var Comment[] $comments */
 	private array $comments = [];
 
 	/**
@@ -44,9 +49,11 @@ class CommentMapperTest extends UnitTestCase {
 	 */
 	protected function setUp(): void {
 		parent::setUp();
-		$this->con = Server::get(IDBConnection::class);
-		$this->commentMapper = new CommentMapper($this->con);
-		$this->pollMapper = new PollMapper($this->con);
+		$this->session = Server::get(ISession::class);
+		$this->session->set('ncPollsUserId', 'TestUser');
+
+		$this->commentMapper = Server::get(CommentMapper::class);
+		$this->pollMapper = Server::get(PollMapper::class);
 
 		$this->polls = [
 			$this->fm->instance('OCA\Polls\Db\Poll')
@@ -55,7 +62,7 @@ class CommentMapperTest extends UnitTestCase {
 		foreach ($this->polls as &$poll) {
 			$poll = $this->pollMapper->insert($poll);
 
-			for ($count=0; $count < 2; $count++) {
+			for ($count = 0; $count < 2; $count++) {
 				$comment = $this->fm->instance('OCA\Polls\Db\Comment');
 				$comment->setPollId($poll->getId());
 				array_push($this->comments, $this->commentMapper->insert($comment));
@@ -64,14 +71,14 @@ class CommentMapperTest extends UnitTestCase {
 		unset($poll);
 	}
 
-	 /**
- 	 * testFind
- 	 */
- 	public function testFind() {
- 		foreach ($this->comments as $comment) {
- 			$this->assertInstanceOf(Comment::class, $this->commentMapper->find($comment->getId()));
- 		}
- 	}
+	/**
+	 * testFind
+	 */
+	public function testFind() {
+		foreach ($this->comments as $comment) {
+			$this->assertInstanceOf(Comment::class, $this->commentMapper->find($comment->getId()));
+		}
+	}
 
 	/**
 	 * testFindByPoll

--- a/tests/Unit/Db/LogMapperTest.php
+++ b/tests/Unit/Db/LogMapperTest.php
@@ -27,24 +27,23 @@ use OCA\Polls\Db\Log;
 use OCA\Polls\Db\LogMapper;
 use OCA\Polls\Db\PollMapper;
 use OCA\Polls\Tests\Unit\UnitTestCase;
-use OCP\IDBConnection;
 use OCP\Server;
 
 class LogMapperTest extends UnitTestCase {
-	private IDBConnection $con;
 	private LogMapper $logMapper;
 	private PollMapper $pollMapper;
-	private array $polls = [];
+	/** @var Log[] $logs*/
 	private array $logs = [];
+	/** @var Poll[] $polls*/
+	private array $polls = [];
 
 	/**
 	 * {@inheritDoc}
 	 */
 	protected function setUp(): void {
 		parent::setUp();
-		$this->con = Server::get(IDBConnection::class);
-		$this->logMapper = new LogMapper($this->con);
-		$this->pollMapper = new PollMapper($this->con);
+		$this->logMapper = Server::get(LogMapper::class);
+		$this->pollMapper = Server::get(PollMapper::class);
 
 		$this->polls = [
 			$this->fm->instance('OCA\Polls\Db\Poll')

--- a/tests/Unit/Db/OptionMapperTest.php
+++ b/tests/Unit/Db/OptionMapperTest.php
@@ -26,30 +26,21 @@ declare(strict_types=1);
 
 namespace OCA\Polls\Db;
 
-use OCP\IDBConnection;
 use OCA\Polls\Tests\Unit\UnitTestCase;
 
 use OCA\Polls\Db\PollMapper;
 use OCA\Polls\Db\Option;
 use OCA\Polls\Db\OptionMapper;
 use OCP\IGroupManager;
+use OCA\Polls\Db\Vote;
+use OCA\Polls\Db\VoteMapper;
 use OCP\ISession;
-use OCP\IUserManager;
-use OCP\IUserSession;
 use OCP\Server;
-use Psr\Log\LoggerInterface;
 
 class OptionMapperTest extends UnitTestCase {
-	private IDBConnection $con;
-	private IGroupManager $groupManager;
 	private ISession $session;
-	private IUserManager $userManager;
-	private IUserSession $userSession;
-	private LoggerInterface $logger;
 	private OptionMapper $optionMapper;
 	private VoteMapper $voteMapper;
-	private PollMapper $pollMapper;
-	private UserMapper $userMapper;
 	/** @var Poll[] $polls */ 
 	private array $polls = [];
 	/** @var Option[] $options */ 
@@ -62,19 +53,12 @@ class OptionMapperTest extends UnitTestCase {
 	 */
 	protected function setUp(): void {
 		parent::setUp();
-		$this->con = Server::get(IDBConnection::class);
-		$this->logger = Server::get(LoggerInterface::class);
-		$this->groupManager = Server::get(IGroupManager::class);
 		$this->session = Server::get(ISession::class);
-		$this->userManager = Server::get(IUserManager::class);
-		$this->userSession = Server::get(IUserSession::class);
 		$this->session->set('ncPollsUserId', 'TestUser');
 
-
-		$this->userMapper = new UserMapper($this->con, $this->groupManager, $this->session, $this->userSession, $this->userManager, $this->logger);
-		$this->voteMapper = new VoteMapper($this->con, $this->userMapper, $this->logger);
-		$this->optionMapper = new OptionMapper($this->con, $this->session, $this->userMapper);
-		$this->pollMapper = new PollMapper($this->con);
+		$this->voteMapper = Server::get(VoteMapper::class);
+		$this->optionMapper = Server::get(OptionMapper::class);
+		$this->pollMapper = Server::get(PollMapper::class);
 
 		$this->polls = [
 			$this->fm->instance('OCA\Polls\Db\Poll')

--- a/tests/Unit/Db/PollMapperTest.php
+++ b/tests/Unit/Db/PollMapperTest.php
@@ -26,15 +26,14 @@ declare(strict_types=1);
 namespace OCA\Polls\Tests\Unit\Db;
 
 use League\FactoryMuffin\Faker\Facade as Faker;
-use OCP\IDBConnection;
 use OCA\Polls\Db\Poll;
 use OCA\Polls\Db\PollMapper;
 use OCA\Polls\Tests\Unit\UnitTestCase;
 use OCP\Server;
 
 class PollMapperTest extends UnitTestCase {
-	private IDBConnection $con;
 	private PollMapper $pollMapper;
+	/** @var Poll[] $polls*/
 	private array $polls = [];
 
 	/**
@@ -42,8 +41,7 @@ class PollMapperTest extends UnitTestCase {
 	 */
 	protected function setUp(): void {
 		parent::setUp();
-		$this->con = Server::get(IDBConnection::class);
-		$this->pollMapper = new PollMapper($this->con);
+		$this->pollMapper = Server::get(PollMapper::class);
 
 		$this->polls = [
 			$this->fm->instance('OCA\Polls\Db\Poll'),

--- a/tests/Unit/Db/SubscriptionMapperTest.php
+++ b/tests/Unit/Db/SubscriptionMapperTest.php
@@ -23,7 +23,6 @@
 
 namespace OCA\Polls\Tests\Unit\Db;
 
-use OCP\IDBConnection;
 use OCA\Polls\Tests\Unit\UnitTestCase;
 use OCA\Polls\Db\PollMapper;
 use OCA\Polls\Db\Subscription;
@@ -31,10 +30,11 @@ use OCA\Polls\Db\SubscriptionMapper;
 use OCP\Server;
 
 class SubscriptionMapperTest extends UnitTestCase {
-	private IDBConnection $con;
 	private SubscriptionMapper $subscriptionMapper;
 	private PollMapper $pollMapper;
+	/** @var Poll[] $polls */
 	private array $polls = [];
+	/** @var Subscription[] $subscriptions */ 
 	private array $subscriptions = [];
 	private array $users = [];
 
@@ -43,9 +43,8 @@ class SubscriptionMapperTest extends UnitTestCase {
 	 */
 	protected function setUp(): void {
 		parent::setUp();
-		$this->con = Server::get(IDBConnection::class);
-		$this->subscriptionMapper = new SubscriptionMapper($this->con);
-		$this->pollMapper = new PollMapper($this->con);
+		$this->subscriptionMapper = Server::get(SubscriptionMapper::class);
+		$this->pollMapper = Server::get(PollMapper::class);
 
 		$this->polls = [
 			$this->fm->instance('OCA\Polls\Db\Poll')

--- a/tests/Unit/Db/VoteMapperTest.php
+++ b/tests/Unit/Db/VoteMapperTest.php
@@ -26,32 +26,20 @@ declare(strict_types=1);
 
 namespace OCA\Polls\Tests\Unit\Db;
 
-use OCP\IDBConnection;
 use OCA\Polls\Tests\Unit\UnitTestCase;
 
 use OCA\Polls\Db\PollMapper;
 use OCA\Polls\Db\Vote;
 use OCA\Polls\Db\VoteMapper;
 use OCA\Polls\Db\OptionMapper;
-use OCA\Polls\Db\UserMapper;
-use OCP\IGroupManager;
 use OCP\ISession;
-use OCP\IUserManager;
-use OCP\IUserSession;
 use OCP\Server;
-use Psr\Log\LoggerInterface;
 
 class VoteMapperTest extends UnitTestCase {
-	private IDBConnection $con;
-	private IGroupManager $groupManager;
 	private ISession $session;
-	private IUserManager $userManager;
-	private IUserSession $userSession;
-	private LoggerInterface $logger;
-	private VoteMapper $voteMapper;
-	private PollMapper $pollMapper;
 	private OptionMapper $optionMapper;
-	private UserMapper $userMapper;
+	private PollMapper $pollMapper;
+	private VoteMapper $voteMapper;
 	/** @var Poll[] $polls */
 	private array $polls = [];
 	/** @var Option[] $options */
@@ -64,18 +52,12 @@ class VoteMapperTest extends UnitTestCase {
 	 */
 	protected function setUp(): void {
 		parent::setUp();
-		$this->con = Server::get(IDBConnection::class);
-		$this->logger = Server::get(LoggerInterface::class);
-		$this->groupManager = Server::get(IGroupManager::class);
 		$this->session = Server::get(ISession::class);
-		$this->userManager = Server::get(IUserManager::class);
-		$this->userSession = Server::get(IUserSession::class);
 		$this->session->set('ncPollsUserId', 'TestUser');
 
-		$this->userMapper = new UserMapper($this->con, $this->groupManager, $this->session, $this->userSession, $this->userManager, $this->logger);
-		$this->pollMapper = new PollMapper($this->con);
-		$this->voteMapper = new VoteMapper($this->con, $this->userMapper, $this->logger);
-		$this->optionMapper = new OptionMapper($this->con, $this->session, $this->userMapper);
+		$this->pollMapper = Server::get(PollMapper::class);
+		$this->voteMapper = Server::get(VoteMapper::class);
+		$this->optionMapper = Server::get(OptionMapper::class);
 
 		$this->polls = [
 			$this->fm->instance('OCA\Polls\Db\Poll')
@@ -133,15 +115,6 @@ class VoteMapperTest extends UnitTestCase {
 	public function testParticipantsByPoll() {
 		foreach ($this->polls as $poll) {
 			$this->assertTrue(count($this->voteMapper->findParticipantsByPoll($poll->getId())) > 0);
-		}
-	}
-
-	/**
-	 * testParticipantsByPoll
-	 */
-	public function testFindParticipantsVotes() {
-		foreach ($this->votes as $vote) {
-			$this->assertTrue(count($this->voteMapper->findParticipantsVotes($vote->getPollId(), $vote->getUserId())) > 0);
 		}
 	}
 


### PR DESCRIPTION
1. Fixed signature of `beforeController` method on the middleware
2. Allow 26 in info.xml
3. Replace attributes by annotations


This PR also includes the following PRs:
- https://github.com/nextcloud/polls/pull/3445
- https://github.com/nextcloud/polls/pull/3446
- https://github.com/nextcloud/polls/pull/3449
- https://github.com/nextcloud/polls/pull/3448
- https://github.com/nextcloud/polls/pull/3451