### PR TITLE
fix: space in token causes 404 on logout

### DIFF
--- a/src/js/helpers/modules/cookieHelper.js
+++ b/src/js/helpers/modules/cookieHelper.js
@@ -56,7 +56,7 @@ const deleteCookieByValue = (searchValue) => {
 
 	if (cookieValue === searchValue) {
 		deleteCookie(cookieName)
-		return cookieName
+		return cookieName.trim()
 	}
 }
 


### PR DESCRIPTION
I noticed after loging out from a public share sometime a space character gets added to the token -> route which causes a 404  
I'm still not sure why it happens and it doesn't look deterministic, I'm still investigating 
<img width="1269" alt="image" src="https://github.com/user-attachments/assets/fb662e72-cd1d-4399-b69c-50b72be9a6e2">
Notice the extra space in the following screenshots
![image](https://github.com/user-attachments/assets/d466b7bb-d81e-49d3-a87c-2c8d01d95d7a)
![image](https://github.com/user-attachments/assets/c5897cd9-9c96-4c96-957c-eab68fbf1ea6)
