### PR TITLE
Apply core share group restrictions

### DIFF
--- a/lib/Model/Acl.php
+++ b/lib/Model/Acl.php
@@ -26,6 +26,7 @@ class Acl implements JsonSerializable {
 	public const PERMISSION_POLL_MAILADDRESSES_VIEW = 'seeMailAddresses';
 	public const PERMISSION_POLL_DOWNLOAD = 'pollDownload';
 	public const PERMISSION_SHARE_CREATE = 'shareCreate';
+	public const PERMISSION_SHARE_CREATE_EXTERNAL = 'shareCreateExternal';
 	/**
 	 * @psalm-suppress PossiblyUnusedMethod
 	 */
@@ -47,7 +48,7 @@ class Acl implements JsonSerializable {
 	}
 
 	/**
-	 * Check perticular rights and inform via boolean value, if the right is granted  or denied
+	 * Check particular rights and inform via boolean value, if the right is granted  or denied
 	 */
 	public function getIsAllowed(string $permission): bool {
 		return match ($permission) {
@@ -58,6 +59,7 @@ class Acl implements JsonSerializable {
 			self::PERMISSION_POLL_MAILADDRESSES_VIEW => $this->appSettings->getAllowSeeMailAddresses(),
 			self::PERMISSION_POLL_DOWNLOAD => $this->appSettings->getPollDownloadAllowed(),
 			self::PERMISSION_SHARE_CREATE => $this->appSettings->getShareCreateAllowed(),
+			self::PERMISSION_SHARE_CREATE_EXTERNAL => $this->appSettings->getExternalShareCreationAllowed(),
 			default => false,
 		};
 	}
@@ -70,6 +72,7 @@ class Acl implements JsonSerializable {
 			'allAccess' => $this->getIsAllowed(self::PERMISSION_ALL_ACCESS),
 			'seeMailAddresses' => $this->getIsAllowed(self::PERMISSION_POLL_MAILADDRESSES_VIEW),
 			'shareCreate' => $this->getIsAllowed(self::PERMISSION_SHARE_CREATE),
+			'shareCreateExternal' => $this->getIsAllowed(self::PERMISSION_SHARE_CREATE_EXTERNAL),
 			'pollCreation' => $this->getIsAllowed(self::PERMISSION_POLL_CREATE),
 			'pollDownload' => $this->getIsAllowed(self::PERMISSION_POLL_DOWNLOAD),
 			'publicShares' => $this->getIsAllowed(self::PERMISSION_PUBLIC_SHARES),

--- a/lib/Model/Acl.php
+++ b/lib/Model/Acl.php
@@ -19,12 +19,13 @@ use OCA\Polls\UserSession;
  * @package OCA\Polls\Model\Acl
  */
 class Acl implements JsonSerializable {
-	public const PERMISSION_OVERRIDE = 'override_permission';
 	public const PERMISSION_ALL_ACCESS = 'allAccess';
+	public const PERMISSION_OVERRIDE = 'override_permission';
 	public const PERMISSION_PUBLIC_SHARES = 'publicShares';
 	public const PERMISSION_POLL_CREATE = 'pollCreate';
 	public const PERMISSION_POLL_MAILADDRESSES_VIEW = 'seeMailAddresses';
 	public const PERMISSION_POLL_DOWNLOAD = 'pollDownload';
+	public const PERMISSION_SHARE_CREATE = 'shareCreate';
 	/**
 	 * @psalm-suppress PossiblyUnusedMethod
 	 */
@@ -39,7 +40,7 @@ class Acl implements JsonSerializable {
 	 */
 	public function jsonSerialize(): array {
 		return	[
-			'currentUser' => $this->userSession->getUser(),
+			'currentUser' => $this->getCurrentUser(),
 			'appPermissions' => $this->getPermissionsArray(),
 			'appSettings' => $this->getAppSettings(),
 		];
@@ -56,6 +57,7 @@ class Acl implements JsonSerializable {
 			self::PERMISSION_POLL_CREATE => $this->appSettings->getPollCreationAllowed(),
 			self::PERMISSION_POLL_MAILADDRESSES_VIEW => $this->appSettings->getAllowSeeMailAddresses(),
 			self::PERMISSION_POLL_DOWNLOAD => $this->appSettings->getPollDownloadAllowed(),
+			self::PERMISSION_SHARE_CREATE => $this->appSettings->getShareCreateAllowed(),
 			default => false,
 		};
 	}
@@ -66,10 +68,11 @@ class Acl implements JsonSerializable {
 	private function getPermissionsArray(): array {
 		return [
 			'allAccess' => $this->getIsAllowed(self::PERMISSION_ALL_ACCESS),
-			'publicShares' => $this->getIsAllowed(self::PERMISSION_PUBLIC_SHARES),
-			'pollCreation' => $this->getIsAllowed(self::PERMISSION_POLL_CREATE),
 			'seeMailAddresses' => $this->getIsAllowed(self::PERMISSION_POLL_MAILADDRESSES_VIEW),
+			'shareCreate' => $this->getIsAllowed(self::PERMISSION_SHARE_CREATE),
+			'pollCreation' => $this->getIsAllowed(self::PERMISSION_POLL_CREATE),
 			'pollDownload' => $this->getIsAllowed(self::PERMISSION_POLL_DOWNLOAD),
+			'publicShares' => $this->getIsAllowed(self::PERMISSION_PUBLIC_SHARES),
 		];
 	}
 

--- a/lib/Model/Settings/AppSettings.php
+++ b/lib/Model/Settings/AppSettings.php
@@ -142,7 +142,7 @@ class AppSettings implements JsonSerializable {
 		}
 
 		// first check group exception mode
-		$groupExceptionMode = $this->getShareGroupExceptionMode();
+		$groupExceptionMode = $this->getCoreLimitSharingBasedOnGroupsMode();
 
 		if ($groupExceptionMode === 'off') {
 			// no group exceptions are set, allow share creation
@@ -153,7 +153,7 @@ class AppSettings implements JsonSerializable {
 			// just kept for the moment as reminder
 			//
 			// Additionally check, if user is in excluded groups 'Exclude groups from creating link shares'
-			$excludedGroups = $this->getShareExcludedGroups();
+			$excludedGroups = $this->getCoreExternalShareCreationGroups();
 			if ($excludedGroups) {
 				// if user is in exception group, allow share creation
 				return !$this->userSession->getUser()->getIsInGroupArray($excludedGroups);
@@ -161,7 +161,7 @@ class AppSettings implements JsonSerializable {
 		}
 
 		// get group exceptions
-		$exceptionGroups = $this->getShareExceptionGroups();
+		$exceptionGroups = $this->getCoreLimitSharingBasedOnGroupsGroups();
 
 		if ($groupExceptionMode === 'allowGroup') {
 			// exception mode is 'Limit sharing to some groups'
@@ -180,7 +180,7 @@ class AppSettings implements JsonSerializable {
 	 * Get share exception groups
 	 * @return array
 	 */
-	public function getShareExceptionGroups(): array {
+	private function getCoreExternalShareCreationGroups(): array {
 		$exceptionGroups = $this->config->getAppValue('core', 'shareapi_exclude_groups_list', '');
 		return json_decode($exceptionGroups, true) ?? [];
 	}
@@ -189,7 +189,7 @@ class AppSettings implements JsonSerializable {
 	 * Get share excluded groups
 	 * @return array
 	 */
-	public function getShareExcludedGroups(): array {
+	private function getCoreLimitSharingBasedOnGroupsGroups(): array {
 		$excludedGroups = $this->config->getAppValue('core', 'shareapi_allow_links_exclude_groups', '');
 		return json_decode($excludedGroups, true) ?? [];
 	}
@@ -203,7 +203,7 @@ class AppSettings implements JsonSerializable {
 	 * 'allow' => 'allowGroup' (Limit sharing to some groups)
 	 * default => 'off' (Allow sharing for everyone) or setting absent
 	 */
-	public function getShareGroupExceptionMode(): string {
+	private function getCoreLimitSharingBasedOnGroupsMode(): string {
 		$excludedMode = $this->config->getAppValue('core', 'shareapi_exclude_groups', '');
 		return match ($excludedMode) {
 			'yes' => 'denyGroup',

--- a/lib/Model/Settings/AppSettings.php
+++ b/lib/Model/Settings/AppSettings.php
@@ -132,86 +132,6 @@ class AppSettings implements JsonSerializable {
 		return false;
 	}
 
-	/**
-	 * Permission to create shares is controlled by core settings
-	 */
-	public function getShareCreateAllowed(): bool {
-		if (!$this->userSession->getIsLoggedIn()) {
-			// only logged in users can create shares
-			return false;
-		}
-
-		// first check group exception mode
-		$groupExceptionMode = $this->getCoreLimitSharingBasedOnGroupsMode();
-
-		if ($groupExceptionMode === 'off') {
-			// no group exceptions are set, allow share creation
-			return true;
-
-			// TODO: get clarification for the usage of the excluded groups
-			// The following code is not reachable by intention, because it is based on a misunderstanding.
-			// just kept for the moment as reminder
-			//
-			// Additionally check, if user is in excluded groups 'Exclude groups from creating link shares'
-			$excludedGroups = $this->getCoreExternalShareCreationGroups();
-			if ($excludedGroups) {
-				// if user is in exception group, allow share creation
-				return !$this->userSession->getUser()->getIsInGroupArray($excludedGroups);
-			}
-		}
-
-		// get group exceptions
-		$exceptionGroups = $this->getCoreLimitSharingBasedOnGroupsGroups();
-
-		if ($groupExceptionMode === 'allowGroup') {
-			// exception mode is 'Limit sharing to some groups'
-			// if user is in exception group, allow share creation
-			return $this->userSession->getUser()->getIsInGroupArray($exceptionGroups);
-		} elseif ($groupExceptionMode === 'denyGroup') {
-			// exception mode is 'Exclude some Groups from sharing'
-			// if user is in exception group, deny share creation
-			return !$this->userSession->getUser()->getIsInGroupArray($exceptionGroups);
-		}
-
-		return true;
-	}
-
-	/**
-	 * Get share exception groups
-	 * @return array
-	 */
-	private function getCoreExternalShareCreationGroups(): array {
-		$exceptionGroups = $this->config->getAppValue('core', 'shareapi_exclude_groups_list', '');
-		return json_decode($exceptionGroups, true) ?? [];
-	}
-
-	/**
-	 * Get share excluded groups
-	 * @return array
-	 */
-	private function getCoreLimitSharingBasedOnGroupsGroups(): array {
-		$excludedGroups = $this->config->getAppValue('core', 'shareapi_allow_links_exclude_groups', '');
-		return json_decode($excludedGroups, true) ?? [];
-	}
-
-	/**
-	 * Get share group exception mode
-	 * @return string
-	 * @psalm-return 'denyGroup'|'allowGroup'|'off'
-	 * Take value from the core setting 'shareapi_exclude_groups' and translate
-	 * 'yes' => 'denyGroup' ('Exclude some groups from sharing')
-	 * 'allow' => 'allowGroup' (Limit sharing to some groups)
-	 * default => 'off' (Allow sharing for everyone) or setting absent
-	 */
-	private function getCoreLimitSharingBasedOnGroupsMode(): string {
-		$excludedMode = $this->config->getAppValue('core', 'shareapi_exclude_groups', '');
-		return match ($excludedMode) {
-			'yes' => 'denyGroup',
-			'allow' => 'allowGroup',
-			default => 'off',
-		};
-	}
-
 	public function getUsePrivacyUrl(): string {
 		if ($this->config->getAppValue(AppConstants::APP_ID, self::SETTING_PRIVACY_URL)) {
 			return $this->config->getAppValue(AppConstants::APP_ID, self::SETTING_PRIVACY_URL);
@@ -363,5 +283,115 @@ class AppSettings implements JsonSerializable {
 			return 'yes';
 		}
 		return 'no';
+	}
+
+	/** Getters for core settings regarding share creation */
+	/**
+	 * Permission to create shares is controlled by core settings
+	 */
+	public function getShareCreateAllowed(): bool {
+		if (!$this->userSession->getIsLoggedIn()) {
+			// only logged in users can create shares
+			return false;
+		}
+
+		// first check group exception mode
+		$groupExceptionMode = $this->getCoreLimitSharingMode();
+
+		if ($groupExceptionMode === 'off') {
+			// no group exceptions are set, allow share creation
+			return true;
+		}
+
+		// get group exceptions
+		$exceptionGroups = $this->getCoreLimitSharingGroups();
+
+		if ($groupExceptionMode === 'allowGroup') {
+			// exception mode is 'Limit sharing to some groups'
+			// if user is in exception group, allow share creation
+			return $this->userSession->getUser()->getIsInGroupArray($exceptionGroups);
+		} elseif ($groupExceptionMode === 'denyGroup') {
+			// exception mode is 'Exclude some Groups from sharing'
+			// if user is in exception group, deny share creation
+			return !$this->userSession->getUser()->getIsInGroupArray($exceptionGroups);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Get share group exception mode
+	 * @return string
+	 * @psalm-return 'denyGroup'|'allowGroup'|'off'
+	 * Take value from the core setting 'shareapi_exclude_groups' and translate
+	 * 'yes' => 'denyGroup' ('Exclude some groups from sharing') existing groups are handeled as deny groups
+	 * 'allow' => 'allowGroup' (Limit sharing to some groups) existing groups are handeled as allow groups
+	 * default => 'off' (Allow sharing for everyone) or setting absent - sharing is allowed for everyone
+	 */
+	private function getCoreLimitSharingMode(): string {
+		$excludedMode = $this->config->getAppValue('core', 'shareapi_exclude_groups', '');
+		return match ($excludedMode) {
+			'yes' => 'denyGroup',
+			'allow' => 'allowGroup',
+			default => 'off',
+		};
+	}
+
+	/**
+	 * Get core setting 'shareapi_exclude_groups_list', subsetting of 'Limit sharing to some groups'
+	 * Lists Groups, which are either denied or allowed to creating shares (depending on )
+	 * @return array
+	 */
+	private function getCoreLimitSharingGroups(): array {
+		$exceptionGroups = $this->config->getAppValue('core', 'shareapi_exclude_groups_list', '');
+		return json_decode($exceptionGroups, true) ?? [];
+	}
+
+	/** Getters for core settings regarding external link creation */
+	/**
+	 * Is creation of external links via email allowed for the current user?
+	 * @psalm-return bool
+	 * @return bool
+	 */
+	public function getExternalShareCreationAllowed(): bool {
+		if ($this->getCoreExternalShareCreationMode() === 'off') {
+			// external share creation is disabled
+			return false;
+		}
+
+		$excludedGroups = $this->getCoreExternalShareCreationGroups();
+		if ($excludedGroups) {
+			// if user is in exception group, disallow external share creation
+			return !$this->userSession->getUser()->getIsInGroupArray($excludedGroups);
+		}
+		return true;
+	}
+
+	/**
+	 * Get external share creation mode
+	 * @return string
+	 * @psalm-return 'denyGroup'|'off'
+	 * Take value from the core setting 'shareapi_allow_links' and translate
+	 * 'no' => 'off' (Creating external links is disabled) or setting absent
+	 * 'yes' => 'denyGroup' ('Creating external links is enablede, but groups may be excluded')
+	 * default => 'denyGroup' System default
+	 */
+	private function getCoreExternalShareCreationMode(): string {
+		$excludedMode = $this->config->getAppValue('core', 'shareapi_allow_links', '');
+		return match ($excludedMode) {
+			'no' => 'off',
+			'yes' => 'denyGroup',
+			default => 'denyGroup',
+		};
+	}
+
+	/**
+	 * Get core setting 'shareapi_allow_links_exclude_groups', subsetting of 'Allow users to share via link and emails'
+	 * Lists Groups, which are excluded from creating external link shares
+	 * @return array
+	 */
+	private function getCoreExternalShareCreationGroups(): array {
+		$excludedGroups = $this->config->getAppValue('core', 'shareapi_allow_links_exclude_groups', '');
+		return json_decode($excludedGroups, true) ?? [];
 	}
 }

--- a/lib/Model/Settings/AppSettings.php
+++ b/lib/Model/Settings/AppSettings.php
@@ -40,7 +40,7 @@ class AppSettings implements JsonSerializable {
 	public const SETTING_PRIVACY_URL = 'privacyUrl';
 	public const SETTING_IMPRINT_URL = 'imprintUrl';
 	public const SETTING_DISCLAIMER = 'disclaimer';
-	
+
 	public const SETTING_UPDATE_TYPE_LONG_POLLING = 'longPolling';
 	public const SETTING_UPDATE_TYPE_NO_POLLING = 'noPolling';
 	public const SETTING_UPDATE_TYPE_PERIODIC_POLLING = 'periodicPolling';
@@ -132,6 +132,65 @@ class AppSettings implements JsonSerializable {
 		return false;
 	}
 
+	/**
+	 * Permission to create shares is controlled by core settings
+	 */
+	public function getShareCreateAllowed(): bool {
+		if (!$this->userSession->getIsLoggedIn()) {
+			// only logged in users can create shares
+			return false;
+		}
+
+		// first check group exception mode
+		$groupExceptionMode = $this->getShareGroupExceptionMode();
+
+		if ($groupExceptionMode === 'off') {
+			// no group exceptions
+			return true;
+		}
+
+		// get group exceptions
+		$excludedGroups = $this->getShareExceptionGroups();
+
+		if ($groupExceptionMode === 'allowGroup') {
+			// exception mode is 'limit sharing to some groups'
+			// if user is in exception group, allow share creation
+			return $this->userSession->getUser()->getIsInGroupArray($excludedGroups);
+		}
+
+		// exception mode is 'Exclude some Groups from sharing'
+		// if user is in exception group, deny share creation
+		return $this->userSession->getUser()->getIsInGroupArray($excludedGroups);
+
+	}
+
+	/**
+	 * Get share exception groups
+	 * @return array
+	 */
+	public function getShareExceptionGroups(): array {
+		$excludedGroups = $this->config->getAppValue('core', 'shareapi_exclude_groups_list', '');
+		return json_decode($excludedGroups, true) ?? [];
+	}
+
+	/**
+	 * Get share group exception mode
+	 * @return string
+	 * @psalm-return 'denyGroup'|'allowGroup'|'off'
+	 * Take value from the core setting 'shareapi_exclude_Mode' and translate
+	 * 'yes' => 'denyGroup' ('Exclude some groups from sharing')
+	 * 'allow' => 'allowGroup' (Limit sharing to some groups)
+	 * default => 'off' (Allow sharing for everyone) or setting absent
+	 */
+	public function getShareGroupExceptionMode(): string {
+		$excludedMode = $this->config->getAppValue('core', 'shareapi_exclude_Mode', '');
+		return match ($excludedMode) {
+			'yes' => 'denyGroup',
+			'allow' => 'allowGroup',
+			default => 'off',
+		};
+	}
+
 	public function getUsePrivacyUrl(): string {
 		if ($this->config->getAppValue(AppConstants::APP_ID, self::SETTING_PRIVACY_URL)) {
 			return $this->config->getAppValue(AppConstants::APP_ID, self::SETTING_PRIVACY_URL);
@@ -145,7 +204,7 @@ class AppSettings implements JsonSerializable {
 		}
 		return $this->config->getAppValue('theming', 'imprintUrl');
 	}
-	
+
 	public function getAutoarchiveOffset(): int {
 		return $this->getIntegerSetting(self::SETTING_AUTO_ARCHIVE_OFFSET, self::SETTING_AUTO_ARCHIVE_OFFSET_DEFAULT);
 	}
@@ -164,7 +223,7 @@ class AppSettings implements JsonSerializable {
 	public function getLoadPollsInNavigation(): bool {
 		return $this->getBooleanSetting(self::SETTING_LOAD_POLLS_IN_NAVIGATION);
 	}
-	
+
 	// Setters
 	// generic setters
 	public function setBooleanSetting(string $key, bool $value): void {

--- a/lib/Model/User/User.php
+++ b/lib/Model/User/User.php
@@ -32,7 +32,7 @@ class User extends UserBase {
 		parent::__construct($id, $type);
 		$this->icon = self::ICON;
 		$this->description = $this->l10n->t('User');
-		
+
 		$this->setUp();
 	}
 

--- a/lib/Model/UserBase.php
+++ b/lib/Model/UserBase.php
@@ -161,7 +161,7 @@ class UserBase implements JsonSerializable {
 
 		return $this->localeCode;
 	}
-	
+
 	public function getTimeZone(): DateTimeZone {
 		if ($this->timeZoneName) {
 			return new DateTimeZone($this->timeZoneName);
@@ -432,6 +432,19 @@ class UserBase implements JsonSerializable {
 
 	public function getIsInGroup(string $groupName): bool {
 		return $this->groupManager->isInGroup($this->getId(), $groupName);
+	}
+
+	public function getIsInGroupArray(array $groupNames): bool {
+		if (!($this instanceof User)) {
+			return false;
+		}
+
+		foreach ($groupNames as $groupName) {
+			if ($this->getIsInGroup($groupName)) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	/**

--- a/lib/Service/ShareService.php
+++ b/lib/Service/ShareService.php
@@ -242,7 +242,7 @@ class ShareService {
 		} else {
 			throw new InvalidShareTypeException('Displayname can only be set for external shares.');
 		}
-		
+
 		$this->share = $this->shareMapper->update($this->share);
 		$this->eventDispatcher->dispatchTyped($dispatchEvent);
 
@@ -269,7 +269,7 @@ class ShareService {
 		} else {
 			throw new InvalidShareTypeException('Label can only be set for public shares.');
 		}
-		
+
 		$this->share = $this->shareMapper->update($this->share);
 		$this->eventDispatcher->dispatchTyped($dispatchEvent);
 
@@ -314,7 +314,7 @@ class ShareService {
 		$this->share->setDisplayName($displayName ?? $this->share->getDisplayName());
 		$this->share->setTimeZoneName($timeZone ?? $this->share->getTimeZoneName());
 		$this->share->setLanguage($language ?? $this->share->getLanguage());
-		
+
 		if ($emailAddress && $emailAddress !== $this->share->getEmailAddress()) {
 			// reset invitation sent, if email address is changed
 			$this->share->setInvitationSent(0);
@@ -561,6 +561,7 @@ class ShareService {
 	): Share {
 		$this->pollMapper->find($pollId)->request(Poll::PERMISSION_POLL_EDIT);
 
+		$this->acl->request(Acl::PERMISSION_SHARE_CREATE);
 
 		if ($type === UserBase::TYPE_PUBLIC) {
 			$this->acl->request(Acl::PERMISSION_PUBLIC_SHARES);
@@ -588,7 +589,7 @@ class ShareService {
 	 * or is accessibale for use by the current user
 	 */
 	private function validateShareType(): void {
-		
+
 		$valid = match ($this->share->getType()) {
 			Share::TYPE_PUBLIC,	Share::TYPE_EMAIL, Share::TYPE_EXTERNAL => true,
 			Share::TYPE_USER => $this->share->getUserId() === $this->userSession->getCurrentUserId(),
@@ -662,7 +663,7 @@ class ShareService {
 			$this->share->setLanguage($userGroup->getLanguageCode());
 			$this->share->setTimeZoneName($timeZone);
 		}
-		
+
 		try {
 			$this->share = $this->shareMapper->insert($this->share);
 			// return new created share

--- a/lib/Service/SystemService.php
+++ b/lib/Service/SystemService.php
@@ -16,10 +16,10 @@ use OCA\Polls\Db\UserMapper;
 use OCA\Polls\Db\VoteMapper;
 use OCA\Polls\Exceptions\InvalidUsernameException;
 use OCA\Polls\Exceptions\TooShortException;
+use OCA\Polls\Model\Acl;
 use OCA\Polls\Model\Group\Circle;
 use OCA\Polls\Model\Group\ContactGroup;
 use OCA\Polls\Model\Group\Group;
-use OCA\Polls\Model\Settings\AppSettings;
 use OCA\Polls\Model\User\Contact;
 use OCA\Polls\Model\User\Email;
 use OCA\Polls\Model\User\User;
@@ -40,7 +40,7 @@ class SystemService {
 		private ShareMapper $shareMapper,
 		private VoteMapper $voteMapper,
 		private UserMapper $userMapper,
-		private AppSettings $appSettings,
+		private Acl $acl,
 	) {
 	}
 
@@ -82,7 +82,7 @@ class SystemService {
 	 * get a list of user objects from the backend matching the query string
 	 */
 	public function search(string $query = ''): array {
-		if (!$this->appSettings->getShareCreateAllowed()) {
+		if (!$this->acl->getIsAllowed(Acl::PERMISSION_SHARE_CREATE)) {
 			return [];
 		}
 

--- a/lib/Service/SystemService.php
+++ b/lib/Service/SystemService.php
@@ -30,6 +30,7 @@ use Psr\Log\LoggerInterface;
 
 class SystemService {
 	private const REGEX_INVALID_USERNAME_CHARACTERS = '/[\x{2000}-\x{206F}]/u';
+	private const MAX_SEARCH_RESULTS = 200;
 	/**
 	 * @psalm-suppress PossiblyUnusedMethod
 	 */
@@ -65,6 +66,7 @@ class SystemService {
 		$list = [];
 		if ($query !== '') {
 			try {
+				$this->acl->request(Acl::PERMISSION_SHARE_CREATE_EXTERNAL);
 				// try to identify an email address
 				$result = MailService::extractEmailAddressAndName($query);
 				$list[] = new Email($result['emailAddress'], $result['displayName'], $result['emailAddress']);
@@ -91,19 +93,26 @@ class SystemService {
 		$types = [
 			IShare::TYPE_USER,
 			IShare::TYPE_GROUP,
-			IShare::TYPE_EMAIL
 		];
-		$maxResults = 200;
+
+		// Add email shares if external shares are allowed
+		if ($this->acl->getIsAllowed(Acl::PERMISSION_SHARE_CREATE_EXTERNAL)) {
+			$types[] = IShare::TYPE_EMAIL;
+		}
+
 		if (Circle::isEnabled() && class_exists('\OCA\Circles\ShareByCircleProvider')) {
 			// Add circles to the search, if app is enabled
 			$types[] = IShare::TYPE_CIRCLE;
 		}
+
 		$startCollaborationSearchTimer = microtime(true);
-		[$result, $more] = $this->userSearch->search($query, $types, false, $maxResults, 0);
+
+		[$result, $more] = $this->userSearch->search($query, $types, false, self::MAX_SEARCH_RESULTS, 0);
+
 		$this->logger->debug('Search took {time}s', ['time' => microtime(true) - $startCollaborationSearchTimer]);
 
 		if ($more) {
-			$this->logger->info('Only first {maxResults} matches will be returned.', ['maxResults' => $maxResults]);
+			$this->logger->info('Only first {maxResults} matches will be returned.', ['maxResults' => self::MAX_SEARCH_RESULTS]);
 		}
 
 		foreach (($result['users'] ?? []) as $item) {
@@ -138,7 +147,8 @@ class SystemService {
 			}
 		}
 
-		if (Contact::isEnabled()) {
+		// Search contacts if external shares are allowed
+		if (Contact::isEnabled() && $this->acl->getIsAllowed(Acl::PERMISSION_SHARE_CREATE_EXTERNAL)) {
 			foreach (Contact::search($query) as $contact) {
 				$items[] = $contact->getRichUserArray();
 			}

--- a/lib/Service/SystemService.php
+++ b/lib/Service/SystemService.php
@@ -19,6 +19,7 @@ use OCA\Polls\Exceptions\TooShortException;
 use OCA\Polls\Model\Group\Circle;
 use OCA\Polls\Model\Group\ContactGroup;
 use OCA\Polls\Model\Group\Group;
+use OCA\Polls\Model\Settings\AppSettings;
 use OCA\Polls\Model\User\Contact;
 use OCA\Polls\Model\User\Email;
 use OCA\Polls\Model\User\User;
@@ -39,6 +40,7 @@ class SystemService {
 		private ShareMapper $shareMapper,
 		private VoteMapper $voteMapper,
 		private UserMapper $userMapper,
+		private AppSettings $appSettings,
 	) {
 	}
 
@@ -80,6 +82,10 @@ class SystemService {
 	 * get a list of user objects from the backend matching the query string
 	 */
 	public function search(string $query = ''): array {
+		if (!$this->appSettings->getShareCreateAllowed()) {
+			return [];
+		}
+
 		$startSearchTimer = microtime(true);
 		$items = [];
 		$types = [

--- a/src/js/components/Shares/SharesList.vue
+++ b/src/js/components/Shares/SharesList.vue
@@ -9,9 +9,9 @@
 			<ShareIcon />
 		</template>
 
-		<UserSearch class="add-share" />
+		<UserSearch v-if="appPermissions.shareCreate" class="add-share" />
 		<ShareItemAllUsers v-if="appPermissions.allAccess" />
-		<SharePublicAdd v-if="appPermissions.publicShares" />
+		<SharePublicAdd v-if="appPermissions.publicShares && appPermissions.shareCreate" />
 
 		<div v-if="activeShares.length" class="shares-list shared">
 			<TransitionGroup is="div"

--- a/src/js/components/Shares/SharesList.vue
+++ b/src/js/components/Shares/SharesList.vue
@@ -11,7 +11,7 @@
 
 		<UserSearch v-if="appPermissions.shareCreate" class="add-share" />
 		<ShareItemAllUsers v-if="appPermissions.allAccess" />
-		<SharePublicAdd v-if="appPermissions.publicShares && appPermissions.shareCreate" />
+		<SharePublicAdd v-if="appPermissions.publicShares && appPermissions.shareCreate && appPermissions.shareCreateExternal" />
 
 		<div v-if="activeShares.length" class="shares-list shared">
 			<TransitionGroup is="div"

--- a/src/js/components/SideBar/SideBarTabShare.vue
+++ b/src/js/components/SideBar/SideBarTabShare.vue
@@ -5,13 +5,14 @@
 
 <template>
 	<div class="sidebar-share">
-		<SharesListUnsent class="shares unsent" />
+		<SharesListUnsent v-if="appPermissions.shareCreate" class="shares unsent" />
 		<SharesList class="shares effective" />
-		<SharesListLocked class="shares" />
+		<SharesListLocked v-if="appPermissions.shareCreate" class="shares" />
 	</div>
 </template>
 
 <script>
+import { mapState } from 'vuex'
 import SharesList from '../Shares/SharesList.vue'
 import SharesListUnsent from '../Shares/SharesListUnsent.vue'
 import SharesListLocked from '../Shares/SharesListLocked.vue'
@@ -23,6 +24,11 @@ export default {
 		SharesList,
 		SharesListUnsent,
 		SharesListLocked,
+		},
+	computed: {
+		...mapState({
+			appPermissions: (state) => state.acl.appPermissions,
+		}),
 	},
 }
 </script>

--- a/src/js/store/modules/acl.js
+++ b/src/js/store/modules/acl.js
@@ -20,7 +20,7 @@ const defaultAcl = () => ({
 		type: 'user',
 		id: '',
 		user: '',
-		organisation: '', 
+		organisation: '',
 		languageCode: '',
 		localeCode: '',
 		timeZone: '',
@@ -33,6 +33,8 @@ const defaultAcl = () => ({
 		pollCreation: false,
 		seeMailAddresses: false,
 		pollDownload: false,
+		shareCreate: true,
+		shareCreateExternal: true,
 	},
 	appSettings: {
 		usePrivacyUrl: '',
@@ -73,7 +75,7 @@ const actions = {
 
 			context.commit('reset')
 			if (context.rootState.route.name === null) {
-				// TODO: for some reason unauthorized users first get the root route resulting in a 401 
+				// TODO: for some reason unauthorized users first get the root route resulting in a 401
 				// and after that the publicVote route is called as next route
 				// therefore we just debug the error and reset the acl
 


### PR DESCRIPTION
Alternative implementation of #3893

For reviewers and testers, please check the checkboxes, if the functionality can be approved. I could confirm the functionality so far. After approval, I will merge and build version 7.4.

Summary: 
- [ ] Deny creation of shares if user is member of a group which is excluded from created shares by `limit sharing based on groups` set to `exclude some groups from sharing` 
![grafik](https://github.com/user-attachments/assets/d484cf8f-d70b-4f2f-8f7f-33d25c77b446)
- [ ] Allow creation of shares only for users which are members of a group which is allowed to create shares by `limit sharing based on groups` set to `limit sharing to some groups` 
![grafik](https://github.com/user-attachments/assets/52b7626e-6d72-4d38-9480-2698753a5404)
- [ ] Allow sharing to everyone by `limit sharing based on groups` set to `Allow sharing for everyone (default)` 
![grafik](https://github.com/user-attachments/assets/3ad3f831-7745-42f9-8035-0a133a7fe23d)


Additionally 
- [ ] Deny all external shares based on `Allow users to share via link and emails` set to `off` 
![grafik](https://github.com/user-attachments/assets/e609ba88-b62c-4197-93b8-da4e2866676d)
- [ ] Deny external shares for excluded groups based on `Allow users to share via link and emails` set to `on` and `Exclude groups from creating link shares` 
![grafik](https://github.com/user-attachments/assets/4ecd8679-8ac2-4712-8d9f-f4b040305e24)

External shares in this context are
* public links
* email shares
* contacts and contact groups

Circles (teams) will still be allowed, but external users are skipped, if the Circle (team) gets resolved. 

Note: Polls still uses the term Circle

