### PR TITLE
Prepare future voting variants

### DIFF
--- a/lib/Controller/PollApiController.php
+++ b/lib/Controller/PollApiController.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace OCA\Polls\Controller;
 
+use OCA\Polls\Db\Poll;
 use OCA\Polls\Service\CommentService;
 use OCA\Polls\Service\OptionService;
 use OCA\Polls\Service\PollService;
@@ -78,8 +79,8 @@ class PollApiController extends BaseApiV2Controller {
 	#[NoAdminRequired]
 	#[NoCSRFRequired]
 	#[ApiRoute(verb: 'POST', url: '/api/v1.0/poll', requirements: ['apiVersion' => '(v2)'])]
-	public function add(string $type, string $title): DataResponse {
-		return $this->responseCreate(fn () => ['poll' => $this->pollService->add($type, $title)]);
+	public function add(string $type, string $title, string $votingVariant = Poll::VARIANT_SIMPLE): DataResponse {
+		return $this->responseCreate(fn () => ['poll' => $this->pollService->add($type, $title, $votingVariant)]);
 	}
 
 	/**

--- a/lib/Controller/PollController.php
+++ b/lib/Controller/PollController.php
@@ -95,8 +95,8 @@ class PollController extends BaseController {
 	 */
 	#[NoAdminRequired]
 	#[FrontpageRoute(verb: 'POST', url: '/poll/add')]
-	public function add(string $type, string $title): JSONResponse {
-		return $this->responseCreate(fn () => $this->pollService->add($type, $title));
+	public function add(string $type, string $title, string $votingVariant = Poll::VARIANT_SIMPLE): JSONResponse {
+		return $this->responseCreate(fn () => $this->pollService->add($type, $title, $votingVariant));
 	}
 
 	/**

--- a/lib/Db/Poll.php
+++ b/lib/Db/Poll.php
@@ -62,6 +62,8 @@ use OCP\IURLGenerator;
  * @method void setLastInteraction(int $value)
  * @method string getMiscSettings()
  * @method void setMiscSettings(string $value)
+ * @method string getVotingVariant()
+ * @method void setVotingVariant(string $value)
  *
  * Magic functions for joined columns
  * @method int getMinDate()
@@ -81,6 +83,7 @@ class Poll extends EntityWithUser implements JsonSerializable {
 	public const TABLE = 'polls_polls';
 	public const TYPE_DATE = 'datePoll';
 	public const TYPE_TEXT = 'textPoll';
+	public const VARIANT_SIMPLE = 'simple';
 	public const ACCESS_HIDDEN = 'hidden';
 	public const ACCESS_PUBLIC = 'public';
 	public const ACCESS_PRIVATE = 'private';
@@ -157,6 +160,7 @@ class Poll extends EntityWithUser implements JsonSerializable {
 	protected int $useNo = 0;
 	protected int $lastInteraction = 0;
 	protected ?string $miscSettings = '';
+	protected string $votingVariant = '';
 
 	// joined columns
 	protected ?int $isCurrentUserLocked = 0;
@@ -216,6 +220,7 @@ class Poll extends EntityWithUser implements JsonSerializable {
 		return [
 			'id' => $this->getId(),
 			'type' => $this->getType(),
+			'votingVariant' => $this->getVotingVariant(),
 			// editable settings
 			'configuration' => $this->getConfigurationArray(),
 			// read only properties

--- a/lib/Migration/TableSchema.php
+++ b/lib/Migration/TableSchema.php
@@ -47,7 +47,7 @@ abstract class TableSchema {
 	public const COMMON_INDICES = [
 		'polls_polls_owners_non_deleted' => ['table' => Poll::TABLE, 'name' => 'polls_polls_owners_non_deleted', 'unique' => false, 'columns' => ['owner', 'deleted']],
 	];
-	
+
 	public const UNIQUE_INDICES = [
 		Option::TABLE => ['name' => 'UNIQ_options', 'unique' => true, 'columns' => ['poll_id', 'poll_option_hash', 'timestamp']],
 		Log::TABLE => ['name' => 'UNIQ_unprocessed', 'unique' => true, 'columns' => ['processed', 'poll_id', 'user_id', 'message_id']],
@@ -171,6 +171,7 @@ abstract class TableSchema {
 			'use_no' => ['type' => Types::BIGINT, 'options' => ['notnull' => true, 'default' => 1, 'length' => 20]],
 			'last_interaction' => ['type' => Types::BIGINT, 'options' => ['notnull' => true, 'default' => 0, 'length' => 20]],
 			'misc_settings' => ['type' => Types::TEXT, 'options' => ['notnull' => false, 'default' => null, 'length' => 65535]],
+			'voting_variant' => ['type' => Types::STRING, 'options' => ['notnull' => true, 'default' => 'simple', 'length' => 64]],
 		],
 		Option::TABLE => [
 			'id' => ['type' => Types::BIGINT, 'options' => ['autoincrement' => true, 'notnull' => true, 'length' => 20]],

--- a/lib/Migration/Version080000Date20250413195001.php
+++ b/lib/Migration/Version080000Date20250413195001.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Polls\Migration;
+
+use Doctrine\DBAL\Types\Type;
+use OCA\Polls\Db\Poll;
+use OCA\Polls\Db\TableManager;
+use OCP\DB\ISchemaWrapper;
+use OCP\IDBConnection;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Installation class for the polls app.
+ * Initial db creation
+ * Changed class naming: Version[jjmmpp]Date[YYYYMMDDHHMMSS]
+ * Version: jj = major version, mm = minor, pp = patch
+ *
+ * @psalm-suppress UnusedClass
+ */
+class Version080000Date20250413195001 extends SimpleMigrationStep {
+	private ISchemaWrapper $schema;
+
+	public function __construct(
+		private TableManager $tableManager,
+		private IDBConnection $connection,
+	) {
+	}
+
+	/**
+	 * $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 */
+	public function changeSchema(IOutput $output, \Closure $schemaClosure, array $options) {
+		$this->schema = $schemaClosure();
+		$messages = $this->createTables();
+
+		foreach ($messages as $message) {
+			$output->info('Polls - ' . $message);
+		};
+
+		return $this->schema;
+	}
+
+	/**
+	 * @return string[]
+	 *
+	 * @psalm-return non-empty-list<string>
+	 */
+	public function createTable(string $tableName, array $columns): array {
+		$messages = [];
+
+		if ($this->schema->hasTable($tableName)) {
+			$table = $this->schema->getTable($tableName);
+			$messages[] = 'Validating table ' . $table->getName();
+			$tableCreated = false;
+		} else {
+			$table = $this->schema->createTable($tableName);
+			$tableCreated = true;
+			$messages[] = 'Creating table ' . $table->getName();
+		}
+
+		foreach ($columns as $columnName => $columnDefinition) {
+			if ($table->hasColumn($columnName)) {
+				$column = $table->getColumn($columnName);
+				if (Type::lookupName($column->getType()) !== $columnDefinition['type']) {
+					$messages[] = 'Migrated type of ' . $table->getName() . '[\'' . $columnName . '\'] from ' . Type::lookupName($column->getType()) . ' to ' . $columnDefinition['type'];
+					$column->setType(Type::getType($columnDefinition['type']));
+				}
+				$column->setOptions($columnDefinition['options']);
+
+				// force change to current options definition
+				$table->modifyColumn($columnName, $columnDefinition['options']);
+			} else {
+				$table->addColumn($columnName, $columnDefinition['type'], $columnDefinition['options']);
+				$messages[] = 'Added ' . $table->getName() . ', ' . $columnName . ' (' . $columnDefinition['type'] . ')';
+			}
+		}
+
+		if ($tableCreated) {
+			$table->setPrimaryKey(['id']);
+		}
+		return $messages;
+	}
+
+	/**
+	 * @return string[]
+	 *
+	 * @psalm-return non-empty-list<string>
+	 */
+	public function createTables(): array {
+		$messages = [];
+
+		foreach (TableSchema::TABLES as $tableName => $columns) {
+			$messages = array_merge($messages, $this->createTable($tableName, $columns));
+		}
+		return $messages;
+	}
+}

--- a/lib/Service/PollService.php
+++ b/lib/Service/PollService.php
@@ -177,7 +177,7 @@ class PollService {
 	/**
 	 * Add poll
 	 */
-	public function add(string $type, string $title): Poll {
+	public function add(string $type, string $title, string $votingVariant = Poll::VARIANT_SIMPLE): Poll {
 		if (!$this->appSettings->getPollCreationAllowed()) {
 			throw new ForbiddenException('Poll creation is disabled');
 		}
@@ -194,6 +194,7 @@ class PollService {
 		$timestamp = time();
 		$this->poll = new Poll();
 		$this->poll->setType($type);
+		$this->poll->setVotingVariant($votingVariant);
 		$this->poll->setTitle($title);
 		$this->poll->setCreated($timestamp);
 		$this->poll->setLastInteraction($timestamp);
@@ -392,6 +393,7 @@ class PollService {
 		$this->poll->setAccess(Poll::ACCESS_PRIVATE);
 
 		$this->poll->setType($origin->getType());
+		$this->poll->setVotingVariant($origin->getVotingVariant());
 		$this->poll->setDescription($origin->getDescription());
 		$this->poll->setExpire($origin->getExpire());
 		// deanonymize cloned polls by default, to avoid locked anonymous polls

--- a/src/stores/poll.ts
+++ b/src/stores/poll.ts
@@ -34,6 +34,10 @@ export enum PollType {
 	Date = 'datePoll',
 }
 
+export enum VoteVariant {
+	Simple = 'simple',
+}
+
 export enum AccessType {
 	Private = 'private',
 	Open = 'open',
@@ -128,6 +132,7 @@ export type CurrentUserStatus = {
 export type Poll = {
 	id: number
 	type: PollType
+	voteVariant: VoteVariant
 	descriptionSafe: string
 	configuration: PollConfiguration
 	owner: User
@@ -146,6 +151,7 @@ export const usePollStore = defineStore('poll', {
 	state: (): Poll => ({
 		id: 0,
 		type: PollType.Date,
+		voteVariant: VoteVariant.Simple,
 		descriptionSafe: '',
 		configuration: {
 			title: '',


### PR DESCRIPTION
Introduces voting variants for polls
* yes/no/may will be used as `simple` variant
* polls get a new attribute `votingVariant`

Voting variants may have a huge impact on configuration combinations. So this is why the base is introduced in 8.0.0 to allow further development.

addressing:
#3897
#3472
#3306
#1694
#1094
#765
#670