### PR TITLE
Avoid expensive index recreation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 -->
 # Changelog
 ##
+## [7.2.2] - 2024-09-06
+### Fix
+ -  fix watcher in situations it may fail on pollId 0
+ -  fix failing routes on tokens with trailing spaces
+ -  Removed index removal from the pre-migration repair steps
+
 ## [7.2.1] - 2024-08-22
 ### Fix
  -  Fix deleted user when email share registers

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -58,7 +58,6 @@
   <repair-steps>
     <pre-migration>
       <step>OCA\Polls\Migration\RepairSteps\RemoveObsoleteMigrations</step>
-      <step>OCA\Polls\Migration\RepairSteps\RemoveIndices</step>
     </pre-migration>
     <post-migration>
       <step>OCA\Polls\Migration\RepairSteps\DropOrphanedTables</step>

--- a/lib/Command/Db/Rebuild.php
+++ b/lib/Command/Db/Rebuild.php
@@ -23,6 +23,12 @@ class Rebuild extends Command {
 	protected array $operationHints = [
 		'All polls tables will get checked against the current schema.',
 		'NO data migration will be executed, so make sure you have a backup of your database.',
+		'',
+		'*****************************',
+		'**    Please understand    **',
+		'*****************************',
+		'The process will also recreate all indices and foreign key constraints.',
+		'This can lead to a database performance impact on the app after the recreation is done.',
 	];
 
 	public function __construct(

--- a/lib/Db/IndexManager.php
+++ b/lib/Db/IndexManager.php
@@ -73,7 +73,7 @@ class IndexManager {
 	/**
 	 * add an on delete fk contraint
 	 *
-	 * @param string $parentTableName name of reffered table
+	 * @param string $parentTableName name of referred table
 	 * @param string $childTableName name of referring table
 	 * @return string log message
 	 */

--- a/lib/Service/PreferencesService.php
+++ b/lib/Service/PreferencesService.php
@@ -30,7 +30,7 @@ class PreferencesService {
 	public function load(): void {
 		try {
 			$this->preferences = $this->preferencesMapper->find($this->userSession->getCurrentUserId());
-		} catch	(Exception $e) {
+		} catch (Exception $e) {
 			$this->preferences = new Preferences;
 		}
 	}

--- a/lib/Service/WatchService.php
+++ b/lib/Service/WatchService.php
@@ -37,7 +37,7 @@ class WatchService {
 	 */
 	public function watchUpdates(int $pollId, ?int $offset = null): array {
 		
-		if($pollId !== 0) {
+		if ($pollId !== 0) {
 			$this->pollMapper->find($pollId)->request(Poll::PERMISSION_POLL_VIEW);
 		}
 


### PR DESCRIPTION
**This is a hotfix** to address a particular problem with heavy and expensive index recreation on large databases.

relates #3679 but not final fix
backlink to #3689 for transparancy

Problem description: 
At least one known instance with a large amount of polls and votes, etc. suffers from the recreation of indices, because it slows down the database after every update. Oviously the database discards existing execution plans and in the result, the database slows down until the execution plans are optimized again. 

This is the problem how I understood it. Correction are welcome. 

A quick analysis of the current code reveals, that it is safe to keep the index creation, since existing indices seem to stay untouched. This affects unique and other indices (check for existing indices already exists) and foreign key constrains as well. So it seems, that the removal of the pre-migration repair step alone will prevent an index recreation.

Currently this is safe for most of the installations, since the last table change, where a prior index removal was neccessary, is long time ago. I will check this later in detail, how long ago. 

If neccesary I plan to add outdated migrations to the latest existing migration, to ensure that this is only applies for updates from Versions before Polls 6.1.

