### PR TITLE
Use different formatted language code for luxon

### DIFF
--- a/lib/Model/UserBase.php
+++ b/lib/Model/UserBase.php
@@ -167,7 +167,7 @@ class UserBase implements JsonSerializable {
 		return $this->languageCode;
 	}
 
-	public function getLanguageCodeFixed(): string {
+	public function getLanguageCodeIntl(): string {
 		return str_replace('_', '-', $this->languageCode);
 	}
 
@@ -327,7 +327,7 @@ class UserBase implements JsonSerializable {
 			'isNoUser' => $this->getIsNoUser(),
 			'isUnrestrictedOwner' => $this->getIsUnrestrictedPollOwner(),
 			'languageCode' => $this->getLanguageCode(),
-			'languageCodeFixed' => $this->getLanguageCodeFixed(),
+			'languageCodeIntl' => $this->getLanguageCodeIntl(),
 			'localeCode' => $this->getLocaleCode(),
 			'organisation' => $this->getOrganisation(),
 			'subname' => $this->getSubName(),

--- a/lib/Model/UserBase.php
+++ b/lib/Model/UserBase.php
@@ -168,7 +168,7 @@ class UserBase implements JsonSerializable {
 	}
 
 	public function getLanguageCodeFixed(): string {
-		return str_replace('_', '-' ,$this->languageCode);
+		return str_replace('_', '-', $this->languageCode);
 	}
 
 	public function getLocaleCode(): string {

--- a/lib/Model/UserBase.php
+++ b/lib/Model/UserBase.php
@@ -167,6 +167,10 @@ class UserBase implements JsonSerializable {
 		return $this->languageCode;
 	}
 
+	public function getLanguageCodeFixed(): string {
+		return str_replace('_', '-' ,$this->languageCode);
+	}
+
 	public function getLocaleCode(): string {
 		if (!$this->localeCode) {
 			return $this->languageCode;
@@ -323,6 +327,7 @@ class UserBase implements JsonSerializable {
 			'isNoUser' => $this->getIsNoUser(),
 			'isUnrestrictedOwner' => $this->getIsUnrestrictedPollOwner(),
 			'languageCode' => $this->getLanguageCode(),
+			'languageCodeFixed' => $this->getLanguageCodeFixed(),
 			'localeCode' => $this->getLocaleCode(),
 			'organisation' => $this->getOrganisation(),
 			'subname' => $this->getSubName(),

--- a/src/Types/index.ts
+++ b/src/Types/index.ts
@@ -164,7 +164,7 @@ export type User = {
 	desc: string | null
 	organisation: string | null
 	languageCode: string
-	languageCodeFixed: string
+	languageCodeIntl: string
 	localeCode: string | null
 	timeZone: string | null
 	categories: string[] | null

--- a/src/Types/index.ts
+++ b/src/Types/index.ts
@@ -164,6 +164,7 @@ export type User = {
 	desc: string | null
 	organisation: string | null
 	languageCode: string
+	languageCodeFixed: string
 	localeCode: string | null
 	timeZone: string | null
 	categories: string[] | null

--- a/src/components/Base/modules/DateBox.vue
+++ b/src/components/Base/modules/DateBox.vue
@@ -16,7 +16,7 @@ const { dateTime: luxonDate, duration: luxonDuration = Duration.fromMillis(0) } 
 	defineProps<Props>()
 
 const from = computed(() =>
-	luxonDate.setLocale(sessionStore.currentUser.languageCode),
+	luxonDate.setLocale(sessionStore.currentUser.languageCodeFixed),
 )
 
 const sessionStore = useSessionStore()

--- a/src/components/Base/modules/DateBox.vue
+++ b/src/components/Base/modules/DateBox.vue
@@ -16,7 +16,7 @@ const { dateTime: luxonDate, duration: luxonDuration = Duration.fromMillis(0) } 
 	defineProps<Props>()
 
 const from = computed(() =>
-	luxonDate.setLocale(sessionStore.currentUser.languageCodeFixed),
+	luxonDate.setLocale(sessionStore.currentUser.languageCodeIntl),
 )
 
 const sessionStore = useSessionStore()

--- a/src/components/Export/ExportPoll.vue
+++ b/src/components/Export/ExportPoll.vue
@@ -212,7 +212,7 @@ function getIntervalRaw(option: Option): string {
  */
 function getFromFormatted(option: Option): string {
 	return DateTime.fromSeconds(option.timestamp)
-		.setLocale(sessionStore.currentUser.languageCode)
+		.setLocale(sessionStore.currentUser.languageCodeFixed)
 		.toLocaleString(DateTime.DATETIME_MED_WITH_WEEKDAY)
 }
 
@@ -222,7 +222,7 @@ function getFromFormatted(option: Option): string {
  */
 function getToFormatted(option: Option): string {
 	return DateTime.fromSeconds(option.timestamp)
-		.setLocale(sessionStore.currentUser.languageCode)
+		.setLocale(sessionStore.currentUser.languageCodeFixed)
 		.plus({ seconds: option.duration })
 		.toLocaleString(DateTime.DATETIME_MED_WITH_WEEKDAY)
 }

--- a/src/components/Export/ExportPoll.vue
+++ b/src/components/Export/ExportPoll.vue
@@ -212,7 +212,7 @@ function getIntervalRaw(option: Option): string {
  */
 function getFromFormatted(option: Option): string {
 	return DateTime.fromSeconds(option.timestamp)
-		.setLocale(sessionStore.currentUser.languageCodeFixed)
+		.setLocale(sessionStore.currentUser.languageCodeIntl)
 		.toLocaleString(DateTime.DATETIME_MED_WITH_WEEKDAY)
 }
 
@@ -222,7 +222,7 @@ function getFromFormatted(option: Option): string {
  */
 function getToFormatted(option: Option): string {
 	return DateTime.fromSeconds(option.timestamp)
-		.setLocale(sessionStore.currentUser.languageCodeFixed)
+		.setLocale(sessionStore.currentUser.languageCodeIntl)
 		.plus({ seconds: option.duration })
 		.toLocaleString(DateTime.DATETIME_MED_WITH_WEEKDAY)
 }

--- a/src/components/Options/OptionItemDateBox.vue
+++ b/src/components/Options/OptionItemDateBox.vue
@@ -19,7 +19,7 @@ const { timeStamp, durationSeconds = 0 } = defineProps<Props>()
 
 // computed from as DateTime from Luxon
 const from = DateTime.fromSeconds(timeStamp).setLocale(
-	sessionStore.currentUser.languageCodeFixed,
+	sessionStore.currentUser.languageCodeIntl,
 )
 
 const duration = Duration.fromMillis(durationSeconds * 1000)

--- a/src/components/Options/OptionItemDateBox.vue
+++ b/src/components/Options/OptionItemDateBox.vue
@@ -19,7 +19,7 @@ const { timeStamp, durationSeconds = 0 } = defineProps<Props>()
 
 // computed from as DateTime from Luxon
 const from = DateTime.fromSeconds(timeStamp).setLocale(
-	sessionStore.currentUser.languageCode,
+	sessionStore.currentUser.languageCodeFixed,
 )
 
 const duration = Duration.fromMillis(durationSeconds * 1000)

--- a/src/components/Options/OptionsDateAddDialog.vue
+++ b/src/components/Options/OptionsDateAddDialog.vue
@@ -86,13 +86,13 @@ const dateTimeOptionsFiltered = computed(() => {
 // computed from as DateTime from Luxon
 const from = computed(() => {
 	const dateFrom = DateTime.fromJSDate(fromInput.value).setLocale(
-		sessionStore.currentUser.languageCodeFixed,
+		sessionStore.currentUser.languageCodeIntl,
 	)
 	// if the option is an all day option, the time is set to 00:00
 	if (allDay.value) {
 		return dateFrom
 			.startOf('day')
-			.setLocale(sessionStore.currentUser.languageCodeFixed)
+			.setLocale(sessionStore.currentUser.languageCodeIntl)
 	}
 	return dateFrom
 })

--- a/src/components/Options/OptionsDateAddDialog.vue
+++ b/src/components/Options/OptionsDateAddDialog.vue
@@ -86,13 +86,13 @@ const dateTimeOptionsFiltered = computed(() => {
 // computed from as DateTime from Luxon
 const from = computed(() => {
 	const dateFrom = DateTime.fromJSDate(fromInput.value).setLocale(
-		sessionStore.currentUser.languageCode,
+		sessionStore.currentUser.languageCodeFixed,
 	)
 	// if the option is an all day option, the time is set to 00:00
 	if (allDay.value) {
 		return dateFrom
 			.startOf('day')
-			.setLocale(sessionStore.currentUser.languageCode)
+			.setLocale(sessionStore.currentUser.languageCodeFixed)
 	}
 	return dateFrom
 })


### PR DESCRIPTION
fixes #4032

Luxon uses different language codes. Nextcloud gives i.e. `en_GB`, but Luxon expects `en-GB`.

See https://moment.github.io/luxon/api-docs/index.html#datetimesetlocale

Luxon seems to rely on the Intl-Formatting. 

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl