### PR TITLE
Fix setting log entries to processed on sent notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,14 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [8.1.4] - 2025-07-15
 ### Fixes
  - Fixed some typos
  - Removed inaccessible polls from polls overview
  - Removed link target from inaccessible polls in navigation
  - Removed clone action from inaccessible polls in navigation
  - Fixed visual bug when scrolling in list view
+ - Fixed exception on notifications which may cause resending notification mails
 
 ### changes
  - Center poll table

--- a/lib/Db/LogMapper.php
+++ b/lib/Db/LogMapper.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace OCA\Polls\Db;
 
 use OCP\AppFramework\Db\QBMapper;
+use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
 
 /**
@@ -31,7 +32,8 @@ class LogMapper extends QBMapper {
 
 		$qb->select('*')
 			->from($this->getTableName())
-			->where($qb->expr()->isNotNull('poll_id'));
+			->where($qb->expr()->isNotNull('poll_id'))
+			->andWhere($qb->expr()->eq('processed', $qb->expr()->literal(0, IQueryBuilder::PARAM_INT)));
 		return $this->findEntities($qb);
 	}
 

--- a/lib/Service/MailService.php
+++ b/lib/Service/MailService.php
@@ -172,7 +172,7 @@ class MailService {
 		}
 
 		foreach ($this->logs as $logItem) {
-			$logItem->setProcessed(microtime(true)*1000);
+			$logItem->setProcessed(intval(microtime(true) * 1000));
 			$this->logMapper->update($logItem);
 			usleep(5000);
 		}

--- a/lib/Service/MailService.php
+++ b/lib/Service/MailService.php
@@ -172,8 +172,9 @@ class MailService {
 		}
 
 		foreach ($this->logs as $logItem) {
-			$logItem->setProcessed(time());
+			$logItem->setProcessed(microtime(true)*1000);
 			$this->logMapper->update($logItem);
+			usleep(5000);
 		}
 	}
 


### PR DESCRIPTION
* fix selecton of unprocessed entries
* switch processed timestamp to ms to avoid further exceptions
* sleep 5 ms between processed markers to avoid same ms timestamp on fast machines
fixes #4165 