### PR TITLE
fix: show full username on hover

### DIFF
--- a/src/components/User/UserItem.vue
+++ b/src/components/User/UserItem.vue
@@ -280,7 +280,7 @@ const componentClass = computed(() => [
 		<slot name="status" />
 
 		<div v-if="!hideNames" class="user-item__name">
-			<div class="name">
+			<div class="name" :title="labelComputed">
 				{{ labelComputed }}
 			</div>
 			<div class="description">


### PR DESCRIPTION
| b | a |
|--------|--------|
|<img width="1917" height="500" alt="image" src="https://github.com/user-attachments/assets/c49dfc40-7d53-4051-bbdf-377c95317043" /> |<img width="1917" height="500" alt="image" src="https://github.com/user-attachments/assets/0786e343-0215-4c35-bba7-c16728ab2610" /> | 