### PR TITLE
fix: Display circle share activities correctly

### DIFF
--- a/src/js/components/Activity/ActivityItem.vue
+++ b/src/js/components/Activity/ActivityItem.vue
@@ -58,6 +58,15 @@ export default {
 						}
 						: `${parameters[key].name}`
 					break
+				case 'circle':
+					parameters[key] =  {
+						component: SimpleLink,
+						props: {
+							href: parameters[key].link,
+							name: parameters[key].name,
+						},
+					}
+					break
 				case 'user':
 					parameters[key] = {
 						component: NcUserBubble,


### PR DESCRIPTION
| b | a |
|--------|--------|
| <img width="461" alt="image" src="https://github.com/nextcloud/polls/assets/40746210/14c9b3e6-b4b1-47d0-a8ae-e084fb6061be"> | <img width="461" alt="image" src="https://github.com/nextcloud/polls/assets/40746210/485bfbc2-69e2-4475-b1e4-1b3713ce059b"> | 