### PR TITLE
Fix excessive vote column width

### DIFF
--- a/src/js/components/VoteTable/VoteTable.vue
+++ b/src/js/components/VoteTable/VoteTable.vue
@@ -139,7 +139,7 @@ export default {
 	.vote-column {
 		order: 2;
 		display: flex;
-		flex: 1 0 11em;
+		flex: 1 0 auto;
 		flex-direction: column;
 		align-items: stretch;
 		max-width: 19em;


### PR DESCRIPTION
Only make the columns as wide as needed.
Allow them to grow if there is unused space left.
Do not allow them to grow and then show a horizontal scrollbar.

Before:
![image](https://github.com/user-attachments/assets/cb03555b-2453-4b0b-8aa4-137c9c5d8d83)


After:
![image](https://github.com/user-attachments/assets/ec219ada-6592-476f-8e5a-fd51f0133595)


Horizontal scrolling still works if there is really not enough space:
![image](https://github.com/user-attachments/assets/c690cda6-2f09-4779-9b4d-1bc7f29c8b71)
