### PR TITLE
fix: Catch exceptions thrown by NotificationMail constructor

### DIFF
--- a/lib/Service/MailService.php
+++ b/lib/Service/MailService.php
@@ -156,15 +156,14 @@ class MailService {
 		}
 
 		foreach ($subscriptions as $subscription) {
-			$subscription->setNotifyLogs($this->logs);
-			$notication = new NotificationMail($subscription);
-
 			try {
+				$subscription->setNotifyLogs($this->logs);
+				$notication = new NotificationMail($subscription);
 				$notication->send();
 			} catch (InvalidEmailAddress $e) {
-				$this->logger->warning('Invalid or no email address for notification: ' . json_encode($subscription));
+				$this->logger->warning('Invalid or no email address for notification: ' . json_encode($subscription), ['exception' => $e]);
 			} catch (\Exception $e) {
-				$this->logger->error('Error sending notification to ' . json_encode($subscription));
+				$this->logger->error('Error sending notification to ' . json_encode($subscription), ['exception' => $e]);
 				continue;
 			}
 		}


### PR DESCRIPTION
Previously when constructor would throw, it would stop there and on the
 next run the notifications before the broken one would get resent.
 Exceptions from constructor are now caught and the process continues.