### PR TITLE
fix: Remove dropdown options limit from sharing search

### DIFF
--- a/src/js/components/User/UserSearch.vue
+++ b/src/js/components/User/UserSearch.vue
@@ -11,7 +11,6 @@
 		:user-select="true"
 		:filterable="false"
 		:tag-width="80"
-		:limit="30"
 		:loading="isLoading"
 		:searchable="true"
 		:placeholder="placeholder"


### PR DESCRIPTION
Fix #3864