### PR TITLE
variant of fixed vote table header

### DIFF
--- a/src/components/Cards/VoteInfoCards.vue
+++ b/src/components/Cards/VoteInfoCards.vue
@@ -80,7 +80,7 @@ const showRegisterCard = computed(
 
 <style lang="scss" scoped>
 .vote-info-cards {
-	margin: auto;
+	// margin: auto;
 	display: flex;
 	gap: 1rem;
 	flex-wrap: wrap;
@@ -94,6 +94,7 @@ const showRegisterCard = computed(
 	.notecard {
 		margin: unset;
 		flex: 1 calc(var(--cap-width) / 2);
+		max-width: var(--cap-width);
 	}
 }
 </style>

--- a/src/components/VoteTable/VoteTable.vue
+++ b/src/components/VoteTable/VoteTable.vue
@@ -262,6 +262,7 @@ async function loadMore() {
 		.option-item {
 			grid-row: 2;
 			position: sticky;
+			opacity: 0.85;
 			top: 0;
 			z-index: 2;
 			background-color: var(--color-main-background);

--- a/src/views/Vote.vue
+++ b/src/views/Vote.vue
@@ -154,13 +154,22 @@ onUnmounted(() => {
 </template>
 
 <style lang="scss">
-.table-view.fixed-table-header .vote_main {
+.table-view .vote_main {
 	flex: 1;
 	overflow: auto;
 	overscroll-behavior-inline: contain;
 
 	.vote-table {
 		max-height: 75vh;
+		min-height: 16.6rem;
+	}
+}
+
+.table-view.fixed-table-header .vote_main {
+	display: flex;
+	flex-direction: column;
+	.vote-table {
+		min-height: 18rem;
 	}
 }
 


### PR DESCRIPTION
* make fixed vote header default
* add a variant with flex items (activate by user settings)
  In the result only the table is scrollable.
  Side effect is a narrow vote table on small screens and when a lot of info cards are used

with info cards | without info cards
-|-
![grafik](https://github.com/user-attachments/assets/44e519b4-1b56-459f-b68f-09e6913d416b) | ![grafik](https://github.com/user-attachments/assets/d51ad83a-10d1-4aec-a5a3-490dde58dfbf)
![grafik](https://github.com/user-attachments/assets/53a7781d-1e4b-411b-b97b-25e938aebf48) | ![grafik](https://github.com/user-attachments/assets/1dfdb6cf-f066-453e-9b46-32e2460bbb0d)



