### PR TITLE
Just patch diff to poll store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,14 @@ All notable changes to this project will be documented in this file.
  - Make vote cell focusable
  - Make shadow of sticky items transparent
  - Changed experimental comments layout
+ - improve poll loading times again by applying diffs after updates
 
 ### Fixes
  - Force list view mode initially on mobile viewports
  - Fix some visual issues of the vote page
  - Bring back indicator for confirmed options after closing the poll
  - Add CSP to allow worker
+ - fix loading archived polls
 
 ## [8.1.4] - 2025-07-15
 ### Fixes

--- a/lib/Controller/PollApiController.php
+++ b/lib/Controller/PollApiController.php
@@ -97,7 +97,7 @@ class PollApiController extends BaseApiV2Controller {
 	#[NoCSRFRequired]
 	#[ApiRoute(verb: 'PUT', url: '/api/v1.0/poll/{pollId}', requirements: ['apiVersion' => '(v2)'])]
 	public function update(int $pollId, array $pollConfiguration): DataResponse {
-		return $this->response(fn () => ['poll' => $this->pollService->update($pollId, $pollConfiguration)]);
+		return $this->response(fn () => $this->pollService->update($pollId, $pollConfiguration));
 	}
 
 	/**

--- a/lib/Controller/PollController.php
+++ b/lib/Controller/PollController.php
@@ -196,9 +196,7 @@ class PollController extends BaseController {
 	#[OpenAPI(OpenAPI::SCOPE_IGNORE)]
 	#[FrontpageRoute(verb: 'PUT', url: '/poll/{pollId}')]
 	public function update(int $pollId, array $poll): JSONResponse {
-		return $this->response(fn () => [
-			'poll' => $this->pollService->update($pollId, $poll),
-		]);
+		return $this->response(fn () => $this->pollService->update($pollId, $poll));
 	}
 
 	/**

--- a/lib/Db/Poll.php
+++ b/lib/Db/Poll.php
@@ -559,13 +559,15 @@ class Poll extends EntityWithUser implements JsonSerializable {
 
 	/**
 	 * Request a permission level and get exception if denied
+	 * @param string $permission The permission to request
+	 * @return Poll Returns the current poll object
 	 * @throws ForbiddenException Thrown if access is denied
 	 */
-	public function request(string $permission): bool {
+	public function request(string $permission): Poll {
 		if (!$this->getIsAllowed($permission)) {
 			throw new ForbiddenException('denied permission ' . $permission);
 		}
-		return true;
+		return $this;
 	}
 
 	/**
@@ -868,8 +870,13 @@ class Poll extends EntityWithUser implements JsonSerializable {
 	 * Checks, if poll owner is allowed to deanonymize votes
 	 **/
 	private function getAllowDeanonymize(): bool {
-		// Current user is allowed to edit the poll and the owner of the poll is unrestricted
-		return $this->getAnonymous() > -1 && $this->getAllowEditPoll() && $this->getUser()->getIsUnrestrictedPollOwner();
+		// Deanonymization is only allowed,
+		// if the anonymize setting is not locked
+		// and the current user is allowed to edit the poll
+		// and the owner of the poll is unrestricted
+		return $this->getAnonymous() > -1
+			&& $this->getAllowEditPoll()
+			&& $this->getUser()->getIsUnrestrictedPollOwner();
 	}
 
 	/**

--- a/lib/Service/CommentService.php
+++ b/lib/Service/CommentService.php
@@ -36,11 +36,11 @@ class CommentService {
 	 */
 	public function list(int $pollId): array {
 		try {
-			$this->pollMapper->get($pollId, withRoles: true)->request(Poll::PERMISSION_COMMENT_ADD);
+			$this->pollMapper->get($pollId, true, withRoles: true)
+				->request(Poll::PERMISSION_COMMENT_ADD);
 		} catch (Exception $e) {
 			return [];
 		}
-		$this->pollMapper->get($pollId, withRoles: true)->request(Poll::PERMISSION_COMMENT_ADD);
 
 		$comments = $this->commentMapper->findByPoll($pollId);
 		// treat comments from the same user within 5 minutes as grouped comments
@@ -66,8 +66,8 @@ class CommentService {
 	 * Add comment
 	 */
 	public function add(string $message, int $pollId, ?bool $confidential = false): Comment {
-		$poll = $this->pollMapper->get($pollId, withRoles: true);
-		$poll->request(Poll::PERMISSION_COMMENT_ADD);
+		$poll = $this->pollMapper->get($pollId, withRoles: true)
+			->request(Poll::PERMISSION_COMMENT_ADD);
 
 		if ($poll->getForceConfidentialComments()) {
 			$confidential = true;
@@ -104,7 +104,8 @@ class CommentService {
 		$this->comment = $this->commentMapper->find($commentId);
 
 		if (!$this->comment->getCurrentUserIsEntityUser()) {
-			$this->pollMapper->get($this->comment->getPollId(), withRoles: true)->request(Poll::PERMISSION_COMMENT_DELETE);
+			$this->pollMapper->get($this->comment->getPollId(), withRoles: true)
+				->request(Poll::PERMISSION_COMMENT_DELETE);
 		}
 
 		$this->comment->setDeleted($restore ? 0 : time());

--- a/lib/Service/DiffService.php
+++ b/lib/Service/DiffService.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Polls\Service;
+
+use OCP\AppFramework\Db\Entity;
+
+/**
+ * DiffService is responsible for calculating the differences between two objects.
+ * It can be used to compare a base object with a comparison object and retrieve
+ * the differences in various formats.
+ *
+ */
+class DiffService {
+	private Entity $compareObject;
+	private array $diff = [];
+	private string $baseJson = '';
+
+	/**
+	 * Constructor for DiffService
+	 *
+	 * @param Entity $baseObject The base object to compare against
+	 * @throws \JsonException If the base object cannot be serialized to JSON
+	 *
+	 * @psalm-param Entity $baseObject
+	 */
+	public function __construct(
+		private Entity $baseObject,
+	) {
+		$this->init();
+	}
+
+	private function init(): void {
+		$this->baseJson = json_encode($this->baseObject);
+	}
+	public function setComparisonObject(\OCA\Polls\Db\Poll $compareObject): void {
+		$this->compareObject = $compareObject;
+		$this->calculateDiff();
+	}
+
+	/**
+	 * Get the full diff between the base object and the comparison object
+	 *
+	 * This method returns an associative array where keys are the paths to the changed values
+	 * and values are arrays containing 'old' and 'new' values.
+	 *
+	 * @return array An associative array containing the differences
+	 *
+	 * @psalm-return array<string, array{old: mixed, new: mixed}>
+	 */
+	public function getFullDiff(): array {
+		return $this->diff;
+	}
+
+	/**
+	 * Get the new values from the diff, preserving the structure of the original object
+	 * This method will return an associative array where keys are the paths to the new values
+	 * and values are the new values themselves.
+	 *
+	 * @return array An associative array containing the new values
+	 *
+	 * @psalm-return array<string, mixed>
+	 */
+	public function getNewValuesDiff(): array {
+		$newValues = [];
+
+		// Recursively search for "new" values and preserve the structure
+		$this->extractNewValues($this->diff, $newValues);
+
+		return $newValues;
+	}
+
+	/**
+	 * Calculate the difference between the base object and the comparison object.
+	 *
+	 * This method serializes the objects to JSON, decodes them into associative arrays,
+	 * and then compares the arrays recursively to find differences.
+	 */
+	private function calculateDiff(): void {
+		// Serialize the objects to JSON format
+		$compareJson = json_encode($this->compareObject);
+
+		// Decode the JSON strings back to associative arrays
+		$baseArray = json_decode($this->baseJson, true);
+		$compareArray = json_decode($compareJson, true);
+
+		// Compare the arrays recursively
+		$this->diff = $this->array_diff_recursive($baseArray, $compareArray);
+	}
+
+	/**
+	 * Recursively extract new values from the diff array.
+	 *
+	 * @param array $diff The diff array containing changes.
+	 * @param array $newValues The array to populate with new values, preserving the structure.
+	 */
+	private function extractNewValues($diff, &$newValues): void {
+		foreach ($diff as $key => $value) {
+			if (is_array($value)) {
+				// If 'new' exists, add it to the correct position in the structure
+				if (isset($value['new'])) {
+					$newValues[$key] = $value['new'];
+				}
+
+				// If the element is an array and the key isn't set yet, initialize it
+				if (!isset($newValues[$key])) {
+					$newValues[$key] = [];
+				}
+
+				// Recursively process nested arrays
+				$this->extractNewValues($value, $newValues[$key]);
+			}
+		}
+	}
+
+	/**
+	 * Recursively compare two arrays and return the differences
+	 *
+	 * This method compares two arrays recursively and returns an associative array
+	 *
+	 * @param array $baseArray The base array to compare against
+	 * @param array $compareArray The array to compare with the base array
+	 * @return array An associative array containing the differences
+	 *
+	 * @psalm-return array<array-key, non-empty-array<string, array{new: mixed, old: mixed}|mixed|null>>
+	 */
+	private function array_diff_recursive($baseArray, $compareArray): array {
+		$diff = [];
+
+		foreach ($baseArray as $key => $value) {
+			if (is_array($value) && isset($compareArray[$key]) && is_array($compareArray[$key])) {
+				$recursiveDiff = $this->array_diff_recursive($value, $compareArray[$key]);
+				if (!empty($recursiveDiff)) {
+					$diff[$key] = $recursiveDiff;
+				}
+			} elseif (!isset($compareArray[$key]) || $value !== $compareArray[$key]) {
+				$diff[$key] = ['old' => $value, 'new' => $compareArray[$key] ?? null];
+			}
+		}
+
+		// Loop through the second array to find keys that are not in the first array
+		foreach ($compareArray as $key => $value) {
+			if (!isset($baseArray[$key])) {
+				$diff[$key] = ['old' => null, 'new' => $value];
+			}
+		}
+
+		return $diff;
+	}
+}

--- a/lib/Service/MailService.php
+++ b/lib/Service/MailService.php
@@ -228,7 +228,8 @@ class MailService {
 	 * Send a confirmation mail for the poll to all participants
 	 */
 	public function sendConfirmations(int $pollId): SentResult {
-		$this->pollMapper->get($pollId, withRoles: true)->request(Poll::PERMISSION_POLL_EDIT);
+		$this->pollMapper->get($pollId, withRoles: true)
+			->request(Poll::PERMISSION_POLL_EDIT);
 		$sentResult = new SentResult();
 
 		$participants = $this->userMapper->getParticipants($pollId);

--- a/lib/Service/OptionService.php
+++ b/lib/Service/OptionService.php
@@ -199,7 +199,8 @@ class OptionService {
 		$option = $this->optionMapper->find($optionId);
 
 		if (!$option->getCurrentUserIsEntityUser()) {
-			$this->pollMapper->get($option->getPollId(), withRoles: true)->request(Poll::PERMISSION_OPTION_DELETE);
+			$this->pollMapper->get($option->getPollId(), withRoles: true)
+				->request(Poll::PERMISSION_OPTION_DELETE);
 		}
 
 		$option->setDeleted($restore ? 0 : time());
@@ -330,8 +331,9 @@ class OptionService {
 	 * Copy options from $fromPoll to $toPoll
 	 */
 	public function clone(int $fromPollId, int $toPollId): void {
-		$this->pollMapper->get($fromPollId, withRoles: true)->request(Poll::PERMISSION_POLL_VIEW);
-		$this->pollMapper->get($toPollId, withRoles: true)->request(Poll::PERMISSION_OPTION_ADD);
+		$this->pollMapper->get($fromPollId, withRoles: true)
+			->request(Poll::PERMISSION_POLL_VIEW)
+			->request(Poll::PERMISSION_OPTION_ADD);
 
 		foreach ($this->optionMapper->findByPoll($fromPollId) as $origin) {
 			$option = new Option();
@@ -442,7 +444,7 @@ class OptionService {
 	 */
 	private function getPoll(int $pollId, string $permission = Poll::PERMISSION_POLL_VIEW): void {
 		if ($this->poll->getId() !== $pollId) {
-			$this->poll = $this->pollMapper->get($pollId, withRoles: true);
+			$this->poll = $this->pollMapper->get($pollId, true, withRoles: true);
 		}
 		$this->poll->request($permission);
 	}

--- a/lib/Service/PollGroupService.php
+++ b/lib/Service/PollGroupService.php
@@ -64,8 +64,8 @@ class PollGroupService {
 		?int $pollGroupId = null,
 		?string $pollGroupName = null,
 	): PollGroup {
-		$poll = $this->pollMapper->get($pollId, withRoles: true);
-		$poll->request(Poll::PERMISSION_POLL_EDIT);
+		$poll = $this->pollMapper->get($pollId, withRoles: true)
+			->request(Poll::PERMISSION_POLL_EDIT);
 
 		// Without poll group id, we create a new poll group
 		if ($pollGroupId === null
@@ -112,8 +112,8 @@ class PollGroupService {
 		int $pollId,
 		int $pollGroupId,
 	): ?PollGroup {
-		$poll = $this->pollMapper->get($pollId, withRoles: true);
-		$poll->request(Poll::PERMISSION_POLL_EDIT);
+		$poll = $this->pollMapper->get($pollId, withRoles: true)
+			->request(Poll::PERMISSION_POLL_EDIT);
 
 		$pollGroup = $this->pollGroupMapper->find($pollGroupId);
 

--- a/lib/Service/PollService.php
+++ b/lib/Service/PollService.php
@@ -248,8 +248,8 @@ class PollService {
 	 * @psalm-return array{poll: Poll, diff: array, changes: array}
 	 */
 	public function update(int $pollId, array $pollConfiguration): array {
-		$this->poll = $this->pollMapper->get($pollId, withRoles: true);
-		$this->poll->request(Poll::PERMISSION_POLL_EDIT);
+		$this->poll = $this->pollMapper->get($pollId, withRoles: true)
+			->request(Poll::PERMISSION_POLL_EDIT);
 
 		// Validate valuess
 		if (isset($pollConfiguration['showResults']) && !in_array($pollConfiguration['showResults'], $this->getValidShowResults())) {
@@ -336,8 +336,8 @@ class PollService {
 	 * @return Poll
 	 */
 	public function toggleArchive(int $pollId): Poll {
-		$this->poll = $this->pollMapper->find($pollId);
-		$this->poll->request(Poll::PERMISSION_POLL_DELETE);
+		$this->poll = $this->pollMapper->find($pollId)
+			->request(Poll::PERMISSION_POLL_DELETE);
 
 		$this->poll->setDeleted($this->poll->getDeleted() ? 0 : time());
 		$this->poll = $this->pollMapper->update($this->poll);
@@ -357,12 +357,12 @@ class PollService {
 	 */
 	public function delete(int $pollId): Poll {
 		try {
-			$this->poll = $this->pollMapper->get($pollId, withRoles: true);
+			$this->poll = $this->pollMapper->get($pollId, withRoles: true)
+				->request(Poll::PERMISSION_POLL_DELETE);
 		} catch (DoesNotExistException $e) {
 			throw new AlreadyDeletedException('Poll not found, assume already deleted');
 		}
 
-		$this->poll->request(Poll::PERMISSION_POLL_DELETE);
 		$this->eventDispatcher->dispatchTyped(new PollDeletedEvent($this->poll));
 
 		$this->pollMapper->delete($this->poll);
@@ -374,7 +374,8 @@ class PollService {
 	 * @return Poll
 	 */
 	public function close(int $pollId): Poll {
-		$this->pollMapper->get($pollId, withRoles: true)->request(Poll::PERMISSION_POLL_EDIT);
+		$this->pollMapper->get($pollId, withRoles: true)
+			->request(Poll::PERMISSION_POLL_EDIT);
 		return $this->toggleClose($pollId, time() - 5);
 	}
 
@@ -383,7 +384,8 @@ class PollService {
 	 * @return Poll
 	 */
 	public function reopen(int $pollId): Poll {
-		$this->pollMapper->get($pollId, withRoles: true)->request(Poll::PERMISSION_POLL_EDIT);
+		$this->pollMapper->get($pollId, withRoles: true)
+			->request(Poll::PERMISSION_POLL_EDIT);
 		return $this->toggleClose($pollId, 0);
 	}
 
@@ -392,8 +394,8 @@ class PollService {
 	 * @return Poll
 	 */
 	private function toggleClose(int $pollId, int $expiry): Poll {
-		$this->poll = $this->pollMapper->find($pollId);
-		$this->poll->request(Poll::PERMISSION_POLL_EDIT);
+		$this->poll = $this->pollMapper->find($pollId)
+			->request(Poll::PERMISSION_POLL_EDIT);
 
 		$this->poll->setExpire($expiry);
 		if ($expiry > 0) {
@@ -412,8 +414,8 @@ class PollService {
 	 * @return Poll
 	 */
 	public function clone(int $pollId): Poll {
-		$origin = $this->pollMapper->get($pollId, withRoles: true);
-		$origin->request(Poll::PERMISSION_POLL_VIEW);
+		$origin = $this->pollMapper->get($pollId, withRoles: true)
+			->request(Poll::PERMISSION_POLL_VIEW);
 		$this->appSettings->getPollCreationAllowed();
 
 		$this->poll = new Poll();
@@ -444,8 +446,8 @@ class PollService {
 	 *
 	 */
 	public function getParticipantsEmailAddresses(int $pollId): array {
-		$this->poll = $this->pollMapper->get($pollId, withRoles: true);
-		$this->poll->request(Poll::PERMISSION_POLL_EDIT);
+		$this->poll = $this->pollMapper->get($pollId, withRoles: true)
+			->request(Poll::PERMISSION_POLL_EDIT);
 
 		$votes = $this->voteMapper->findParticipantsByPoll($this->poll->getId());
 		$list = [];

--- a/lib/Service/ShareService.php
+++ b/lib/Service/ShareService.php
@@ -88,8 +88,8 @@ class ShareService {
 	public function list(int $pollOrPollGroupId, string $purpose = 'poll'): array {
 		try {
 			if ($purpose === 'poll') {
-				$poll = $this->pollMapper->get($pollOrPollGroupId, withRoles: true);
-				$poll->request(Poll::PERMISSION_POLL_EDIT);
+				$poll = $this->pollMapper->get($pollOrPollGroupId, withRoles: true)
+					->request(Poll::PERMISSION_POLL_EDIT);
 				$this->shares = $this->shareMapper->findByPoll($pollOrPollGroupId, $poll->getPollGroups());
 			} else {
 				$this->pollGroupMapper->find($pollOrPollGroupId);
@@ -113,7 +113,8 @@ class ShareService {
 	 */
 	public function listNotInvited(int $pollId): array {
 		try {
-			$this->pollMapper->get($pollId, withRoles: true)->request(Poll::PERMISSION_POLL_EDIT);
+			$this->pollMapper->get($pollId, withRoles: true)
+				->request(Poll::PERMISSION_POLL_EDIT);
 			$this->shares = $this->shareMapper->findByPollNotInvited($pollId);
 		} catch (ForbiddenException $e) {
 			return [];
@@ -187,7 +188,8 @@ class ShareService {
 	 */
 	public function setType(string $token, string $type): Share {
 		$this->share = $this->shareMapper->findByToken($token);
-		$this->pollMapper->get($this->share->getPollId(), withRoles: true)->request(Poll::PERMISSION_POLL_EDIT);
+		$this->pollMapper->get($this->share->getPollId(), withRoles: true)
+			->request(Poll::PERMISSION_POLL_EDIT);
 
 		// ATM only type user can transform to type admin and vice versa
 		if (($type === Share::TYPE_ADMIN && $this->share->getType() === Share::TYPE_USER)
@@ -206,7 +208,8 @@ class ShareService {
 	public function setPublicPollEmail(string $token, string $value): Share {
 		try {
 			$this->share = $this->shareMapper->findByToken($token);
-			$this->pollMapper->get($this->share->getPollId(), withRoles: true)->request(Poll::PERMISSION_POLL_EDIT);
+			$this->pollMapper->get($this->share->getPollId(), withRoles: true)
+				->request(Poll::PERMISSION_POLL_EDIT);
 			$this->share->setPublicPollEmail($value);
 			$this->share = $this->shareMapper->update($this->share);
 		} catch (ShareNotFoundException $e) {
@@ -269,7 +272,8 @@ class ShareService {
 		$this->share = $this->shareMapper->findByToken($token);
 
 		if ($this->share->getType() === Share::TYPE_PUBLIC) {
-			$this->pollMapper->get($this->share->getPollId(), withRoles: true)->request(Poll::PERMISSION_POLL_EDIT);
+			$this->pollMapper->get($this->share->getPollId(), withRoles: true)
+				->request(Poll::PERMISSION_POLL_EDIT);
 			$this->share->setLabel($label);
 
 			// overwrite any possible displayName
@@ -433,9 +437,11 @@ class ShareService {
 	 */
 	public function delete(Share $share, bool $restore = false): Share {
 		if (!$share->getPollId() && $share->getGroupId()) {
-			$this->pollGroupMapper->find($share->getGroupId())->request(PollGroup::PERMISSION_POLL_GROUP_EDIT);
+			$this->pollGroupMapper->find($share->getGroupId())
+				->request(PollGroup::PERMISSION_POLL_GROUP_EDIT);
 		} else {
-			$this->pollMapper->get($share->getPollId(), withRoles: true)->request(Poll::PERMISSION_POLL_EDIT);
+			$this->pollMapper->get($share->getPollId(), withRoles: true)
+				->request(Poll::PERMISSION_POLL_EDIT);
 		}
 
 		$share->setDeleted($restore ? 0 : time());
@@ -464,7 +470,8 @@ class ShareService {
 	 * @param bool $unlock Set true, if share is to be unlocked
 	 */
 	private function lock(Share $share, bool $unlock = false): Share {
-		$this->pollMapper->get($share->getPollId(), withRoles: true)->request(Poll::PERMISSION_POLL_EDIT);
+		$this->pollMapper->get($share->getPollId(), withRoles: true)
+			->request(Poll::PERMISSION_POLL_EDIT);
 
 		$share->setLocked($unlock ? 0 : time());
 		$this->shareMapper->update($share);
@@ -586,9 +593,9 @@ class ShareService {
 		string $purpose = 'poll',
 	): Share {
 		if ($purpose === 'poll') {
-			$poll = $this->pollMapper->get($pollOrPollGroupId, withRoles: true);
-			$poll->request(Poll::PERMISSION_POLL_EDIT);
-			$poll->request(Poll::PERMISSION_SHARE_ADD);
+			$poll = $this->pollMapper->get($pollOrPollGroupId, withRoles: true)
+				->request(Poll::PERMISSION_POLL_EDIT)
+				->request(Poll::PERMISSION_SHARE_ADD);
 
 			if ($type === UserBase::TYPE_PUBLIC) {
 				$this->appSettings->getPublicSharesAllowed();

--- a/lib/Service/SubscriptionService.php
+++ b/lib/Service/SubscriptionService.php
@@ -27,7 +27,8 @@ class SubscriptionService {
 	}
 
 	public function get(int $pollId): bool {
-		$this->pollMapper->get($pollId, withRoles: true)->request(Poll::PERMISSION_POLL_VIEW);
+		$this->pollMapper->get($pollId, true, withRoles: true)
+			->request(Poll::PERMISSION_POLL_VIEW);
 
 		try {
 			$this->subscriptionMapper->findByPollAndUser($pollId, $this->userSession->getCurrentUserId());
@@ -53,7 +54,8 @@ class SubscriptionService {
 		} else {
 			try {
 				// $this->pollMapper->get($pollId, withRoles: true);
-				$this->pollMapper->get($pollId, withRoles: true)->request(Poll::PERMISSION_POLL_SUBSCRIBE);
+				$this->pollMapper->get($pollId, withRoles: true)
+					->request(Poll::PERMISSION_POLL_SUBSCRIBE);
 				$this->add($pollId, $this->userSession->getCurrentUserId());
 			} catch (ForbiddenException $e) {
 				return false;

--- a/lib/Service/WatchService.php
+++ b/lib/Service/WatchService.php
@@ -35,7 +35,8 @@ class WatchService {
 	 */
 	public function watchUpdates(int $pollId, ?int $offset = null): array {
 		if ($pollId) {
-			$this->pollMapper->get($pollId, withRoles: true)->request(Poll::PERMISSION_POLL_VIEW);
+			$this->pollMapper->get($pollId, true, withRoles: true)
+				->request(Poll::PERMISSION_POLL_VIEW);
 		}
 
 		$start = time();

--- a/src/Api/modules/polls.ts
+++ b/src/Api/modules/polls.ts
@@ -105,7 +105,13 @@ const polls = {
 	writePoll(
 		pollId: number,
 		poll: PollConfiguration,
-	): Promise<AxiosResponse<{ poll: Poll }>> {
+	): Promise<
+		AxiosResponse<{
+			poll: Poll
+			diff: Partial<Poll>
+			changes: Partial<Poll>
+		}>
+	> {
 		return httpInstance.request({
 			method: 'PUT',
 			url: `poll/${pollId}`,

--- a/src/components/Configuration/ConfigAnonymous.vue
+++ b/src/components/Configuration/ConfigAnonymous.vue
@@ -62,7 +62,7 @@ function spawnConfirmationDialog(forceDialog: boolean = false) {
  *
  */
 function lockAnonymous() {
-	pollStore.LockAnonymous()
+	pollStore.lockAnonymous()
 	emit('change')
 }
 


### PR DESCRIPTION
Every single configuration change causes a complete round trip by patching all stores based on the reported request return.

Changes:
* Do not reload full poll on config changes
* Backend additionally sends the diff of the poll attributes after changing
* Only patch the diff to the poll store
* Selective reloading of other stores depending on the changed values

Additionally refactored the permission requests

In very big polls there is still a lag between the user action and applying the changes. Further investigation will be done, to determine, if this can be eliminated, too.