### PR TITLE
fix aftermath of #3716

### DIFF
--- a/lib/Db/CommentMapper.php
+++ b/lib/Db/CommentMapper.php
@@ -53,12 +53,17 @@ class CommentMapper extends QBMapperWithUser {
 	/**
 	 * @return void
 	 */
-	public function renameUserId(string $userId, string $replacementName): void {
+	public function renameUserId(string $userId, string $replacementId, int|null $pollId = null): void {
 		$query = $this->db->getQueryBuilder();
 		$query->update($this->getTableName(), self::TABLE)
-			->set('user_id', $query->createNamedParameter($replacementName))
-			->where($query->expr()->eq('user_id', $query->createNamedParameter($userId)))
-			->executeStatement();
+			->set('user_id', $query->createNamedParameter($replacementId))
+			->where($query->expr()->eq('user_id', $query->createNamedParameter($userId)));
+
+		if ($pollId !== null) {
+			$query->andWhere($query->expr()->eq('poll_id', $query->createNamedParameter($pollId, IQueryBuilder::PARAM_INT)));
+		}
+	
+		$query->executeStatement();
 	}
 
 	public function purgeDeletedComments(int $offset): void {

--- a/lib/Db/OptionMapper.php
+++ b/lib/Db/OptionMapper.php
@@ -128,12 +128,17 @@ class OptionMapper extends QBMapperWithUser {
 		return $this->findEntities($qb);
 	}
 
-	public function renameUserId(string $userId, string $replacementName): void {
+	public function renameUserId(string $userId, string $replacementName, int|null $pollId = null): void {
 		$query = $this->db->getQueryBuilder();
 		$query->update($this->getTableName())
 			->set('owner', $query->createNamedParameter($replacementName))
-			->where($query->expr()->eq('owner', $query->createNamedParameter($userId)))
-			->executeStatement();
+			->where($query->expr()->eq('owner', $query->createNamedParameter($userId)));
+
+		if ($pollId !== null) {
+			$query->andWhere($query->expr()->eq('poll_id', $query->createNamedParameter($pollId, IQueryBuilder::PARAM_INT)));
+		}
+
+		$query->executeStatement();
 	}
 
 	public function purgeDeletedOptions(int $offset): void {

--- a/lib/Db/VoteMapper.php
+++ b/lib/Db/VoteMapper.php
@@ -115,12 +115,17 @@ class VoteMapper extends QBMapperWithUser {
 		$qb->executeStatement();
 	}
 
-	public function renameUserId(string $userId, string $replacementName): void {
+	public function renameUserId(string $userId, string $replacementId, int|null $pollId = null): void {
 		$query = $this->db->getQueryBuilder();
 		$query->update($this->getTableName())
-			->set('user_id', $query->createNamedParameter($replacementName))
-			->where($query->expr()->eq('user_id', $query->createNamedParameter($userId)))
-			->executeStatement();
+			->set('user_id', $query->createNamedParameter($replacementId))
+			->where($query->expr()->eq('user_id', $query->createNamedParameter($userId)));
+
+		if ($pollId !== null) {
+			$query->andWhere($query->expr()->eq('poll_id', $query->createNamedParameter($pollId, IQueryBuilder::PARAM_INT)));
+		}
+	
+		$query->executeStatement();
 	}
 
 	public function fixVoteOptionText(int $pollId, int $optionId, string $searchOptionText, string $replaceOptionText): void {

--- a/lib/Service/ShareService.php
+++ b/lib/Service/ShareService.php
@@ -39,7 +39,6 @@ use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\DB\Exception;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Security\ISecureRandom;
-use phpDocumentor\Reflection\Types\This;
 use Psr\Log\LoggerInterface;
 
 class ShareService {
@@ -339,7 +338,7 @@ class ShareService {
 	 * belonging to the renamed user
 	 * 
 	 * This situation could occur, if a user already registered before the update to 7.2.4 and 
-	 * already voted, commented or suggested an option and reenters the pol lwith an email or contact share
+	 * already voted, commented or suggested an option and reenters the poll with an email or contact share
 	 * 
 	 * added in Polls 7.2.4 (can be removed later)
 	 */

--- a/lib/Service/ShareService.php
+++ b/lib/Service/ShareService.php
@@ -333,13 +333,13 @@ class ShareService {
 
 	/**
 	 * Rename userId as a follow up on renaming share's userId
-	 * This methods covers the situation, where a userId of a share 
-	 * is changed, but there are already existing votes or options 
+	 * This methods covers the situation, where a userId of a share
+	 * is changed, but there are already existing votes or options
 	 * belonging to the renamed user
-	 * 
-	 * This situation could occur, if a user already registered before the update to 7.2.4 and 
+	 *
+	 * This situation could occur, if a user already registered before the update to 7.2.4 and
 	 * already voted, commented or suggested an option and reenters the poll with an email or contact share
-	 * 
+	 *
 	 * added in Polls 7.2.4 (can be removed later)
 	 */
 	private function convertDependingObjects(string $userId, string $replacementId, int $pollId) {


### PR DESCRIPTION
Rename userId as a follow up on renaming a share's userId 

This covers the situation, where a userId of a share is changed, but there are already existing votes, comments  or options belonging to the renamed user.

This situation could occur, if a user already registered before the update to 7.2.4 and 
already voted, commented or suggested an option and reenters the poll with an email or contact share

Follow up to #3716