### PR TITLE
Fix user search by email

### DIFF
--- a/lib/Model/UserBase.php
+++ b/lib/Model/UserBase.php
@@ -308,14 +308,14 @@ class UserBase implements JsonSerializable {
 	 *
 	 * @return (bool|string|string[])[]
 	 *
-	 * @psalm-return array{userId: string, displayName: string, emailAddress: string, subName: string, subtitle: string, isNoUser: bool, desc: string, type: string, id: string, user: string, organisation: string, languageCode: string, localeCode: string, timeZone: string, icon: string, categories: array<string>}
+	 * @psalm-return array{userId: string, displayName: string, emailAddress: string, subname: string, subtitle: string, isNoUser: bool, desc: string, type: string, id: string, user: string, organisation: string, languageCode: string, localeCode: string, timeZone: string, icon: string, categories: array<string>}
 	 */
 	public function getRichUserArray(): array {
 		return	[
 			'userId' => $this->getId(),
 			'displayName' => $this->getDisplayName(),
 			'emailAddress' => $this->getEmailAddress(),
-			'subName' => $this->getSubName(),
+			'subname' => $this->getSubName(),
 			'subtitle' => $this->getDescription(),
 			'isNoUser' => $this->getIsNoUser(),
 			'desc' => $this->getDescription(),

--- a/src/js/components/User/UserSearch.vue
+++ b/src/js/components/User/UserSearch.vue
@@ -9,6 +9,7 @@
 		:options="users"
 		:multiple="false"
 		:user-select="true"
+		:filterable="false"
 		:tag-width="80"
 		:limit="30"
 		:loading="isLoading"


### PR DESCRIPTION
Searching for users to share with by email was broken.
This is due to 2 problems:

1. The subname key for users had the wrong casing `subName` instead of `subname`
2. The frontend filtering was active despite not being needed as backend already returns a filtered list

Before  | After
------------- | -------------
![Copie d'écran_20241114_175310](https://github.com/user-attachments/assets/ede2213c-8467-4be7-965c-d66214e4d790)  | ![Copie d'écran_20241114_175142](https://github.com/user-attachments/assets/4b0b8b00-9508-4703-a025-9c4f4929a78c)

@dartcafe Is it safe to rename subName to subname or is used elsewhere? The only instance I could find is https://github.com/nextcloud/polls/blob/master/src/js/store/modules/acl.js#L16 and it looks pretty safe to rename if needed.