### PR TITLE
fix: Rename sidebar-share css class

### DIFF
--- a/src/components/SideBar/SideBarTabShare.vue
+++ b/src/components/SideBar/SideBarTabShare.vue
@@ -31,7 +31,7 @@ onBeforeRouteLeave(() => {
 </script>
 
 <template>
-	<div class="sidebar-share">
+	<div class="polls-sidebar-share">
 		<SharesListUnsent
 			v-if="sessionStore.appPermissions.addShares"
 			class="shares unsent" />
@@ -43,7 +43,7 @@ onBeforeRouteLeave(() => {
 </template>
 
 <style lang="scss">
-.sidebar-share {
+.polls-sidebar-share {
 	display: flex;
 	flex-direction: column;
 }

--- a/src/components/SideBar/SideBarTabSharePollGroup.vue
+++ b/src/components/SideBar/SideBarTabSharePollGroup.vue
@@ -28,7 +28,7 @@ onBeforeRouteUpdate(async () => {
 </script>
 
 <template>
-	<div class="sidebar-share">
+	<div class="polls-sidebar-share">
 		<div>
 			{{
 				t(
@@ -42,7 +42,7 @@ onBeforeRouteUpdate(async () => {
 </template>
 
 <style lang="scss">
-.sidebar-share {
+.polls-sidebar-share {
 	display: flex;
 	flex-direction: column;
 }


### PR DESCRIPTION
.sidebar-share is unfortunately a pretty usual class for ads so it's blocklisted in ublock origin cosmetic lists. Rename it to polls-sidebar-share instead.

Fix #4292 