### PR TITLE
Updating 'dudle' name

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 # Note: This is the vue3 branch (v8.x), which still is in alpha state and replaced the [master branch](https://github.com/nextcloud/polls/tree/master-7) (v7.x) as main branch
 ## For the current release branch (v7.x) please switch to the [master branch](https://github.com/nextcloud/polls/tree/master-7)
 
-# Polls - an app, similar to doodle or dudle, for Nextcloud written in PHP and JS/Vue.
+# Polls - an app, similar to doodle or DuD-Poll, for Nextcloud written in PHP and JS/Vue.
 ![psalm](https://github.com/nextcloud/polls/actions/workflows/static-analysis.yml/badge.svg)
 ![tests](https://github.com/nextcloud/polls/actions/workflows/phpunit.yml/badge.svg)
 ![puild](https://github.com/nextcloud/polls/actions/workflows/nodejs.yml/badge.svg)

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -2,8 +2,8 @@
 <info xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://apps.nextcloud.com/schema/apps/info.xsd">
   <id>polls</id>
   <name>Polls</name>
-  <summary>A polls app, similar to Doodle/Dudle with the possibility to restrict access.</summary>
-  <description>A polls app, similar to Doodle/Dudle with the possibility to restrict access (members, certain groups/users, hidden and public).</description>
+  <summary>A polls app, similar to Doodle/DuD-Poll with the possibility to restrict access.</summary>
+  <description>A polls app, similar to Doodle/DuD-Poll with the possibility to restrict access (members, certain groups/users, hidden and public).</description>
   <version>8.0.0-alpha14</version>
   <licence>agpl</licence>
   <author>Vinzenz Rosenkranz</author>


### PR DESCRIPTION
The polling service by the TU Dresden, formerly known as dudle, as been renamed to DuD-Polls, due to a request by Doodle

> Warum wurde Dudle zu DuD-Poll umbenannt?
>
> Anfang 2022 gab es eine Aufforderung von Doodle, den Dienst umzubenennen. Wir haben weder Zeit noch Interesse an einer rechtlichen Auseinandersetzung.

https://dud-poll.inf.tu-dresden.de/about.cgi

this pull request so far only contains changing this name in appinfo/info.xml and the readme.

what is the best way to handle all the l10n files?