### PR TITLE
Fix index creation 3

### DIFF
--- a/lib/Db/V8/IndexManager.php
+++ b/lib/Db/V8/IndexManager.php
@@ -435,7 +435,7 @@ class IndexManager extends DbManager {
 				$table = $this->schema->getTable($prefixedTable);
 
 				foreach ($table->getIndexes() as $index) {
-					if ($index->isUnique()) {
+					if ($index->isUnique() && !$index->isPrimary()) {
 						$table->dropIndex($index->getName());
 						$messages[] = 'Dropped unique index ' . $index->getName() . ' from ' . $tableName;
 					}

--- a/lib/Db/V8/IndexManager.php
+++ b/lib/Db/V8/IndexManager.php
@@ -59,6 +59,39 @@ class IndexManager extends DbManager {
 	}
 
 	/**
+	 * Ensure all tables have their primary key on 'id'.
+	 * All PKs in this app are autoincrement 'id' columns — if one is missing
+	 * (e.g. after a failed migration on a non-transactional DB engine), restore it.
+	 *
+	 * @return string[] logged messages
+	 */
+	public function repairPrimaryKeys(): array {
+		$this->needsSchema();
+		$messages = [];
+
+		foreach (array_keys(TableSchema::TABLES) as $tableName) {
+			$prefixedTable = $this->getTableName($tableName);
+
+			if (!$this->schema->hasTable($prefixedTable)) {
+				continue;
+			}
+
+			$table = $this->schema->getTable($prefixedTable);
+
+			if ($table->getPrimaryKey() === null) {
+				$table->setPrimaryKey(['id']);
+				$messages[] = 'Restored missing primary key for ' . $tableName;
+			}
+		}
+
+		if (empty($messages)) {
+			$messages[] = 'All primary keys intact';
+		}
+
+		return $messages;
+	}
+
+	/**
 	 * add 'on delete' fk contraints to all tables referencing the main polls table
 	 * Foreign key constraints are crucial for the correct operation of the polls app.
 	 * This for they have to be updated on every update.

--- a/lib/Db/V8/IndexManager.php
+++ b/lib/Db/V8/IndexManager.php
@@ -261,7 +261,7 @@ class IndexManager extends DbManager {
 			$table = $this->schema->getTable($tableName);
 
 			foreach ($table->getIndexes() as $index) {
-				if (strpos($index->getName(), 'UNIQ_') === 0) {
+				if (stripos($index->getName(), 'UNIQ_') === 0) {
 					$table->dropIndex($index->getName());
 					$messages[] = 'Removed ' . $index->getName() . ' from ' . $tableName;
 				}

--- a/lib/Migration/RepairSteps/CreateUniqueIndices.php
+++ b/lib/Migration/RepairSteps/CreateUniqueIndices.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace OCA\Polls\Migration\RepairSteps;
 
-use Doctrine\DBAL\Exception as DBALException;
 use Doctrine\DBAL\Schema\Schema;
 use OCA\Polls\Db\V8\IndexManager;
 use OCP\IDBConnection;
@@ -38,7 +37,7 @@ class CreateUniqueIndices implements IRepairStep {
 
 		try {
 			$this->connection->migrateToSchema($this->schema);
-		} catch (DBALException $e) {
+		} catch (\Exception $e) {
 			// Hard fallback!
 			// Recreating indices can affect system performance on some db engines with large datasets.
 			// But the app relies on these indices to function properly, so we have to ensure they are created.

--- a/lib/Migration/RepairSteps/CreateUniqueIndices.php
+++ b/lib/Migration/RepairSteps/CreateUniqueIndices.php
@@ -47,6 +47,7 @@ class CreateUniqueIndices implements IRepairStep {
 				$output->warning('Polls - Index conflict detected, rebuilding unique indices: ' . $e->getMessage());
 				$this->schema = $this->connection->createSchema();
 				$this->indexManager->setSchema($this->schema);
+				$messages = array_merge($messages, $this->indexManager->repairPrimaryKeys());
 				$messages = array_merge($messages, $this->indexManager->removeAllUniqueIndices());
 				$this->connection->migrateToSchema($this->schema);
 


### PR DESCRIPTION
* The check for existing index names has to be case insensitive for PostgreSQL
  changed strpos() to stripos()
* DBALException was catched, but Exception was thrown
  Changed catch from ...\DBAL\Exception to \Exception
* Primary keys could have been dropped in hard fallback
  Secure PKs when dropping unique indices
  Added a repair step to restore PK on accidentially drop
