### PR TITLE
 add rank voting feature merge chosenrank with 8.1.4 refactorings  using variant 'generic'

### DIFF
--- a/lib/Db/Poll.php
+++ b/lib/Db/Poll.php
@@ -41,6 +41,8 @@ use OCP\IURLGenerator;
  * @method void setAllowComment(int $value)
  * @method int getAllowMaybe()
  * @method void setAllowMaybe(int $value)
+ * @method string getChosenRank()
+ * @method void setChosenRank(string $value)
  * @method string getAllowProposals()
  * @method void setAllowProposals(string $value)
  * @method int getProposalsExpire()
@@ -81,6 +83,7 @@ class Poll extends EntityWithUser implements JsonSerializable {
 	public const TYPE_DATE = 'datePoll';
 	public const TYPE_TEXT = 'textPoll';
 	public const VARIANT_SIMPLE = 'simple';
+	public const VARIANT_GENERIC = 'generic';
 	public const ACCESS_HIDDEN = 'hidden';
 	public const ACCESS_PUBLIC = 'public';
 	public const ACCESS_PRIVATE = 'private';
@@ -146,6 +149,7 @@ class Poll extends EntityWithUser implements JsonSerializable {
 	protected string $access = '';
 	protected int $anonymous = 0;
 	protected int $allowMaybe = 0;
+	protected string $chosenRank = '';
 	protected string $allowProposals = '';
 	protected int $proposalsExpire = 0;
 	protected int $voteLimit = 0;
@@ -181,6 +185,7 @@ class Poll extends EntityWithUser implements JsonSerializable {
 		$this->addType('anonymous', 'integer');
 		$this->addType('allowComment', 'integer');
 		$this->addType('allowMaybe', 'integer');
+		$this->addType('chosenRank', 'string');
 		$this->addType('proposalsExpire', 'integer');
 		$this->addType('voteLimit', 'integer');
 		$this->addType('optionLimit', 'integer');
@@ -246,6 +251,7 @@ class Poll extends EntityWithUser implements JsonSerializable {
 			'access' => $this->getAccess(),
 			'allowComment' => boolval($this->getAllowComment()),
 			'allowMaybe' => boolval($this->getAllowMaybe()),
+			'chosenRank' => $this->getChosenRank(),
 			'allowProposals' => $this->getAllowProposals(),
 			'anonymous' => boolval($this->getAnonymous()),
 			'autoReminder' => $this->getAutoReminder(),
@@ -315,6 +321,17 @@ class Poll extends EntityWithUser implements JsonSerializable {
 		$this->setAccess($pollConfiguration['access'] ?? $this->getAccess());
 		$this->setAllowComment($pollConfiguration['allowComment'] ?? $this->getAllowComment());
 		$this->setAllowMaybe($pollConfiguration['allowMaybe'] ?? $this->getAllowMaybe());
+		$chosenRank = $pollConfiguration['chosenRank'] ?? $this->getChosenRank();
+			if (is_array($chosenRank)) {
+				 $chosenRank = json_encode($chosenRank); // explicit serialisation
+			} elseif (is_string($chosenRank)) {
+				if (!json_decode($chosenRank)) {
+					$chosenRank = '[]';
+				}
+			} else {
+				$chosenRank = '[]';
+			}
+		$this->setChosenRank($chosenRank);
 		$this->setAllowProposals($pollConfiguration['allowProposals'] ?? $this->getAllowProposals());
 		$this->setAnonymousSafe($pollConfiguration['anonymous'] ?? $this->getAnonymous());
 		$this->setAutoReminder($pollConfiguration['autoReminder'] ?? $this->getAutoReminder());

--- a/lib/Exceptions/InvalidVotingVariantException.php
+++ b/lib/Exceptions/InvalidVotingVariantException.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Polls\Exceptions;
+
+use OCP\AppFramework\Http;
+
+class InvalidVotingVariantException extends Exception {
+	public function __construct(
+		string $e = 'Invalid votingVariant value',
+	) {
+		parent::__construct($e, Http::STATUS_CONFLICT);
+	}
+}

--- a/lib/Migration/TableSchema.php
+++ b/lib/Migration/TableSchema.php
@@ -195,6 +195,7 @@ abstract class TableSchema {
 			'access' => ['type' => Types::STRING, 'options' => ['notnull' => true, 'default' => 'private', 'length' => 1024]],
 			'anonymous' => ['type' => Types::BIGINT, 'options' => ['notnull' => true, 'default' => 0, 'length' => 20]],
 			'allow_maybe' => ['type' => Types::BIGINT, 'options' => ['notnull' => true, 'default' => 1, 'length' => 20]],
+			'chosen_rank' => ['type' => Types::TEXT, 'options' => ['notnull' => true, 'default' => 1, 'length' => 200]],
 			'allow_proposals' => ['type' => Types::STRING, 'options' => ['notnull' => true, 'default' => 'disallow', 'length' => 64]],
 			'proposals_expire' => ['type' => Types::BIGINT, 'options' => ['notnull' => true, 'default' => 0, 'length' => 20]],
 			'vote_limit' => ['type' => Types::BIGINT, 'options' => ['notnull' => true, 'default' => 0, 'length' => 20]],

--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -79,6 +79,7 @@ namespace OCA\Polls;
  *  access: string,
  *  allowComment: boolean,
  *  allowMaybe: boolean,
+ *  chosenRank: String,
  *  allowProposals: string,
  *  anonymous: boolean,
  *  autoReminder: boolean,

--- a/lib/Service/PollService.php
+++ b/lib/Service/PollService.php
@@ -27,6 +27,7 @@ use OCA\Polls\Exceptions\InvalidAccessException;
 use OCA\Polls\Exceptions\InvalidPollTypeException;
 use OCA\Polls\Exceptions\InvalidShowResultsException;
 use OCA\Polls\Exceptions\InvalidUsernameException;
+use OCA\Polls\Exceptions\InvalidVotingVariantException;
 use OCA\Polls\Exceptions\NotFoundException;
 use OCA\Polls\Exceptions\UserNotFoundException;
 use OCA\Polls\Model\Settings\AppSettings;
@@ -198,10 +199,15 @@ class PollService {
 			throw new ForbiddenException('Poll creation is disabled');
 		}
 
-		// Validate valuess
+		// Validate values
 		if (!in_array($type, $this->getValidPollType())) {
 			throw new InvalidPollTypeException('Invalid poll type');
 		}
+
+		if (!in_array($votingVariant, $this->getValidVotingVariant())) {
+			throw new InvalidVotingVariantException('Invalid voting variant');
+		}
+
 
 		if (!$title) {
 			throw new EmptyTitleException('Title must not be empty');
@@ -226,6 +232,7 @@ class PollService {
 		$this->poll->setExpire(0);
 		$this->poll->setAnonymousSafe(0);
 		$this->poll->setAllowMaybe(0);
+		$this->poll->setChosenRank('');
 		$this->poll->setVoteLimit(0);
 		$this->poll->setShowResults(Poll::SHOW_RESULTS_ALWAYS);
 		$this->poll->setDeleted(0);
@@ -418,6 +425,7 @@ class PollService {
 		// deanonymize cloned polls by default, to avoid locked anonymous polls
 		$this->poll->setAnonymous(0);
 		$this->poll->setAllowMaybe($origin->getAllowMaybe());
+		$this->poll->setChosenRank($origin->getChosenRank());
 		$this->poll->setVoteLimit($origin->getVoteLimit());
 		$this->poll->setShowResults($origin->getShowResults());
 		$this->poll->setAdminAccess($origin->getAdminAccess());
@@ -472,6 +480,17 @@ class PollService {
 	 */
 	private function getValidPollType(): array {
 		return [Poll::TYPE_DATE, Poll::TYPE_TEXT];
+	}
+
+	/**
+	 * Get valid values for votingVariant
+	 *
+	 * @return string[]
+	 *
+	 * @psalm-return array{0: string, 1: string}
+	 */
+	private function getValidVotingVariant(): array {
+		return [Poll::VARIANT_SIMPLE, Poll::VARIANT_GENERIC];
 	}
 
 	/**

--- a/src/Api/modules/polls.ts
+++ b/src/Api/modules/polls.ts
@@ -2,7 +2,7 @@
  * SPDX-FileCopyrightText: 2022 Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-import { Poll, PollConfiguration, PollType } from '../../stores/poll.ts'
+import { Poll, PollConfiguration, PollType, VotingVariant } from '../../stores/poll.ts'
 import { AxiosResponse } from '@nextcloud/axios'
 import { httpInstance, createCancelTokenHandler } from './HttpApi.js'
 import { Option } from '../../stores/options.ts'
@@ -98,13 +98,14 @@ const polls = {
 		})
 	},
 
-	addPoll(type: PollType, title: string): Promise<AxiosResponse<{ poll: Poll }>> {
+	addPoll(type: PollType, title: string, votingVariant: VotingVariant): Promise<AxiosResponse<{ poll: Poll }>> {
 		return httpInstance.request({
 			method: 'POST',
 			url: 'poll/add',
 			data: {
 				type,
 				title,
+				votingVariant,
 			},
 			cancelToken:
 				cancelTokenHandlerObject[

--- a/src/components/Configuration/ConfigRankOptions.vue
+++ b/src/components/Configuration/ConfigRankOptions.vue
@@ -1,0 +1,111 @@
+<template>
+	<div class="option-container">
+		<!-- Menu to choose the rank for this poll -->
+		<select v-model="selectedOption">
+			<option v-for="(option, index) in internalChosenRank" :key="index" :value="option">
+			{{ option }}
+			</option>
+		</select>
+		<!-- text field to add a new value to the rank -->
+		<NcTextField
+			v-model="newOption"
+			:placeholder="t('polls', 'Enter a new option')"
+			:label="t('polls', 'New option')"
+			class="nc-text-field"
+		/>
+		<NcButton icon @click="addOption">
+			<PlusIcon />
+		</NcButton>
+		<!-- Delete selected rank from the select -->
+		<NcButton :disabled="!selectedOption" @click="removeOption">
+			<CloseIcon />
+		</NcButton>
+	</div>
+</template>
+
+<script setup>
+import { ref,onMounted } from 'vue'
+import { usePollStore } from '../../stores/poll.js'
+import { t } from '@nextcloud/l10n'
+import { NcButton, NcTextField } from '@nextcloud/vue'
+import PlusIcon from 'vue-material-design-icons/Plus.vue'
+import CloseIcon from 'vue-material-design-icons/Close.vue'
+import { showError } from '@nextcloud/dialogs'
+
+const store = usePollStore()
+
+// Parse chosenRank string from store into array
+const internalChosenRank = ref([])
+const selectedOption = ref(null)
+const newOption = ref('')
+
+onMounted(() => {
+	try {
+		const initialValue = JSON.parse(store.configuration.chosenRank || '[]');
+		if ( Array.isArray(initialValue) ) {
+			internalChosenRank.value = initialValue;
+		} else {
+			internalChosenRank.value = [initialValue];
+		}
+		if (internalChosenRank.value.length > 0) {
+			selectedOption.value = internalChosenRank.value[0]
+		}
+	} catch (e) {
+		console.error('Erreur de parsing chosenRank:', e)
+		internalChosenRank.value = []
+	}
+})
+
+// update in store + API
+async function updateChosenRank(newValue) {
+	try {
+		await store.setChosenRank(newValue)
+		await store.write()
+	} catch (err) {
+		console.error('Update failed:', err)
+		showError(t('polls', 'Failed to update options'))
+	}
+}
+
+async function addOption() {
+	const value = newOption.value.trim()
+	if (value && !internalChosenRank.value.includes(value)) {
+		const updated = [...internalChosenRank.value, value].sort()
+		internalChosenRank.value = updated
+		newOption.value = ''
+		selectedOption.value = updated[0]
+		await updateChosenRank(updated)
+	}
+}
+
+async function removeOption() {
+	const updated = internalChosenRank.value.filter(o => o !== selectedOption.value)
+	internalChosenRank.value = updated
+	selectedOption.value = updated[0] || null
+	await updateChosenRank(updated)
+}
+
+</script>
+
+<style scoped>
+.option-container {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.nc-text-field {
+  flex-grow: 1;
+  margin-right: 8px;
+  margin-bottom: 8px;
+  width: 100px;
+}
+
+.option-item {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+</style>
+

--- a/src/components/Create/PollCreateDlg.vue
+++ b/src/components/Create/PollCreateDlg.vue
@@ -14,7 +14,7 @@ import CheckIcon from 'vue-material-design-icons/Check.vue'
 
 import { ConfigBox, RadioGroupDiv, InputDiv } from '../Base/index.ts'
 
-import { PollType, pollTypes, usePollStore } from '../../stores/poll.ts'
+import { PollType, VotingVariant, pollTypes, votingVariants, usePollStore } from '../../stores/poll.ts'
 import { showError, showSuccess } from '@nextcloud/dialogs'
 
 const pollStore = usePollStore()
@@ -32,10 +32,16 @@ const emit = defineEmits<{
 
 const pollTitle = ref('')
 const pollType = ref<PollType>('datePoll')
+const votingVariant = ref<VotingVariant>('simple')
 const pollId = ref<number | null>(null)
 const adding = ref(false)
 
 const pollTypeOptions = Object.entries(pollTypes).map(([key, value]) => ({
+	value: key,
+	label: value.name,
+}))
+
+const votingVariantOptions = Object.entries(votingVariants).map(([key, value]) => ({
 	value: key,
 	label: value.name,
 }))
@@ -51,6 +57,7 @@ async function addPoll() {
 		const poll = await pollStore.add({
 			type: pollType.value,
 			title: pollTitle.value,
+			votingVariant: votingVariant.value
 		})
 
 		if (poll) {
@@ -105,6 +112,13 @@ function resetPoll() {
 				<CheckIcon />
 			</template>
 			<RadioGroupDiv v-model="pollType" :options="pollTypeOptions" />
+		</ConfigBox>
+
+		<ConfigBox :name="t('polls', 'Vote variant')">
+			<template #icon>
+				<CheckIcon />
+			</template>
+			<RadioGroupDiv v-model="votingVariant" :options="votingVariantOptions" />
 		</ConfigBox>
 
 		<div class="create-buttons">

--- a/src/components/Navigation/PollNavigationItems.vue
+++ b/src/components/Navigation/PollNavigationItems.vue
@@ -33,7 +33,7 @@ const sessionStore = useSessionStore()
 		"
 		:class="{ closed: poll.status.isExpired }">
 		<template #icon>
-			<TextPollIcon v-if="poll.type === 'textPoll'" />
+			<TextPollIcon v-if="poll.type === 'textPoll'"/>
 			<DatePollIcon v-else />
 		</template>
 		<template #actions>

--- a/src/components/SideBar/SideBarTabConfiguration.vue
+++ b/src/components/SideBar/SideBarTabConfiguration.vue
@@ -28,6 +28,7 @@ import ConfigShowResults from '../Configuration/ConfigShowResults.vue'
 import ConfigTitle from '../Configuration/ConfigTitle.vue'
 import ConfigUseNo from '../Configuration/ConfigUseNo.vue'
 import ConfigVoteLimit from '../Configuration/ConfigVoteLimit.vue'
+import ConfigRankOptions from '../Configuration/ConfigRankOptions.vue'
 
 import { usePollStore } from '../../stores/poll.ts'
 import { useVotesStore } from '../../stores/votes.ts'
@@ -70,12 +71,20 @@ const votesStore = useVotesStore()
 			<ConfigForceConfidentialComments
 				v-if="pollStore.configuration.allowComment"
 				@change="pollStore.write" />
+			<template v-if="pollStore.votingVariant === 'generic'">
 			<ConfigAllowMayBe @change="pollStore.write" />
 			<ConfigUseNo @change="pollStore.write" />
 			<ConfigAnonymous @change="pollStore.write" />
-
+			</template>
 			<ConfigVoteLimit @change="pollStore.write" />
 			<ConfigOptionLimit @change="pollStore.write" />
+		</ConfigBox>
+
+		<ConfigBox v-if="pollStore.votingVariant === 'generic'" :name="t('polls', 'Generic Options')">
+			<template #icon>
+				<PollConfigIcon />
+			</template>
+			<ConfigRankOptions />
 		</ConfigBox>
 
 		<ConfigBox :name="t('polls', 'Poll closing status')">

--- a/src/components/VoteTable/VoteColumn.vue
+++ b/src/components/VoteTable/VoteColumn.vue
@@ -54,7 +54,7 @@ const showCalendarPeek = computed(
 			<OptionItem :option="option" />
 
 			<Counter
-				v-if="pollStore.permissions.seeResults"
+				v-if="pollStore.votingVariant === 'simple' && pollStore.permissions.seeResults"
 				:show-maybe="pollStore.configuration.allowMaybe"
 				:option="option" />
 

--- a/src/components/VoteTable/VoteIndicator.vue
+++ b/src/components/VoteTable/VoteIndicator.vue
@@ -4,11 +4,15 @@
 -->
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { ref,computed, watch } from 'vue'
 import CheckIcon from 'vue-material-design-icons/Check.vue'
 import CloseIcon from 'vue-material-design-icons/Close.vue'
 import { MaybeIcon } from '../AppIcons/index.ts'
 import { Answer } from '../../Types/index.ts'
+import { usePollStore } from '../../stores/poll.ts'
+const pollStore = usePollStore()
+const chosenRank=JSON.parse(pollStore.configuration.chosenRank)
+
 
 const ICON_SIZE = 26
 
@@ -17,9 +21,11 @@ interface Props {
 	active?: boolean
 }
 
-const { answer, active = false } = defineProps<Props>()
+const props = defineProps<Props>()
 
-const emit = defineEmits(['click'])
+const selectedRank = ref(props.answer)
+
+const emit = defineEmits(['click','selectChange'])
 
 const colorCodeNo = getComputedStyle(document.documentElement).getPropertyValue(
 	'--color-error',
@@ -32,25 +38,53 @@ const colorCodeMaybe = getComputedStyle(document.documentElement).getPropertyVal
 )
 
 const foregroundColor = computed(() => {
-	if (answer === 'yes') {
+	if (props.answer === 'yes') {
 		return colorCodeYes
 	}
-	if (answer === 'maybe') {
+	if (props.answer === 'maybe') {
 		return colorCodeMaybe
 	}
 	return colorCodeNo
 })
 
+// Watchers
+watch(() => props.answer, (newValue) => {
+  selectedRank.value = newValue
+})
+
+// Methods
+const handleRankSelected = (event) => {
+  const rank = event.target.value
+  emit('selectChange', rank)
+}
+
+
 function onClick() {
-	if (active) {
+	if (props.active) {
 		emit('click')
 	}
 }
 </script>
 
 <template>
-	<div :class="['vote-indicator', active]" @click="onClick()">
-		<MaybeIcon v-if="answer === 'maybe'" :size="ICON_SIZE" />
+	<div class="vote-cell-container">
+	<div v-if="pollStore.votingVariant === 'generic'" class="generic-vote">
+		<span v-if="!props.active" class="selected-value">
+			{{ selectedRank }}
+		</span>
+		<select
+			v-else
+			:value="selectedRank"
+			class="vote-ranking"
+			@change="handleRankSelected">
+			<option disabled value=""></option>
+			<option v-for="rank in chosenRank" :key="rank" :value="rank">
+				{{ rank }}
+			</option>
+		</select>
+	</div>
+	<div v-else :class="['vote-indicator', props.active]" @click="onClick()">
+		<MaybeIcon v-if="props.answer === 'maybe'" :size="ICON_SIZE" />
 		<CheckIcon
 			v-if="answer === 'yes'"
 			:fill-color="foregroundColor"
@@ -60,9 +94,48 @@ function onClick() {
 			:fill-color="foregroundColor"
 			:size="ICON_SIZE" />
 	</div>
+	</div>
 </template>
 
 <style lang="scss">
+.selected-value {
+	background-color: #f9f9f9;
+	border: 1px solid #ddd;
+	color: #444;
+	border-radius: 6px;
+	padding: 4px 10px;
+	display: inline-block;
+	text-align: center;
+	width: 100%;
+}
+
+.vote-cell-container {
+  display: flex;
+  justify-content: center;
+}
+
+.generic-vote {
+  width: fit-content;
+  min-width: 60px;
+  max-width: 200px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height:100%;
+}  
+.vote-ranking {
+    width: auto;
+    padding: 6px 24px 6px 12px;
+    
+    /* dynamic size based on content size */
+    &::after {
+      content: attr(data-content);
+      visibility: hidden;
+      padding: inherit;
+      font: inherit;
+    }
+  }
+
 .vote-indicator {
 	color: var(--color-polls-foreground-no);
 	min-width: 30px;
@@ -101,5 +174,9 @@ function onClick() {
 			height: 31px;
 		}
 	}
+}
+
+.error-message {
+  color: var(--color-error);
 }
 </style>

--- a/src/components/VoteTable/VoteItem.vue
+++ b/src/components/VoteTable/VoteItem.vue
@@ -66,9 +66,26 @@ const nextAnswer = computed(() => {
 
 const isValidUser = computed(() => user.id !== '' && user.id !== null)
 
-/**
- *
- */
+async function handleRankSelected(rank){
+	if (isVotable.value) {
+		try {
+			await votesStore.set({
+				option,
+				setTo: String(rank),
+		});
+		showSuccess(t('polls', 'Vote saved'), { timeout: 2000 });
+		} catch (error) {
+			if ((error as AxiosError).status === 409) {
+				showError(t('polls', 'Vote already booked out'));
+			} else {
+				showError(t('polls', 'Error saving vote'));
+			}
+		}
+	} else {
+		showError(t('polls', 'Error saving vote'));
+	}
+}
+
 async function setVote() {
 	if (isVotable.value) {
 		try {
@@ -94,7 +111,7 @@ async function setVote() {
 	<div
 		class="vote-item"
 		:class="[answer, { active: isVotable }, { 'current-user': isCurrentUser }]">
-		<VoteIndicator :answer="iconAnswer" :active="isVotable" @click="setVote()" />
+		<VoteIndicator :answer="iconAnswer" :active="isVotable" @click="setVote()"  @select-change="handleRankSelected" />
 	</div>
 </template>
 

--- a/src/components/VoteTable/VoteTable.vue
+++ b/src/components/VoteTable/VoteTable.vue
@@ -109,7 +109,7 @@ const showCalendarPeek = computed(
 				:class="{ 'sticky-bottom-shadow': !downPage }"
 				:option="option" />
 			<Counter
-				v-if="pollStore.permissions.seeResults"
+				v-if="pollStore.votingVariant === 'simple' && pollStore.permissions.seeResults"
 				:id="`counter-${option.id}`"
 				:key="`counter-${option.id}`"
 				:show-maybe="pollStore.configuration.allowMaybe"

--- a/src/components/VoteTable/VoteTable.vue
+++ b/src/components/VoteTable/VoteTable.vue
@@ -143,8 +143,10 @@ const showCalendarPeek = computed(
 	overflow: scroll;
 
 	.vote-cell {
-		padding: 0.4rem;
-		display: flex;
+		display: grid;
+		place-items: center;
+		grid-template-columns: 1fr;
+		width: 100%;
 	}
 
 	.participant {
@@ -281,6 +283,40 @@ const showCalendarPeek = computed(
 		.counter {
 			grid-column: 2;
 			flex-direction: column;
+		}
+
+		.vote-cell-container {
+			display: flex;
+			justify-content: center;
+			align-items: center;
+			width: 100%;
+			height: 100%;
+			padding: 4px;
+		}
+
+		.vote-select {
+			width: 100%;
+			max-width: 120px;
+			min-width: 80px;
+			margin: 0 auto;
+			padding: 8px 12px;
+			text-align: center;
+			text-align-last: center; /* Centrage pour Firefox */
+			border-radius: 8px;
+			border: 1px solid var(--color-border);
+			background: var(--color-main-background);
+			cursor: pointer;
+			appearance: none;
+			transition: all 0.2s ease;
+
+			&:hover {
+			border-color: var(--color-primary);
+			}
+
+			&:focus {
+			outline: none;
+			box-shadow: 0 0 0 2px var(--color-primary-light);
+			}
 		}
 
 		.vote-cell {

--- a/src/stores/votes.ts
+++ b/src/stores/votes.ts
@@ -139,7 +139,7 @@ export const useVotesStore = defineStore('votes', {
 
 			// sort participants by votes for the selected option if sortByOption is set
 			// TODO: Future usage: This is only valid for simple votes (not ranked)
-			if (state.sortByOption > 0 && pollStore.voteVariant === 'simple') {
+			if (state.sortByOption > 0 && pollStore.votingVariant === 'simple') {
 				participants.sort((aUser, bUser) => {
 					// find the votes for the selected option and the users to compare
 					const aAnswer =


### PR DESCRIPTION
Add a new 'generic' voting variant to replace generic poll type based on @vinimoz rank-vote-feature-vue3 branch.

Variant is another choice than Poll type :

<img width="388" height="543" alt="Capture d’écran du 2025-08-02 23-47-44" src="https://github.com/user-attachments/assets/4dd3ab4f-b990-4b6d-8646-57cd76dcce5f" />

Works with both Date and Text.
There is no result displayed, cumul of votes is not (yet) implemented for generic variant.

This PR is intended to be merged into at v8.1.4 tag, but can't find related branch in PR request GUI,
I am still working on a merge in main too.
 

