### PR TITLE
Support NC27

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -25,8 +25,8 @@ jobs:
       # do not stop on another job's failure
       fail-fast: false
       matrix:
-        php-versions: ['8.1']
-        server-versions: ['master']
+        php-versions: ['8.0', '8.1']
+        server-versions: ['stable27']
 
     name: SQLite
 
@@ -57,7 +57,7 @@ jobs:
       fail-fast: false
       matrix:
         php-versions: ['8.2']
-        server-versions: ['master']
+        server-versions: ['stable28', 'master']
 
     name: MySQL
 

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -25,7 +25,7 @@ jobs:
       # do not stop on another job's failure
       fail-fast: false
       matrix:
-        php-versions: ['8.0', '8.1']
+        php-versions: ['8.1']
         server-versions: ['stable27']
 
     name: SQLite

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ocp-version: ['master']
+        ocp-version: ['stable27', 'master']
         php-versions: ['8.1', '8.2', '8.3']
 
     name: Psalm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ All notable changes to this project will be documented in this file.
 ### Fix
  - Fix opening and closing of sidebar after changed component
  - try avoiding update error by removing class registering
- ## [7.1.0] - 2024-06-09
+## Change
+ - Support Nextcloud 27
+## [7.1.0] - 2024-06-09
 ###  !!! changed API structure, please refer to the documentation
 ### Fix
  - Fixed counting of orphaned votes

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -23,7 +23,7 @@
   <screenshot>https://raw.githubusercontent.com/nextcloud/polls/master/screenshots/edit-poll.png</screenshot>
   <dependencies>
     <php min-version="8.0"/>
-    <nextcloud min-version="28" max-version="29"/>
+    <nextcloud min-version="27" max-version="29"/>
   </dependencies>
   <activity>
     <providers>

--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
 		"optimize-autoloader": true,
 		"autoloader-suffix": "Polls",
 		"platform": {
-        "php": "8.0"
-      },
+			"php": "8.0"
+		},
 		"allow-plugins": {
 			"bamarni/composer-bin-plugin": true
 		}

