### PR TITLE
fix : deleted user when email share registers

### DIFF
--- a/src/js/components/Cards/VoteInfoCards.vue
+++ b/src/js/components/Cards/VoteInfoCards.vue
@@ -76,6 +76,7 @@ export default {
 			return (this.$route.name === 'publicVote'
 				&& ['public', 'email', 'contact'].includes(this.userRole)
 				&& !this.isPollClosed
+				&& !this.permissions.vote
 				&& !this.isLocked
 				&& !!this.pollId
 			)


### PR DESCRIPTION
Reproduction:

1. Create a poll with a few options 
2. Share poll by mail 
3. open the share link received in the email 
4. Vote 
5. Register with the same email 

**Desired behaviour :** 
The new display name gets updated in the vote results 
**Actual behaviour :**
The vote is displayed as deleted user