### PR TITLE
Fix using public share on already accessible poll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file.
  - Bring back indicator for confirmed options after closing the poll
  - Add CSP to allow worker
  - fix loading archived polls
+ - broken access if a logged in user by public share enters a poll he already had access to
 
 ## [8.1.4] - 2025-07-15
 ### Fixes

--- a/lib/Service/ShareService.php
+++ b/lib/Service/ShareService.php
@@ -161,6 +161,19 @@ class ShareService {
 			$this->share->setDisplayName('');
 		}
 
+		$poll = $this->pollMapper->get($this->share->getPollId(), withRoles: true);
+
+		if ($poll->getIsAllowed(Poll::PERMISSION_VOTE_EDIT)
+			|| $poll->getIsAllowed(Poll::PERMISSION_POLL_EDIT)
+		) {
+			// user is allowed to access the poll, continue without creating a new share
+			return $this->share;
+		}
+
+		if (!$poll->getIsAllowed(Poll::PERMISSION_POLL_VIEW)) {
+			throw new ForbiddenException('User is not allowed to access this poll');
+		}
+
 		// Exception: logged in user, accesses the poll via public share link
 		if ($this->share->getType() === Share::TYPE_PUBLIC && $this->userSession->getIsLoggedIn()) {
 			$this->convertPublicShareToPersonalShare();


### PR DESCRIPTION
Fix an issue, where logged in useres were prevented to access a poll with the public share, after the second usage.

Users will no more get a new share, if they already have access to a poll.

fixes #4178