### PR TITLE
Add configuration to use footer with default terms

### DIFF
--- a/lib/Controller/PublicController.php
+++ b/lib/Controller/PublicController.php
@@ -28,6 +28,7 @@ use OCP\AppFramework\Http\Attribute\PublicPage;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Http\Template\PublicTemplateResponse;
 use OCP\AppFramework\Http\TemplateResponse;
+use OCP\IAppConfig;
 use OCP\IRequest;
 use OCP\Util;
 
@@ -41,6 +42,7 @@ class PublicController extends BasePublicController {
 	public function __construct(
 		string $appName,
 		IRequest $request,
+		private IAppConfig $appConfig,
 		private UserSession $userSession,
 		private AppSettings $appSettings,
 		private CommentService $commentService,
@@ -70,7 +72,7 @@ class PublicController extends BasePublicController {
 			return new TemplateResponse(AppConstants::APP_ID, 'main');
 		} else {
 			$template = new PublicTemplateResponse(AppConstants::APP_ID, 'main');
-			$template->setFooterVisible(false);
+			$template->setFooterVisible($this->appConfig->getValueBool('polls', AppSettings::SETTING_USE_SITE_LEGAL, true));
 			return $template;
 		}
 	}

--- a/lib/Model/Settings/AppSettings.php
+++ b/lib/Model/Settings/AppSettings.php
@@ -39,6 +39,7 @@ class AppSettings implements JsonSerializable {
 	public const SETTING_UNRESTRICTED_POLL_OWNER = 'unrestrictedOwner';
 	public const SETTING_UNRESTRICTED_POLL_OWNER_GROUPS = 'unrestrictedOwnerGroups';
 
+	public const SETTING_USE_SITE_LEGAL = 'useSiteLegalTerms';
 	public const SETTING_LEGAL_TERMS_IN_EMAIL = 'legalTermsInEmail';
 	public const SETTING_DISCLAIMER = 'disclaimer';
 	public const SETTING_PRIVACY_URL = 'privacyUrl';
@@ -92,6 +93,7 @@ class AppSettings implements JsonSerializable {
 			'finalPrivacyUrl' => '',
 			'finalImprintUrl' => '',
 			'useLogin' => true,
+			'useSiteLegalTerms' => true,
 			'useActivity' => false,
 			'navigationPollsInList' => false,
 			'updateType' => $this->getUpdateType(),
@@ -287,7 +289,7 @@ class AppSettings implements JsonSerializable {
 	 */
 	public function getFinalPrivacyUrl(): string {
 		$privacyUrl = $this->getStringSetting(self::SETTING_PRIVACY_URL);
-		if ($privacyUrl) {
+		if ($privacyUrl && !$this->getBooleanSetting(self::SETTING_USE_SITE_LEGAL)) {
 			return $privacyUrl;
 		}
 
@@ -301,7 +303,7 @@ class AppSettings implements JsonSerializable {
 	 */
 	public function getFinalImprintUrl(): string {
 		$imprintUrl = $this->getStringSetting(self::SETTING_IMPRINT_URL);
-		if ($imprintUrl) {
+		if ($imprintUrl && !$this->getBooleanSetting(self::SETTING_USE_SITE_LEGAL)) {
 			return $imprintUrl;
 		}
 
@@ -417,6 +419,7 @@ class AppSettings implements JsonSerializable {
 			self::SETTING_AUTO_ARCHIVE => $this->getBooleanSetting(self::SETTING_AUTO_ARCHIVE),
 			self::SETTING_AUTO_ARCHIVE_OFFSET_DAYS => $this->getAutoarchiveOffsetDays(),
 
+			self::SETTING_USE_SITE_LEGAL => $this->getBooleanSetting(self::SETTING_USE_SITE_LEGAL),
 			self::SETTING_LEGAL_TERMS_IN_EMAIL => $this->getBooleanSetting(self::SETTING_LEGAL_TERMS_IN_EMAIL),
 			self::SETTING_DISCLAIMER => $this->appConfig->getValueString(AppConstants::APP_ID, self::SETTING_DISCLAIMER),
 			self::SETTING_IMPRINT_URL => $this->appConfig->getValueString(AppConstants::APP_ID, self::SETTING_IMPRINT_URL),

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -38,6 +38,7 @@ class SettingsService {
 		$this->appSettings->setBooleanSetting(AppSettings::SETTING_AUTO_ARCHIVE, $settingsArray[AppSettings::SETTING_AUTO_ARCHIVE]);
 		$this->appSettings->setBooleanSetting(AppSettings::SETTING_SHOW_LOGIN, $settingsArray[AppSettings::SETTING_SHOW_LOGIN]);
 		$this->appSettings->setBooleanSetting(AppSettings::SETTING_USE_ACTIVITY, $settingsArray[AppSettings::SETTING_USE_ACTIVITY]);
+		$this->appSettings->setBooleanSetting(AppSettings::SETTING_USE_SITE_LEGAL, $settingsArray[AppSettings::SETTING_USE_SITE_LEGAL]);
 		$this->appSettings->setBooleanSetting(AppSettings::SETTING_LEGAL_TERMS_IN_EMAIL, $settingsArray[AppSettings::SETTING_LEGAL_TERMS_IN_EMAIL]);
 		$this->appSettings->setBooleanSetting(AppSettings::SETTING_LOAD_POLLS_IN_NAVIGATION, $settingsArray[AppSettings::SETTING_LOAD_POLLS_IN_NAVIGATION]);
 		$this->appSettings->setBooleanSetting(AppSettings::SETTING_UNRESTRICTED_POLL_OWNER, $settingsArray[AppSettings::SETTING_UNRESTRICTED_POLL_OWNER]);

--- a/src/components/Base/modules/InputDiv.vue
+++ b/src/components/Base/modules/InputDiv.vue
@@ -84,6 +84,10 @@ const props = defineProps({
 		type: String,
 		default: null,
 	},
+	disabled: {
+		type: Boolean,
+		default: false,
+	},
 })
 
 const emit = defineEmits(['input', 'change', 'submit'])
@@ -221,6 +225,7 @@ onMounted(() => {
 			<input
 				v-model="model"
 				v-input-focus
+				:disabled="disabled"
 				:type="type"
 				:inputmode="inputmode"
 				:placeholder="placeholder"

--- a/src/components/Public/PublicRegisterModal.vue
+++ b/src/components/Public/PublicRegisterModal.vue
@@ -12,7 +12,6 @@ import { generateUrl } from '@nextcloud/router'
 import { t } from '@nextcloud/l10n'
 
 import NcCheckboxRadioSwitch from '@nextcloud/vue/components/NcCheckboxRadioSwitch'
-import NcRichText from '@nextcloud/vue/components/NcRichText'
 import NcButton, { ButtonType } from '@nextcloud/vue/components/NcButton'
 
 import { InputDiv } from '../Base/index.ts'
@@ -63,27 +62,6 @@ const emailGeneratedStatus = computed(() =>
 		: checkStatus.value.email,
 )
 const offerCookies = computed(() => sessionStore.share.type === ShareType.Public)
-
-const privacyRich = computed(() => {
-	const subject = t(
-		'polls',
-		'By clicking the "OK" button you accept our {privacyPolicy}.',
-	)
-	const parameters = {
-		privacyPolicy: {
-			component: SimpleLink,
-			props: {
-				href: sessionStore.appSettings.finalPrivacyUrl,
-				name: t('polls', 'privacy policy'),
-				target: '_blank',
-			},
-		},
-	}
-	return {
-		subject,
-		parameters,
-	}
-})
 
 const loginLink = computed(() => {
 	const redirectUrl = router.resolve({
@@ -322,14 +300,6 @@ async function submitRegistration(): Promise<void> {
 					{{ t('polls', 'Remember me for 30 days') }}
 				</NcCheckboxRadioSwitch>
 
-				<div
-					v-if="sessionStore.appSettings.finalPrivacyUrl"
-					class="section__optin">
-					<NcRichText
-						:text="privacyRich.subject"
-						:arguments="privacyRich.parameters" />
-				</div>
-
 				<div class="modal__buttons">
 					<div class="left">
 						<div class="legal_links">
@@ -338,6 +308,11 @@ async function submitRegistration(): Promise<void> {
 								:href="sessionStore.appSettings.finalImprintUrl"
 								target="_blank"
 								:name="t('polls', 'Legal Notice')" />
+							<SimpleLink
+								v-if="sessionStore.appSettings.finalPrivacyUrl"
+								:href="sessionStore.appSettings.finalPrivacyUrl"
+								target="_blank"
+								:name="t('polls', 'Privacy policy')" />
 						</div>
 					</div>
 					<div class="right">
@@ -446,7 +421,7 @@ async function submitRegistration(): Promise<void> {
 		}
 
 		&:after {
-			content: '|';
+			content: '·';
 			padding: 0 4px;
 		}
 

--- a/src/components/Settings/AdminSettings/AdminLegal.vue
+++ b/src/components/Settings/AdminSettings/AdminLegal.vue
@@ -36,7 +36,7 @@ const placeholder = computed(() => {
 			{{
 				t(
 					'polls',
-					'Use the default terms for public polls and enable the default footer.',
+					'Use the default terms for public polls and enable the default footer',
 				)
 			}}
 		</NcCheckboxRadioSwitch>

--- a/src/components/Settings/AdminSettings/AdminLegal.vue
+++ b/src/components/Settings/AdminSettings/AdminLegal.vue
@@ -8,6 +8,7 @@ import { InputDiv } from '../../Base/index.ts'
 import { t } from '@nextcloud/l10n'
 import { useAppSettingsStore } from '../../../stores/appSettings.ts'
 import { computed } from 'vue'
+import { NcCheckboxRadioSwitch } from '@nextcloud/vue'
 
 const appSettingsStore = useAppSettingsStore()
 const placeholder = computed(() => {
@@ -28,11 +29,25 @@ const placeholder = computed(() => {
 
 <template>
 	<div class="user_settings">
-		<p class="settings-description">
+		<NcCheckboxRadioSwitch
+			v-model="appSettingsStore.useSiteLegalTerms"
+			type="switch"
+			@update:model-value="appSettingsStore.write()">
 			{{
 				t(
 					'polls',
-					'If you use different legal terms and privacy policy for public polls, enter the links below. Leave empty to use your default terms.',
+					'Use the default terms for public polls and enable the default footer.',
+				)
+			}}
+		</NcCheckboxRadioSwitch>
+
+	</div>
+	<div v-if="!appSettingsStore.useSiteLegalTerms" class="user_settings">
+		<p class="settings-description" >
+			{{
+				t(
+					'polls',
+					'If you want to use diferent terms for public polls, enter them below.',
 				)
 			}}
 		</p>

--- a/src/components/Settings/AdminSettings/AdminLegal.vue
+++ b/src/components/Settings/AdminSettings/AdminLegal.vue
@@ -40,10 +40,9 @@ const placeholder = computed(() => {
 				)
 			}}
 		</NcCheckboxRadioSwitch>
-
 	</div>
 	<div v-if="!appSettingsStore.useSiteLegalTerms" class="user_settings">
-		<p class="settings-description" >
+		<p class="settings-description">
 			{{
 				t(
 					'polls',

--- a/src/stores/appSettings.ts
+++ b/src/stores/appSettings.ts
@@ -43,6 +43,7 @@ export type AppSettings = {
 	updateType: UpdateType
 	useActivity: boolean
 	useCollaboration: boolean
+	useSiteLegalTerms: boolean
 	navigationPollsInList: boolean
 	finalPrivacyUrl: string
 	finalImprintUrl: string
@@ -80,6 +81,7 @@ export const useAppSettingsStore = defineStore('appSettings', {
 		updateType: UpdateType.NoPolling,
 		useActivity: false,
 		useCollaboration: true,
+		useSiteLegalTerms: true,
 		navigationPollsInList: true,
 		finalPrivacyUrl: '',
 		finalImprintUrl: '',


### PR DESCRIPTION
* Added a configuration setting to use the default terms (default is enabled) and 
* activate the footer for public polls
* change display of the link to the privacy policy and removed the text about accepting them

fixes #3895

. |Setting | Apperance
-|-|-
footer enabled| ![grafik](https://github.com/user-attachments/assets/f71ceaa3-dd9d-403b-b174-0313a4fa9e7b) | ![grafik](https://github.com/user-attachments/assets/93e26b57-f5a3-4ba7-9b30-eb0186be9ab2)
footer disabled| ![grafik](https://github.com/user-attachments/assets/506e4289-1d9a-4433-a12b-2773b55485a4)| ![grafik](https://github.com/user-attachments/assets/5bb9eb7b-fd1b-4108-a05f-88b1772fbd7a)

* With disabled footer alternative links to terms can be set, otherwise the default is used
* with enabled footer only the default terms are being used.