### PR TITLE
Move comments config to comment tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ If you experience update problems, please refer to [this article](https://github
  - Separated the commands in more granular index and database commands
  - Adjust icon style
  - Adjust CSS Vars
+ - Moved comment config to comment tab
+   - Make comments available to owner and delegated poll administration if commenting is disabled
+   - Add hint, if commenting is disabled
 
 ## [8.2.2] - 2025-08-03
 ### Added

--- a/lib/Db/Poll.php
+++ b/lib/Db/Poll.php
@@ -841,6 +841,11 @@ class Poll extends EntityWithUser implements JsonSerializable {
 	 * Checks, if user is allowed to see and write comments
 	 **/
 	private function getAllowCommenting(): bool {
+		if ($this->getAllowEditPoll()) {
+			// users with edit rights are allowed to comment
+			return true;
+		}
+
 		// user has no access right to this poll
 		if (!$this->getAllowAccessPoll()) {
 			return false;

--- a/src/components/Configuration/AutoReminderInformation.vue
+++ b/src/components/Configuration/AutoReminderInformation.vue
@@ -14,7 +14,7 @@ import { t } from '@nextcloud/l10n'
 				t('polls', 'The automatic reminder is sent to all shares via email:')
 			}}
 		</h1>
-		<h2>{{ t('polls', 'For polls with expiration:') }}</h2>
+		<h2>{{ t('polls', 'For polls with expiration') }}</h2>
 		<ul>
 			<li>
 				{{
@@ -33,7 +33,7 @@ import { t } from '@nextcloud/l10n'
 				}}
 			</li>
 		</ul>
-		<h2>{{ t('polls', 'For date polls without expiration:') }}</h2>
+		<h2>{{ t('polls', 'For date polls without expiration') }}</h2>
 		<ul>
 			<li>
 				{{
@@ -52,7 +52,7 @@ import { t } from '@nextcloud/l10n'
 				}}
 			</li>
 		</ul>
-		<h2>{{ t('polls', 'No reminder is sent:') }}</h2>
+		<h2>{{ t('polls', 'No reminder is sent') }}</h2>
 		<ul>
 			<li>{{ t('polls', 'For text polls without expiration.') }}</li>
 			<li>

--- a/src/components/Configuration/ConfigAutoReminder.vue
+++ b/src/components/Configuration/ConfigAutoReminder.vue
@@ -29,7 +29,7 @@ const pollStore = usePollStore()
 			@update:model-value="emit('change')">
 			{{ t('polls', 'Use Autoreminder') }}
 		</NcCheckboxRadioSwitch>
-		<NcPopover :focus-trap="false">
+		<NcPopover no-focus-trap close-on-click-outside>
 			<template #trigger>
 				<NcActions>
 					<NcActionButton

--- a/src/components/SideBar/SideBarTabComments.vue
+++ b/src/components/SideBar/SideBarTabComments.vue
@@ -16,6 +16,11 @@ import CommentsIcon from 'vue-material-design-icons/CommentProcessing.vue'
 
 import { usePollStore } from '../../stores/poll'
 import { useCommentsStore } from '../../stores/comments'
+import ConfigAllowComment from '../Configuration/ConfigAllowComment.vue'
+import ConfigForceConfidentialComments from '../Configuration/ConfigForceConfidentialComments.vue'
+import ConfigBox from '../Base/modules/ConfigBox.vue'
+import PollConfigIcon from 'vue-material-design-icons/Wrench.vue'
+import CardDiv from '../Base/modules/CardDiv.vue'
 
 const pollStore = usePollStore()
 const commentsStore = useCommentsStore()
@@ -49,6 +54,24 @@ watch(
 
 <template>
 	<div class="comments">
+		<ConfigBox
+			v-if="pollStore.permissions.edit"
+			:name="t('polls', 'Configuration')">
+			<template #icon>
+				<PollConfigIcon />
+			</template>
+			<ConfigAllowComment @change="pollStore.write" />
+			<ConfigForceConfidentialComments @change="pollStore.write" />
+			<CardDiv v-if="!pollStore.configuration.allowComment" type="warning">
+				{{
+					t(
+						'polls',
+						'Comments are disabled, except for owner and delegated poll administration.',
+					)
+				}}
+			</CardDiv>
+		</ConfigBox>
+
 		<CommentAdd v-if="pollStore.permissions.comment" />
 		<Comments v-if="!showEmptyContent" />
 		<NcEmptyContent v-else v-bind="emptyContentProps">

--- a/src/components/SideBar/SideBarTabConfiguration.vue
+++ b/src/components/SideBar/SideBarTabConfiguration.vue
@@ -18,7 +18,6 @@ import ShowResultsNeverIcon from 'vue-material-design-icons/MonitorOff.vue'
 
 import CardDiv from '../Base/modules/CardDiv.vue'
 import ConfigBox from '../Base/modules/ConfigBox.vue'
-import ConfigAllowComment from '../Configuration/ConfigAllowComment.vue'
 import ConfigAllowMayBe from '../Configuration/ConfigAllowMayBe.vue'
 import ConfigAnonymous from '../Configuration/ConfigAnonymous.vue'
 import ConfigAutoReminder from '../Configuration/ConfigAutoReminder.vue'
@@ -33,7 +32,6 @@ import ConfigVoteLimit from '../Configuration/ConfigVoteLimit.vue'
 import { usePollStore } from '../../stores/poll'
 import { useVotesStore } from '../../stores/votes'
 import ConfigDangerArea from '../Configuration/ConfigDangerArea.vue'
-import ConfigForceConfidentialComments from '../Configuration/ConfigForceConfidentialComments.vue'
 
 const pollStore = usePollStore()
 const votesStore = useVotesStore()
@@ -63,14 +61,10 @@ const votesStore = useVotesStore()
 			<ConfigDescription @change="pollStore.write" />
 		</ConfigBox>
 
-		<ConfigBox :name="t('polls', 'Poll configurations')">
+		<ConfigBox :name="t('polls', 'Poll configuration')">
 			<template #icon>
 				<PollConfigIcon />
 			</template>
-			<ConfigAllowComment @change="pollStore.write" />
-			<ConfigForceConfidentialComments
-				v-if="pollStore.configuration.allowComment"
-				@change="pollStore.write" />
 			<ConfigAllowMayBe @change="pollStore.write" />
 			<ConfigUseNo @change="pollStore.write" />
 			<ConfigAnonymous @change="pollStore.write" />

--- a/src/components/VoteTable/VoteTable.vue
+++ b/src/components/VoteTable/VoteTable.vue
@@ -125,7 +125,7 @@ function isVotable(participant: User, option: Option) {
 				<CalendarPeek
 					v-if="showCalendarPeek"
 					:id="`peek-${option.id}`"
-					:focus-trap="false"
+					no-focus-trap
 					:option="option" />
 
 				<OptionMenu :option="option" use-sort />


### PR DESCRIPTION
* moved the configuration
* made comments available to owner ad delegated admins if disabled
* added a hint, in case commenting is not available for other participants

(Warning info card background is rather light since NC32 beta1)
<img width="592" height="528" alt="image" src="https://github.com/user-attachments/assets/9158c3d9-59cf-4f7e-83fd-6d8f0f97686e" />

