### PR TITLE
Migrate calendar keys to URI for calendarcheck

### DIFF
--- a/lib/Controller/UserController.php
+++ b/lib/Controller/UserController.php
@@ -39,7 +39,7 @@ class UserController extends BaseController {
 	#[NoAdminRequired]
 	#[OpenAPI(OpenAPI::SCOPE_IGNORE)]
 	#[FrontpageRoute(verb: 'GET', url: '/preferences')]
-	public function getPreferences(): JSONResponse {
+	public function getUserSettings(): JSONResponse {
 		return $this->response(fn () => $this->preferencesService->get());
 	}
 

--- a/lib/Db/Preferences.php
+++ b/lib/Db/Preferences.php
@@ -19,16 +19,25 @@ use OCP\AppFramework\Db\Entity;
  * @method void setUserId(string $value)
  * @method string getTimestamp()
  * @method void setTimestamp(int $value)
+ * @method string getPreferences()
  * @method void setPreferences(string $value)
  */
 class Preferences extends Entity implements JsonSerializable {
 	public const TABLE = 'polls_preferences';
 
-	public const DEFAULT = [
+	public const DEPRECATED_SETTINGS = [
+		'checkCalendars',
+		'checkCalendarUris',
+		'checkCalendarsFullUris',
+		'checkCalendarsBefore',
+		'checkCalendarsAfter',
+	];
+
+	public const DEFAULT_SETTINGS = [
 		'useCommentsAlternativeStyling' => false,
 		'useAlternativeStyling' => false,
 		'calendarPeek' => false,
-		'checkCalendars' => [],
+		'checkCalendarsUris' => [],
 		'checkCalendarsHoursBefore' => 0,
 		'checkCalendarsHoursAfter' => 0,
 		'defaultViewTextPoll' => 'table-view',
@@ -47,37 +56,37 @@ class Preferences extends Entity implements JsonSerializable {
 		$this->addType('timestamp', 'integer');
 
 		// initialize with default values
-		$this->setPreferences(json_encode(self::DEFAULT));
+		$this->setUserSettings(self::DEFAULT_SETTINGS);
 	}
 
-	public function getPreferences(): string {
-		return $this->preferences ?? '';
+	public function setUserSettings(array $settings): void {
+		$this->setPreferences(json_encode($settings));
 	}
 
-	public function getPreferences_decoded(): mixed {
-		return json_decode($this->getPreferences());
+	public function getUserSettings(): array {
+		return json_decode($this->getPreferences() ?? '', true);
 	}
 
 	public function getCheckCalendarsHoursBefore(): int {
-		if (isset($this->getPreferences_decoded()->checkCalendarsHoursBefore)) {
-			return intval($this->getPreferences_decoded()->checkCalendarsHoursBefore);
+		if (isset($this->getUserSettings()['checkCalendarsHoursBefore'])) {
+			return intval($this->getUserSettings()['checkCalendarsHoursBefore']);
 		}
 
 		// in case old property name is used, return the value
-		if (isset($this->getPreferences_decoded()->checkCalendarsBefore)) {
-			return intval($this->getPreferences_decoded()->checkCalendarsBefore);
+		if (isset($this->getUserSettings()['checkCalendarsBefore'])) {
+			return intval($this->getUserSettings()['checkCalendarsBefore']);
 		}
 		return 0;
 	}
 
 	public function getCheckCalendarsHoursAfter(): int {
-		if (isset($this->getPreferences_decoded()->checkCalendarsHoursAfter)) {
-			return intval($this->getPreferences_decoded()->checkCalendarsHoursAfter);
+		if (isset($this->getUserSettings()['checkCalendarsHoursAfter'])) {
+			return intval($this->getUserSettings()['checkCalendarsHoursAfter']);
 		}
 
 		// in case old property name is used, return the value
-		if (isset($this->getPreferences_decoded()->checkCalendarsAfter)) {
-			return intval($this->getPreferences_decoded()->checkCalendarsAfter);
+		if (isset($this->getUserSettings()['checkCalendarsAfter'])) {
+			return intval($this->getUserSettings()['checkCalendarsAfter']);
 		}
 		return 0;
 	}
@@ -89,7 +98,7 @@ class Preferences extends Entity implements JsonSerializable {
 	 */
 	public function jsonSerialize(): array {
 		return [
-			'preferences' => json_decode((string)$this->preferences),
+			'preferences' => $this->getUserSettings(),
 		];
 	}
 }

--- a/lib/Service/CalendarService.php
+++ b/lib/Service/CalendarService.php
@@ -96,7 +96,7 @@ class CalendarService {
 		$query->setTimerangeEnd($to);
 
 		foreach ($this->calendars as $calendar) {
-			if (in_array($calendar->getKey(), json_decode($this->preferences->getPreferences())->checkCalendars)) {
+			if (in_array($calendar->getUri(), $this->preferences->getUserSettings()['checkCalendarsUris'])) {
 				$query->addSearchCalendar($calendar->getUri());
 			}
 		}

--- a/lib/Service/PreferencesService.php
+++ b/lib/Service/PreferencesService.php
@@ -9,12 +9,12 @@ declare(strict_types=1);
 namespace OCA\Polls\Service;
 
 use Exception;
-use OCP\Calendar\IManager as CalendarManager;
 use OCA\Polls\Db\Preferences;
 use OCA\Polls\Db\PreferencesMapper;
 use OCA\Polls\Exceptions\NotAuthorizedException;
 use OCA\Polls\Exceptions\NotFoundException;
 use OCA\Polls\UserSession;
+use OCP\Calendar\IManager as CalendarManager;
 
 class PreferencesService {
 
@@ -30,14 +30,13 @@ class PreferencesService {
 
 	public function load(): void {
 		try {
-			$migration = false;
 			$this->preferences = $this->preferencesMapper->find($this->userSession->getCurrentUserId());
 
 			if (!$this->preferences->getUserSettings()) {
 				$this->preferences->setUserSettings(Preferences::DEFAULT_SETTINGS);
 				throw new NotFoundException('load: No preferences array found');
 			}
-			$migration = $this->convertCalendars() || $migration;
+			$migration = $this->convertCalendars();
 			$migration = $this->adjustTimeToleranceProperties() || $migration;
 			$migration = $this->removeDeprecatedProperties() || $migration;
 

--- a/src/components/Settings/UserSettings/CalendarSettings.vue
+++ b/src/components/Settings/UserSettings/CalendarSettings.vue
@@ -15,17 +15,17 @@ const preferencesStore = usePreferencesStore()
 
 const calendarChoices = computed(() =>
 	preferencesStore.availableCalendars.map((calendar) => ({
-		key: calendar.key.toString(),
+		calendarUri: calendar.calendarUri,
 		name: calendar.name,
 		displayColor: calendar.displayColor,
-		selected: preferencesStore.user.checkCalendars.includes(
-			calendar.key.toString(),
+		selected: preferencesStore.user.checkCalendarsUris.includes(
+			calendar.calendarUri,
 		),
 	})),
 )
 
 const clickedCalendar = (calendar) => {
-	if (preferencesStore.user.checkCalendars.includes(calendar.key)) {
+	if (preferencesStore.user.checkCalendarsUris.includes(calendar.calendarUri)) {
 		preferencesStore.removeCheckCalendar(calendar)
 	} else {
 		preferencesStore.addCheckCalendar(calendar)
@@ -52,7 +52,7 @@ const clickedCalendar = (calendar) => {
 
 				<div
 					v-for="calendar in calendarChoices"
-					:key="calendar.key"
+					:key="calendar.calendarUri"
 					class="calendar-item">
 					<NcCheckboxRadioSwitch
 						:model-value="calendar.selected"

--- a/src/stores/preferences.ts
+++ b/src/stores/preferences.ts
@@ -15,7 +15,7 @@ export const usePreferencesStore = defineStore('preferences', {
 	state: (): PreferencesStore => ({
 		user: {
 			calendarPeek: false,
-			checkCalendars: [],
+			checkCalendarsUris: [],
 			checkCalendarsHoursBefore: 0,
 			checkCalendarsHoursAfter: 0,
 			defaultViewTextPoll: 'table-view',
@@ -53,14 +53,14 @@ export const usePreferencesStore = defineStore('preferences', {
 		},
 
 		addCheckCalendar(calendar: Calendar) {
-			this.user.checkCalendars.push(calendar.key)
+			this.user.checkCalendarsUris.push(calendar.calendarUri)
 			this.write()
 		},
 
 		removeCheckCalendar(calendar: Calendar) {
-			const index = this.user.checkCalendars.indexOf(calendar.key)
+			const index = this.user.checkCalendarsUris.indexOf(calendar.calendarUri)
 			if (index !== -1) {
-				this.user.checkCalendars.splice(index, 1)
+				this.user.checkCalendarsUris.splice(index, 1)
 			}
 			this.write()
 		},

--- a/src/stores/preferences.types.ts
+++ b/src/stores/preferences.types.ts
@@ -7,7 +7,7 @@ export type ViewMode = 'table-view' | 'list-view'
 
 export type UserPreferences = {
 	calendarPeek: boolean
-	checkCalendars: string[]
+	checkCalendarsUris: string[]
 	checkCalendarsHoursBefore: number
 	checkCalendarsHoursAfter: number
 	defaultViewTextPoll: ViewMode


### PR DESCRIPTION
fixes #4171

The calendar key is not unique can can be mixed up by own calendars and subscribed calendars
* migrate usage of calendar URI instead of key
* rename preferences array to `settings` for better differentiation from the `Preferences ` class (backend side)