### PR TITLE
revert merging constants partially to avoid updater confusion

### DIFF
--- a/lib/AppConstants.php
+++ b/lib/AppConstants.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2023 Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Polls;
+
+/**
+ * @deprecated Use Application::* constants directly
+ */
+abstract class AppConstants {
+	/** @var string */
+	public const SESSION_KEY_CRON_JOB = 'ncPollsCronJob';
+}

--- a/lib/Cron/AutoReminderCron.php
+++ b/lib/Cron/AutoReminderCron.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace OCA\Polls\Cron;
 
 use Exception;
-use OCA\Polls\AppInfo\Application;
+use OCA\Polls\AppConstants;
 use OCA\Polls\Attributes\ManuallyRunnableCronJob;
 use OCA\Polls\Service\MailService;
 use OCP\AppFramework\Utility\ITimeFactory;
@@ -38,13 +38,13 @@ class AutoReminderCron extends TimedJob {
 	 * @return void
 	 */
 	protected function run($argument) {
-		$this->session->set(Application::SESSION_KEY_CRON_JOB, true);
+		$this->session->set(AppConstants::SESSION_KEY_CRON_JOB, true);
 		try {
 			$this->mailService->sendAutoReminder();
 		} catch (Exception $e) {
 			return;
 		} finally {
-			$this->session->remove(Application::SESSION_KEY_CRON_JOB);
+			$this->session->remove(AppConstants::SESSION_KEY_CRON_JOB);
 		}
 	}
 }

--- a/lib/Cron/GroupDeletedJob.php
+++ b/lib/Cron/GroupDeletedJob.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
 
 namespace OCA\Polls\Cron;
 
-use OCA\Polls\AppInfo\Application;
+use OCA\Polls\AppConstants;
 use OCA\Polls\Db\Share;
 use OCA\Polls\Db\ShareMapper;
 use OCP\AppFramework\Utility\ITimeFactory;
@@ -34,13 +34,13 @@ class GroupDeletedJob extends QueuedJob {
 	 * @return void
 	 */
 	protected function run($argument) {
-		$this->session->set(Application::SESSION_KEY_CRON_JOB, true);
+		$this->session->set(AppConstants::SESSION_KEY_CRON_JOB, true);
 		$group = $argument['group'];
 		$this->logger->info('Removing group shares for deleted group', [
 			'group' => $group
 		]);
 
 		$this->shareMapper->deleteByIdAndType($group, Share::TYPE_GROUP);
-		$this->session->remove(Application::SESSION_KEY_CRON_JOB);
+		$this->session->remove(AppConstants::SESSION_KEY_CRON_JOB);
 	}
 }

--- a/lib/Cron/JanitorCron.php
+++ b/lib/Cron/JanitorCron.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace OCA\Polls\Cron;
 
 use Exception;
-use OCA\Polls\AppInfo\Application;
+use OCA\Polls\AppConstants;
 use OCA\Polls\Attributes\ManuallyRunnableCronJob;
 use OCA\Polls\Db\CommentMapper;
 use OCA\Polls\Db\LogMapper;
@@ -54,7 +54,7 @@ class JanitorCron extends TimedJob {
 	 * @return void
 	 */
 	protected function run($argument) {
-		$this->session->set(Application::SESSION_KEY_CRON_JOB, true);
+		$this->session->set(AppConstants::SESSION_KEY_CRON_JOB, true);
 
 		try {
 
@@ -127,7 +127,7 @@ class JanitorCron extends TimedJob {
 				['message' => $e->getMessage()]
 			);
 		} finally {
-			$this->session->remove(Application::SESSION_KEY_CRON_JOB);
+			$this->session->remove(AppConstants::SESSION_KEY_CRON_JOB);
 		}
 	}
 }

--- a/lib/Cron/NotificationCron.php
+++ b/lib/Cron/NotificationCron.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace OCA\Polls\Cron;
 
 use Exception;
-use OCA\Polls\AppInfo\Application;
+use OCA\Polls\AppConstants;
 use OCA\Polls\Attributes\ManuallyRunnableCronJob;
 use OCA\Polls\Service\MailService;
 use OCP\AppFramework\Utility\ITimeFactory;
@@ -38,7 +38,7 @@ class NotificationCron extends TimedJob {
 	 * @return void
 	 */
 	protected function run($argument) {
-		$this->session->set(Application::SESSION_KEY_CRON_JOB, true);
+		$this->session->set(AppConstants::SESSION_KEY_CRON_JOB, true);
 		try {
 			$this->mailService->sendNotifications();
 		} catch (Exception $e) {
@@ -47,7 +47,7 @@ class NotificationCron extends TimedJob {
 				['message' => $e->getMessage()]
 			);
 		} finally {
-			$this->session->remove(Application::SESSION_KEY_CRON_JOB);
+			$this->session->remove(AppConstants::SESSION_KEY_CRON_JOB);
 		}
 
 	}

--- a/lib/Cron/UserDeletedJob.php
+++ b/lib/Cron/UserDeletedJob.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
 
 namespace OCA\Polls\Cron;
 
-use OCA\Polls\AppInfo\Application;
+use OCA\Polls\AppConstants;
 use OCA\Polls\Db\CommentMapper;
 use OCA\Polls\Db\LogMapper;
 use OCA\Polls\Db\OptionMapper;
@@ -51,7 +51,7 @@ class UserDeletedJob extends QueuedJob {
 	 * @return void
 	 */
 	protected function run($argument) {
-		$this->session->set(Application::SESSION_KEY_CRON_JOB, true);
+		$this->session->set(AppConstants::SESSION_KEY_CRON_JOB, true);
 		$userId = $argument['userId'];
 		$this->logger->info('Deleting polls for deleted user', [
 			'userId' => $userId
@@ -72,6 +72,6 @@ class UserDeletedJob extends QueuedJob {
 		$this->commentMapper->renameUserId($userId, $replacementName);
 		$this->optionMapper->renameUserId($userId, $replacementName);
 		$this->voteMapper->renameUserId($userId, $replacementName);
-		$this->session->remove(Application::SESSION_KEY_CRON_JOB);
+		$this->session->remove(AppConstants::SESSION_KEY_CRON_JOB);
 	}
 }

--- a/lib/UserSession.php
+++ b/lib/UserSession.php
@@ -10,7 +10,6 @@ namespace OCA\Polls;
 
 use DateTimeZone;
 use Exception;
-use OCA\Polls\AppInfo\Application;
 use OCA\Polls\Db\Share;
 use OCA\Polls\Db\ShareMapper;
 use OCA\Polls\Db\UserMapper;
@@ -23,7 +22,7 @@ use OCP\IUserSession;
 
 class UserSession {
 	/** @var string */
-	public const SESSION_KEY_CRON_JOB = Application::SESSION_KEY_CRON_JOB;
+	public const SESSION_KEY_CRON_JOB = 'ncPollsCronJob';
 	/** @var string */
 	public const SESSION_KEY_USER_ID = 'ncPollsUserId';
 	/** @var string */


### PR DESCRIPTION
The updater is missing the new constant location, because of long standing issue (Classes not updated on update)
