### PR TITLE
change loglevel

### DIFF
--- a/lib/Model/Settings/AppSettings.php
+++ b/lib/Model/Settings/AppSettings.php
@@ -138,7 +138,7 @@ class AppSettings implements JsonSerializable {
 				return true;
 			}
 
-			$this->logger->warning('Setting type does not match', [
+			$this->logger->debug('Setting type does not match', [
 				'app' => $app,
 				'key' => $key,
 				'expectedType' => $expectedType,
@@ -146,7 +146,7 @@ class AppSettings implements JsonSerializable {
 			]);
 
 		} catch (\Exception $e) {
-			$this->logger->warning('Could not get setting type', [
+			$this->logger->debug('Could not get setting type', [
 				'app' => $app,
 				'key' => $key,
 				'expectedType' => $expectedType,


### PR DESCRIPTION
fixes #4019

Missing or invalid config keys got logged at `warning` level
Changed to `debug`