### PR TITLE
extract shallow currentRoute from router

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -8,7 +8,6 @@ import {
 	createWebHistory,
 	createRouter,
 } from 'vue-router'
-import { shallowRef } from 'vue'
 
 import { getCurrentUser } from '@nextcloud/auth'
 import { generateUrl } from '@nextcloud/router'
@@ -19,6 +18,7 @@ import { Event } from './Types'
 
 import Navigation from './views/Navigation.vue'
 
+import { activeRoute } from './routerState'
 import { useSessionStore } from './stores/session'
 import { usePollStore } from './stores/poll'
 import { usePollsStore } from './stores/polls'
@@ -219,11 +219,8 @@ const router = createRouter({
 	linkActiveClass: 'active',
 })
 
-// Reflects the navigation target during guards (router.currentRoute is only
-// updated after navigation commits, so stores must read this ref instead).
-export const activeRoute = shallowRef<RouteLocationNormalized>(
-	router.currentRoute.value,
-)
+// Initialize activeRoute with the router's starting location.
+activeRoute.value = router.currentRoute.value
 
 router.beforeEach(
 	async (to: RouteLocationNormalized, from: RouteLocationNormalized) => {

--- a/src/routerState.ts
+++ b/src/routerState.ts
@@ -1,0 +1,22 @@
+/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+// Shared ref for the active route — kept in a separate module so that stores
+// can import it without triggering the router creation (and its createWebHistory
+// side-effects) in contexts like the Dashboard widget.
+import { shallowRef } from 'vue'
+import type { RouteLocationNormalized } from 'vue-router'
+
+export const activeRoute = shallowRef<RouteLocationNormalized>({
+	meta: {},
+	params: {},
+	query: {},
+	hash: '',
+	path: '/',
+	name: null,
+	matched: [],
+	fullPath: '/',
+	redirectedFrom: undefined,
+} as unknown as RouteLocationNormalized)

--- a/src/stores/comments.ts
+++ b/src/stores/comments.ts
@@ -6,7 +6,7 @@
 import { defineStore } from 'pinia'
 
 import { CommentsAPI, PublicAPI } from '../Api'
-import { activeRoute } from '../router'
+import { activeRoute } from '../routerState'
 import { groupComments } from '../helpers/modules/comments'
 import { Logger } from '../helpers/modules/logger'
 

--- a/src/stores/options.ts
+++ b/src/stores/options.ts
@@ -7,7 +7,7 @@ import { defineStore } from 'pinia'
 import orderBy from 'lodash/orderBy'
 
 import { PublicAPI, OptionsAPI } from '../Api'
-import { activeRoute } from '../router'
+import { activeRoute } from '../routerState'
 import { Logger } from '../helpers/modules/logger'
 
 import { usePollStore } from './poll'

--- a/src/stores/poll.ts
+++ b/src/stores/poll.ts
@@ -16,7 +16,7 @@ import { emit } from '@nextcloud/event-bus'
 
 import { Logger } from '../helpers/modules/logger'
 import { PublicAPI, PollsAPI } from '../Api'
-import { activeRoute } from '../router'
+import { activeRoute } from '../routerState'
 import { defaultUser, Event } from '../Types'
 
 import { usePollsStore } from './polls'

--- a/src/stores/pollGroups.ts
+++ b/src/stores/pollGroups.ts
@@ -10,7 +10,7 @@ import orderBy from 'lodash/orderBy'
 
 import { t } from '@nextcloud/l10n'
 import { usePollsStore } from './polls'
-import { activeRoute } from '../router'
+import { activeRoute } from '../routerState'
 
 import { PollGroupsAPI } from '../Api'
 

--- a/src/stores/polls.ts
+++ b/src/stores/polls.ts
@@ -10,7 +10,7 @@ import { t } from '@nextcloud/l10n'
 
 import { Logger } from '../helpers/modules/logger'
 import { PollsAPI } from '../Api'
-import { activeRoute } from '../router'
+import { activeRoute } from '../routerState'
 
 import { useSessionStore } from './session'
 import { usePollGroupsStore } from './pollGroups'

--- a/src/stores/session.ts
+++ b/src/stores/session.ts
@@ -9,7 +9,7 @@ import { getCurrentUser } from '@nextcloud/auth'
 import { t } from '@nextcloud/l10n'
 
 import { Logger } from '../helpers/modules/logger'
-import { activeRoute } from '../router'
+import { activeRoute } from '../routerState'
 import { PublicAPI, SessionAPI } from '../Api'
 
 import { useSubscriptionStore } from './subscription'

--- a/src/stores/subscription.ts
+++ b/src/stores/subscription.ts
@@ -7,7 +7,7 @@ import { ref } from 'vue'
 import { defineStore } from 'pinia'
 
 import { PublicAPI, PollsAPI } from '../Api'
-import { activeRoute } from '../router'
+import { activeRoute } from '../routerState'
 import { Logger } from '../helpers/modules/logger'
 
 import { useSessionStore } from './session'

--- a/src/stores/votes.ts
+++ b/src/stores/votes.ts
@@ -5,7 +5,7 @@
 
 import { defineStore } from 'pinia'
 import { PublicAPI, VotesAPI } from '../Api'
-import { activeRoute } from '../router'
+import { activeRoute } from '../routerState'
 import { Logger } from '../helpers/modules/logger'
 import { StoreHelper } from '../helpers/modules/StoreHelper'
 


### PR DESCRIPTION
fix #4628

Since v9 we eliminated the `routerStore` and use the router directly inside the stores. This has the side effect, that by loading the store the router gets imported, initialized completely and sets the router base to `apps/polls`on `createRouter()`. 

Because the dashboard uses the `pollStore` this also happens when the dashboard gets registered.

To avoid this, the `routerState` gets extracted from the router to it's own external shallowRef. 

Stores now only import the `routerState` instead of the complete router.

The router itself only gets imported and initialized within `main.ts`.

The routerState gets still updated inside the `beforeEach` guard.
