### PR TITLE
feat: Keep unchanged indices and foreign keys instead of recreating

### DIFF
--- a/lib/Migration/RepairSteps/RemoveIndices.php
+++ b/lib/Migration/RepairSteps/RemoveIndices.php
@@ -43,12 +43,12 @@ class RemoveIndices implements IRepairStep {
 		$this->schema = $this->connection->createSchema();
 		$this->indexManager->setSchema($this->schema);
 
-		$messages = $this->indexManager->removeAllForeignKeyConstraints();
+		$messages = $this->indexManager->removeIncorrectForeignKeyConstraints();
 		foreach ($messages as $message) {
 			$output->info($message);
 		}
 
-		$messages = $this->indexManager->removeAllUniqueIndices();
+		$messages = $this->indexManager->removeChangedUniqueIndices();
 		foreach ($messages as $message) {
 			$output->info($message);
 		}


### PR DESCRIPTION
Hello,

As an alternative to switching to the standard way of handling schemas and indices, this PR avoid recreating already correct indices and foreign keys.

On foreign keys I’m less sure because I fail to see why they were recreated to start with, given that they are only removed on tables from `TableSchema::FK_CHILD_TABLES`, and I do not think the name of the parent table can ever change?