--- a/lib/Db/TableManager.php
+++ b/lib/Db/TableManager.php
@@ -150,7 +150,7 @@ class TableManager {
 
 				// TODO: reactivate after drop of NC27 support
 				// if (Type::lookupName($column->getType()) !== $columnDefinition['type']) {
-					// $messages[] = 'Migrated type of ' . $table->getName() . '[\'' . $columnName . '\'] from ' . Type::lookupName($column->getType()) . ' to ' . $columnDefinition['type'];
+				// 	$messages[] = 'Migrated type of ' . $table->getName() . '[\'' . $columnName . '\'] from ' . Type::lookupName($column->getType()) . ' to ' . $columnDefinition['type'];
 				if ($column->getType()->getName() !== $columnDefinition['type']) {
 					$messages[] = 'Migrated type of ' . $table->getName() . '[\'' . $columnName . '\'] from ' . $column->getType()->getName() . ' to ' . $columnDefinition['type'];
 					$column->setType(Type::getType($columnDefinition['type']));

--- a/lib/Db/TableManager.php
+++ b/lib/Db/TableManager.php
@@ -147,10 +147,16 @@ class TableManager {
 		foreach ($columns as $columnName => $columnDefinition) {
 			if ($table->hasColumn($columnName)) {
 				$column = $table->getColumn($columnName);
-				if (Type::lookupName($column->getType()) !== $columnDefinition['type']) {
-					$messages[] = 'Migrated type of ' . $table->getName() . '[\'' . $columnName . '\'] from ' . Type::lookupName($column->getType()) . ' to ' . $columnDefinition['type'];
+
+				// TODO: reactivate after drop of NC27 support
+				// if (Type::lookupName($column->getType()) !== $columnDefinition['type']) {
+					// $messages[] = 'Migrated type of ' . $table->getName() . '[\'' . $columnName . '\'] from ' . Type::lookupName($column->getType()) . ' to ' . $columnDefinition['type'];
+				if ($column->getType()->getName() !== $columnDefinition['type']) {
+					$messages[] = 'Migrated type of ' . $table->getName() . '[\'' . $columnName . '\'] from ' . $column->getType()->getName() . ' to ' . $columnDefinition['type'];
 					$column->setType(Type::getType($columnDefinition['type']));
+
 				}
+
 				$column->setOptions($columnDefinition['options']);
 
 				// force change to current options definition

--- a/lib/Migration/TableSchema.php
+++ b/lib/Migration/TableSchema.php
@@ -270,7 +270,10 @@ abstract class TableSchema {
 				if ($table->hasColumn($columnName)) {
 					$column = $table->getColumn($columnName);
 					$column->setOptions($columnDefinition['options']);
-					if (Type::lookupName($column->getType()) !== $columnDefinition['type']) {
+
+				// TODO: reactivate after drop of NC27 support
+				// if (Type::lookupName($column->getType()) !== $columnDefinition['type']) {
+				if ($column->getType()->getName() !== $columnDefinition['type']) {
 						$messages[] = 'Migrating type of ' . $tableName . ', ' . $columnName . ' to ' . $columnDefinition['type'];
 						$column->setType(Type::getType($columnDefinition['type']));
 					}

--- a/lib/Migration/TableSchema.php
+++ b/lib/Migration/TableSchema.php
@@ -271,9 +271,9 @@ abstract class TableSchema {
 					$column = $table->getColumn($columnName);
 					$column->setOptions($columnDefinition['options']);
 
-				// TODO: reactivate after drop of NC27 support
-				// if (Type::lookupName($column->getType()) !== $columnDefinition['type']) {
-				if ($column->getType()->getName() !== $columnDefinition['type']) {
+					// TODO: reactivate after drop of NC27 support
+					// if (Type::lookupName($column->getType()) !== $columnDefinition['type']) {
+					if ($column->getType()->getName() !== $columnDefinition['type']) {
 						$messages[] = 'Migrating type of ' . $tableName . ', ' . $columnName . ' to ' . $columnDefinition['type'];
 						$column->setType(Type::getType($columnDefinition['type']));
 					}

--- a/lib/Migration/Version060100Date20240209073304.php
+++ b/lib/Migration/Version060100Date20240209073304.php
@@ -84,7 +84,7 @@ class Version060100Date20240209073304 extends SimpleMigrationStep {
 
 				// TODO: reactivate after drop of NC27 support
 				// if (Type::lookupName($column->getType()) !== $columnDefinition['type']) {
-					// $messages[] = 'Migrated type of ' . $table->getName() . '[\'' . $columnName . '\'] from ' . Type::lookupName($column->getType()) . ' to ' . $columnDefinition['type'];
+				// 	$messages[] = 'Migrated type of ' . $table->getName() . '[\'' . $columnName . '\'] from ' . Type::lookupName($column->getType()) . ' to ' . $columnDefinition['type'];
 				if ($column->getType()->getName() !== $columnDefinition['type']) {
 					$messages[] = 'Migrated type of ' . $table->getName() . '[\'' . $columnName . '\'] from ' . $column->getType()->getName() . ' to ' . $columnDefinition['type'];
 					$column->setType(Type::getType($columnDefinition['type']));

--- a/lib/Migration/Version060100Date20240209073304.php
+++ b/lib/Migration/Version060100Date20240209073304.php
@@ -81,8 +81,12 @@ class Version060100Date20240209073304 extends SimpleMigrationStep {
 		foreach ($columns as $columnName => $columnDefinition) {
 			if ($table->hasColumn($columnName)) {
 				$column = $table->getColumn($columnName);
-				if (Type::lookupName($column->getType()) !== $columnDefinition['type']) {
-					$messages[] = 'Migrated type of ' . $table->getName() . '[\'' . $columnName . '\'] from ' . Type::lookupName($column->getType()) . ' to ' . $columnDefinition['type'];
+
+				// TODO: reactivate after drop of NC27 support
+				// if (Type::lookupName($column->getType()) !== $columnDefinition['type']) {
+					// $messages[] = 'Migrated type of ' . $table->getName() . '[\'' . $columnName . '\'] from ' . Type::lookupName($column->getType()) . ' to ' . $columnDefinition['type'];
+				if ($column->getType()->getName() !== $columnDefinition['type']) {
+					$messages[] = 'Migrated type of ' . $table->getName() . '[\'' . $columnName . '\'] from ' . $column->getType()->getName() . ' to ' . $columnDefinition['type'];
 					$column->setType(Type::getType($columnDefinition['type']));
 				}
 				$column->setOptions($columnDefinition['options']);


### PR DESCRIPTION
Rely on the PHP 8.0 compatibility and avoid forcing devtools being compatible with PHP 8.0.
The PHPUnit fails, due to locked dev tools that rely on PHP >= 8.1. So tests with PHP8.0 got removed.