### PR TITLE
[next] fix: Remove dropdown options limit from sharing search

### DIFF
--- a/src/components/User/UserSearch.vue
+++ b/src/components/User/UserSearch.vue
@@ -58,7 +58,6 @@
 		:multiple="false"
 		:user-select="true"
 		:tag-width="80"
-		:limit="30"
 		:loading="isLoading"
 		:filterable="false"
 		:searchable="true"


### PR DESCRIPTION
manual backport of #3878

Signed-off-by: dartcafe <github@dartcafe.de>