### PR TITLE
fix: show edit inputs only for external shares

### DIFF
--- a/lib/Db/Share.php
+++ b/lib/Db/Share.php
@@ -69,12 +69,16 @@ class Share extends EntityWithUser implements JsonSerializable {
 	public const TYPE_CONTACTGROUP = 'contactGroup';
 
 
+	public const CONVERATABLE_PUBLIC_SHARES = [
+		self::TYPE_EMAIL,
+		self::TYPE_CONTACT,
+	];
+
 	// Share types, that are allowed for public access (without login)
 	public const SHARE_PUBLIC_ACCESS_ALLOWED = [
 		self::TYPE_PUBLIC,
-		self::TYPE_CONTACT,
-		self::TYPE_EMAIL,
 		self::TYPE_EXTERNAL,
+		...self::CONVERATABLE_PUBLIC_SHARES,
 	];
 
 	// Share types, that are allowed for authenticated access (with login)

--- a/src/js/components/User/UserMenu.vue
+++ b/src/js/components/User/UserMenu.vue
@@ -17,7 +17,7 @@
 			</template>
 		</NcActionButton>
 		<NcActionSeparator v-if="$route.name === 'publicVote'" />
-		<NcActionInput v-if="$route.name === 'publicVote'"
+		<NcActionInput v-if="share.type === 'external'"
 			v-bind="userEmail.inputProps"
 			:value.sync="userEmail.inputValue"
 			:label-outside="false"
@@ -29,7 +29,7 @@
 			</template>
 			{{ t('polls', 'Edit Email Address') }}
 		</NcActionInput>
-		<NcActionInput v-if="$route.name === 'publicVote' && permissions.vote"
+		<NcActionInput v-if="share.type === 'external' && permissions.vote"
 			v-bind="userName.inputProps"
 			:value.sync="userName.inputValue"
 			:label-outside="false"
@@ -57,7 +57,7 @@
 			@change="toggleSubscription">
 			{{ t('polls', 'Subscribe to notifications') }}
 		</NcActionCheckbox>
-		<NcActionButton v-if="$route.name === 'publicVote' && emailAddress"
+		<NcActionButton v-if="share.type === 'external' && emailAddress"
 			:name="t('polls', 'Remove Email Address')"
 			:aria-label="t('polls', 'Remove Email Address')"
 			:disabled="!emailAddress"


### PR DESCRIPTION
Steps to reproduce:

1. Create a poll with some options
2. Go to share tab and share vial mail
3. Open the poll with that share link
4. open the settings 
5. seem them turn green
6. Hit the fields' save arrow at the right
7. `Displayname can only be set for external shares.`
