### PR TITLE
avoid race condition on context loading

### DIFF
--- a/src/composables/context.ts
+++ b/src/composables/context.ts
@@ -6,16 +6,18 @@
 import { RouteLocationNormalized } from 'vue-router'
 import { useSessionStore } from '../stores/session.ts'
 import { usePreferencesStore } from '../stores/preferences.ts'
+import { Logger } from '../helpers/index.ts'
 
-const loadContext = (to: RouteLocationNormalized) => {
+async function loadContext(to: RouteLocationNormalized) {
 	const preferencesStore = usePreferencesStore()
 	const sessionStore = useSessionStore()
-	sessionStore.setRouter(to)
-	sessionStore.load().then(() => {
-		if (sessionStore.userStatus.isLoggedin) {
-			preferencesStore.load()
-		}
-	})
+	await sessionStore.setRouter(to)
+	await sessionStore.load()
+	if (sessionStore.userStatus.isLoggedin) {
+		await preferencesStore.load()
+	}
+
+	Logger.debug('Context loaded')
 }
 
 export { loadContext }

--- a/src/router.ts
+++ b/src/router.ts
@@ -27,12 +27,12 @@ async function validateToken(to: RouteLocationNormalized) {
 	if (getCurrentUser()) {
 		try {
 			const response = await PublicAPI.getShare(to.params.token)
-			// if the user is logged in, we diretly route to 
+			// if the user is logged in, we diretly route to
 			// the internal vote page
 			return {
 				name: 'vote',
 				params: {
-					id: response.data.share.pollId 
+					id: response.data.share.pollId
 				}
 			}
 		} catch (error) {
@@ -42,7 +42,7 @@ async function validateToken(to: RouteLocationNormalized) {
 			}
 		}
 	}
-	
+
 	// continue for external users
 	try {
 		// first validate the existance of the public token
@@ -52,7 +52,7 @@ async function validateToken(to: RouteLocationNormalized) {
 		window.location.replace(generateUrl('login'))
 	}
 
-	// then look for an existing personal token from 
+	// then look for an existing personal token from
 	// the user's client stored cookie
 	// matching the public token
 	const personalToken = getCookieValue(<string>to.params.token)
@@ -210,7 +210,7 @@ router.beforeEach(async (to: RouteLocationNormalized) => {
 		if (to.meta.votePage) {
 			await pollStore.load()
 		}
-	
+
 	} catch (error) {
 		Logger.warn('Could not load poll', error)
 		return {

--- a/src/stores/session.ts
+++ b/src/stores/session.ts
@@ -30,7 +30,7 @@ export type Route = {
 	}
 }
 
-export type UserStatus = { 
+export type UserStatus = {
 	isLoggedin: boolean
 	isAdmin: boolean
 }
@@ -125,7 +125,7 @@ export const useSessionStore = defineStore('session', {
 
 		viewTextPoll(state): ViewMode {
 			const preferencesStore = usePreferencesStore()
-			
+
 			if (state.sessionSettings.manualViewTextPoll) {
 				return state.sessionSettings.manualViewTextPoll
 			}
@@ -149,6 +149,7 @@ export const useSessionStore = defineStore('session', {
 
 	actions: {
 		async load() {
+			Logger.debug('Loading session')
 			let response = null
 			try {
 				if (this.route.name === 'publicVote') {
@@ -159,7 +160,7 @@ export const useSessionStore = defineStore('session', {
 				this.$patch(response.data)
 			} catch (error) {
 				if (error?.code === 'ERR_CANCELED') return
-	
+
 				this.$reset()
 				if (this.route.name === null) {
 					this.$reset()
@@ -167,6 +168,7 @@ export const useSessionStore = defineStore('session', {
 					throw error
 				}
 			}
+			Logger.debug('Session loaded')
 		},
 
 		setViewDatePoll(viewMode: ViewMode) {


### PR DESCRIPTION
A race condition could raise errors, where the user object is loaded too late and after following objects