### PR TITLE
Remove names from unique indices

### DIFF
--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Nextcloud contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
 name: Sync docs to Wiki
 
 on:

--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -1,0 +1,27 @@
+name: Sync docs to Wiki
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'docs/**.md'
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Push docs to Wiki
+        env:
+          WIKI_PAT: ${{ secrets.WIKI_PAT }}
+        run: |
+          git clone https://x-access-token:${WIKI_PAT}@github.com/nextcloud/polls.wiki.git wiki
+          cp docs/*.md wiki/
+          cd wiki
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add .
+          git diff --cached --quiet && echo "No changes, skipping." || git commit -m "Sync docs/ from main repo"
+          git push

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -50,6 +50,7 @@
     <command>OCA\Polls\Command\Db\RemoveOptionalIndices</command>
     <command>OCA\Polls\Command\Db\RemoveUniqueIndices</command>
     <command>OCA\Polls\Command\Db\ResetWatch</command>
+    <command>OCA\Polls\Command\Db\ResetUniqueIndices</command>
     <command>OCA\Polls\Command\Poll\TransferOwnership</command>
     <command>OCA\Polls\Command\Share\Add</command>
     <command>OCA\Polls\Command\Share\Remove</command>

--- a/docs/Installation-help.md
+++ b/docs/Installation-help.md
@@ -1,3 +1,7 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 # Update Issues
 **This should be no issue anymore since v8.3.**
 

--- a/docs/Installation-help.md
+++ b/docs/Installation-help.md
@@ -1,0 +1,70 @@
+# Update Issues
+**This should be no issue anymore since v8.3.**
+
+When Polls gets updated and needs changed classes while updating a situation may occur which lets the migration fail. This is because Polls relies on its own declarative database definitions. On updates a situation now can occur where changed classes, which are used while updating, get not loaded properly and the old version of these classes are still cached and loaded.
+
+This can lead to two states:
+
+## Migration leaves site in maintenance mode
+In this situation Nextcloud refuses any further action and stays in maintenance mode.
+To fix this follow these steps:
+* call `occ app:disable polls`
+* call `occ maintenance:mode --off`
+* call `occ app:enable polls`
+After that the site should be up again and Polls updated to the latest version. If this actions lead to no success end the site ended in maintenance mode again, keep polls disabled and turn off the maintenance mode. Please report that issue [here](https://github.com/nextcloud/polls/issues).
+
+## Polls stays disabled
+If Polls just did not get enabled and the update terminated with an error message, try to enable it again.
+After that Polls should be updated to the latest version. If Polls resumed back to disabled state again, keep polls disabled and please report that issue [here](https://github.com/nextcloud/polls/issues).
+
+# Installation variants
+## Install via Git
+If you want to run the latest development version from git source, you need to clone the repo to your apps folder:
+```
+git clone https://github.com/nextcloud/polls.git
+```
+* Install runtime environment with `make setup-build`
+* Compile javascript with `npm run build`
+* call `occ app:enable polls` to enable Polls
+
+* With `make appstore` You can create a distribution build (Find the output in the build directory)
+* Install dev environment with `make setup-dev`
+
+## Install via Appstore
+Got to your apps page (https://nc.foo.com/settings/apps) and search for Polls. Just enable or install the app with the button.
+
+## Install via occ
+Call `occ app:install polls` or `occ app:enable polls`
+
+# Install Paths of Nextcloud
+Depending on the installation variant different steps are executed. (This mainly for self documentation)
+
+## Enabling Polls (first install or re-enable)
+Every time the app is enabled — whether for the first time or after being disabled — Nextcloud executes:
+* unexecuted `migration classes` (not listed in the `*_migrations` table)
+* `install` repair steps — none currently registered
+
+## Version Update
+After a version update (changed version attribute in appinfo/info.xml) Nextcloud executes:
+* `pre-migration` repair steps (none currently registered)
+* unexecuted `migration classes` (not listed in the `*_migrations` table)
+* `post-migration` repair steps:
+  * **DropOrphanedIndices** — removes obsolete indices from previous versions
+  * **CreateUniqueIndices** — creates or updates unique indices (column-based)
+  * **UpdateHashes** — creates or updates hashes for votes and options
+  * **MigratePublicToOpen** — migrates access values from `public` to `open`
+
+Note: `post-migration` repair steps also run when executing `occ maintenance:repair`.
+
+# Install via File Base
+Download the desired version from the [releases page](https://github.com/nextcloud/polls/releases) and extract it to your app folder where common apps reside. After extraction there should be a polls folder containing the Polls app.
+
+If updating this way, make sure the Polls folder gets removed or emptied before. Otherwise side effects can occur while migrating or on run time.
+
+# Removing Polls
+Call `occ polls:db:purge` to remove Polls completely.
+* removes all Polls related tables
+* removes all Polls related migration records
+* removes all Polls related app config records (this also disables Polls)
+
+This does not remove Polls' files (call `occ app:remove polls` to remove it complete afterwards) but it resets Polls into an 'uninstalled' state. Enabling the app is then equivalent to a first time install and calls the migration and the install repair step (see above).

--- a/docs/occ.md
+++ b/docs/occ.md
@@ -1,0 +1,153 @@
+# Available occ Commands
+Note: In any case make sure you have a backup of your database and only use these commands if you know what you are doing. Although no data loss is reported until now caused from the usage of these commands (especially these from the `polls:db` namespace).
+
+All commands require polls to be enabled and are not available after uninstall or while in maintenance mode.
+
+## Overview
+|Command|Description|
+|-|-|
+|[`db:add-missing-indices`](#create-optional-indices)                                                     | Create optional indices (NC core command)    |
+|[`maintenance:repair`](#run-repair-steps)                                                                | Run Polls post-migration repair steps (NC core command) |
+|[`polls:index:remove:foreign-key-constraints`](#remove-foreign-key-constraints)                         | Remove foreign key constraints              |
+|[`polls:index:remove:unique-indices`](#remove-unique-indices)                                            | Remove unique indices                        |
+|[`polls:index:remove:optional`](#remove-optional-indices)                                                | Remove optional indices                      |
+|[`polls:index:create`](#create-indices)                                                                  | Add unique indices and foreign key constraints |
+|[`polls:db:clean-migrations`](#remove-migration-entries)                                                 | Remove migration entries                     |
+|[`polls:db:fix`](#fix-table-structure)                                                                   | Fix table structure                          |
+|[`polls:db:reset-unique-indices`](#reset-unique-indices)                                                 | Reset unique indices to named UNIQ_ form     |
+|[`polls:db:reset-watch`](#refresh-watch-table)                                                           | Refresh watch table                          |
+|[`polls:db:rebuild`](#rebuild-tables)                                                                    | Rebuild tables                               |
+|[`polls:db:purge`](#purge-polls)                                                                         | Purge Polls                                  |
+|[`polls:poll:transfer-ownership  <source-user> <target-user>`](#transfer-ownership)                      | Transfer ownership                           |
+|[`polls:share:add [--user USER] [--group GROUP] [--email EMAIL] [--] <id>`](#invite-people)              | Invite people                                |
+|[`polls:share:remove [--user USER] [--group GROUP] [--email EMAIL] [--] <id>`](#remove-share)            | Remove share                                 |
+
+
+## Nextcloud Core Commands
+These are Nextcloud core commands that trigger Polls-specific behavior.
+
+### Create Optional Indices
+**Command:** `occ db:add-missing-indices`
+
+Creates missing optional indices for all apps, including Polls. Refer to the 'Administration settings' of your instance — missing indices are reported in the 'Security & warnings' section.
+
+Keep in mind that the creation of optional indices can be time consuming.
+
+### Run Repair Steps
+**Command:** `occ maintenance:repair`
+
+Triggers all registered `post-migration` repair steps for every enabled app, including Polls. The following Polls-specific repair steps are executed:
+
+* **DropOrphanedIndices** — removes obsolete indices left over from previous versions
+* **CreateUniqueIndices** — creates or updates unique indices (column-based, no unnecessary re-indexing)
+* **UpdateHashes** — creates or updates hashes for votes and options
+* **MigratePublicToOpen** — migrates access values from `public` to `open`
+
+This command is useful after manual database interventions or when the repair steps did not complete successfully during an update.
+
+## Indices
+**Namespace:** `polls:index`
+
+These commands are usually only for analysis or tests. So you should not need them under normal operation mode.
+
+### Remove Foreign Key Constraints
+**Command:** `occ polls:index:remove:foreign-key-constraints`
+
+**Note:** This is highly **NOT RECOMMENDED**. These indices are responsible for database health and help avoiding orphaned records. The unique indices grant that by removing a poll all depending records from other tables like options and votes are removed from the database as well.
+So, if you have to remove them, take care, that the indices are regenerated in time. Otherwise you may have to clean your database manually.
+
+### Remove Unique Indices
+**Command:** `occ polls:index:remove:unique-indices`
+
+**Note:** This is highly **NOT RECOMMENDED**. These indices are responsible for database integrity. Besides the unique main key (the entity id) the indices avoid duplication of options, votes and more. Removing these indices may result in a broken application and duplicates have to be manually identified and removed, before the indices can get recreated again.
+
+### Remove Optional Indices
+**Command:** `occ polls:index:remove:optional`
+
+Optional indices are for better database performance. Removing them does no harm to the application, but the database has to do full table scans, especially for complex joins. This can result in heavy performance issues.
+
+### Create Indices
+**Command:** `occ polls:index:create`
+
+Recreates all foreign key constraints and unique indices. Existing indices covering the correct columns are kept regardless of their name — no unnecessary re-indexing occurs.
+
+## Database
+**Namespace:** `polls:db`
+
+### Remove Migration Entries
+**Command:** `occ polls:db:clean-migrations`
+
+**Note:** Although this command removes only old polls related migration steps which are not used anymore, you should not use it because it may trigger old migration steps. If really necessary, this will be done while updating polls anyways.
+
+### Fix Table Structure
+**Command:** `occ polls:db:fix`
+
+Checks all polls tables and updates their structure against the current schema definition. No indices are created, updated or removed. No data migration is executed.
+
+### Reset Unique Indices
+**Command:** `occ polls:db:reset-unique-indices`
+
+**For testing purposes only.** Drops all unique indices from Polls tables and recreates them with explicit `UNIQ_` names. This simulates the pre-migration state to verify that the repair step handles existing named indices correctly without triggering an unnecessary re-indexing.
+
+**Note:** This triggers a full re-indexing on all affected tables and can be time consuming on large installations.
+
+### Refresh Watch Table
+**Command:** `occ polls:db:reset-watch`
+
+The watch table is for temporary usage and reports changes in time (especially for long polling and periodic polling). This can result in a rapidly rising amount of id numbers. This command resets the table to start again with id 0. This is done on every update of polls, so you probably should never need it.
+
+### Rebuild Tables
+**Command:** `occ polls:db:rebuild`
+
+**Note:** This will not build a consistent database when downgrading to a prior major or minor version and new database columns have been added. No database columns get removed if not explicitly listed as orphaned and obsolete. In this case you have to remove these columns manually.
+
+In any situation where the database seems to be corrupt, this command checks and corrects issues of the database. In detail it performs the following actions:
+* Remove all foreign key constraints
+* Remove all unique indices
+* Remove all optional indices
+* Remove orphaned tables and columns possibly left over from old installations
+* Check the table schema and update all tables to the currently defined database schema
+* Check hashes of the votes and options table and add missing ones (based on the unique index definitions)
+  The hashes are short md5 hashes of the poll id and option texts and are essential for fast comparisons and for the unique indices
+* Search for duplicates and orphaned entries and remove them (based on the unique indices including the foreign key constraints)
+  Only one of the duplicates will be kept. Otherwise the index creation would fail.
+* Recreate foreign key constraints and unique indices
+
+To add the removed optional indices call `occ db:add-missing-indices` after the recreation finished without error.
+
+### Purge Polls
+**Command:** `occ polls:db:purge`
+
+Unfortunately or luckily Nextcloud does not remove any tables from the database when uninstalling an app. If you plan to reinstall the app later and want to make sure your already persisted data can be used after the new installation, this is safe behavior. But if you just want to test polls and decide not to use it further, you have to live with orphaned tables inside your database.
+
+This command allows you to remove all persisted data of polls and wipe it from your database. So before uninstalling polls you should call `occ polls:db:purge`. In detail this command executes the following actions:
+* Purge all foreign key constraint child tables, to make sure parents can be removed as well
+* Purge all foreign key constraint parent tables
+* Purge any eventually left over tables of polls
+* Remove all polls related migration records from `oc_migrations` to make sure a later reinstall is possible
+* Remove all polls related appconfig settings from `oc_appconfig`
+
+Then remove polls from the apps directory by calling `occ app:remove polls`
+
+In case you already uninstalled polls, just install it (`occ app:install polls`) and follow the path above.
+
+## Poll Actions
+**Namespace:** `polls:poll`
+
+### Transfer Ownership
+**Command:** `occ polls:poll:transfer-ownership <source-user> <target-user>`
+
+Transfers the ownership of all source user's polls from `<source-user>` to `<target-user>`
+
+## Shares
+**Namespace:** `polls:share`
+
+### Invite People
+**Command:** `occ polls:share:add [--user USER] [--group GROUP] [--email EMAIL] [--] <id>`
+
+Invite people by username, group membership or by email address to poll `<id>`
+
+### Remove Share
+**Command:** `occ polls:share:remove [--user USER] [--group GROUP] [--email EMAIL] [--] <id>`
+
+Remove share by username, group or email address from poll `<id>`

--- a/docs/occ.md
+++ b/docs/occ.md
@@ -1,3 +1,7 @@
+<!--
+  - SPDX-FileCopyrightText: 2026
+  - SPDX-License-Identifier: AGP
+-->
 # Available occ Commands
 Note: In any case make sure you have a backup of your database and only use these commands if you know what you are doing. Although no data loss is reported until now caused from the usage of these commands (especially these from the `polls:db` namespace).
 

--- a/docs/occ.md
+++ b/docs/occ.md
@@ -1,6 +1,6 @@
 <!--
   - SPDX-FileCopyrightText: 2026
-  - SPDX-License-Identifier: AGP
+  - SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 # Available occ Commands
 Note: In any case make sure you have a backup of your database and only use these commands if you know what you are doing. Although no data loss is reported until now caused from the usage of these commands (especially these from the `polls:db` namespace).

--- a/lib/Command/Db/ResetUniqueIndices.php
+++ b/lib/Command/Db/ResetUniqueIndices.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Polls\Command\Db;
+
+use Doctrine\DBAL\Schema\Schema;
+use OCA\Polls\Command\Command;
+use OCA\Polls\Db\V9\IndexManager;
+use OCP\IDBConnection;
+
+/**
+ * @psalm-api
+ */
+class ResetUniqueIndices extends Command {
+	protected string $name = parent::NAME_PREFIX . 'db:reset-unique-indices';
+	protected string $description = '[TEST] Drop all unique indices and recreate them with named UNIQ_ prefix';
+	protected array $operationHints = [
+		'For testing purposes only.',
+		'Drops all unique indices from Polls tables and recreates them with explicit UNIQ_ names.',
+		'This simulates the pre-migration state to verify that the repair step handles existing named indices correctly.',
+		'Note: This triggers a full re-indexing and can be time consuming on large installations.',
+	];
+
+	public function __construct(
+		private IndexManager $indexManager,
+		private IDBConnection $connection,
+		private Schema $schema,
+	) {
+		parent::__construct();
+	}
+
+	protected function runCommands(): int {
+		$this->schema = $this->connection->createSchema();
+		$this->indexManager->setSchema($this->schema);
+
+		$this->printComment('Dropping all unique indices');
+		$messages = $this->indexManager->removeAllUniqueIndices();
+		$this->printInfo($messages, ' - ');
+		$this->connection->migrateToSchema($this->schema);
+
+		$this->schema = $this->connection->createSchema();
+		$this->indexManager->setSchema($this->schema);
+
+		$this->printComment('Recreating unique indices with UNIQ_ names');
+		$messages = $this->indexManager->createUniqueIndices(true);
+		$this->printInfo($messages, ' - ');
+		$this->connection->migrateToSchema($this->schema);
+
+		$this->printComment('Existing indices after reset:');
+		$messages = $this->indexManager->listExistingIndices();
+		$this->printInfo($messages, ' - ');
+
+		return 0;
+	}
+}

--- a/lib/Command/Db/ResetWatch.php
+++ b/lib/Command/Db/ResetWatch.php
@@ -47,8 +47,8 @@ class ResetWatch extends Command {
 
 		$messages = $this->tableManager->createTable($tableName);
 
-		foreach (TableSchema::UNIQUE_INDICES[$tableName] as $name => $definition) {
-			$messages[] = $this->indexManager->createIndex($tableName, $name, $definition['columns'], true);
+		foreach (TableSchema::UNIQUE_INDICES[$tableName] as $definition) {
+			$messages[] = $this->indexManager->createIndex($tableName, '', $definition['columns'], true);
 		}
 
 		$this->connection->migrateToSchema($this->schema);

--- a/lib/Db/V9/IndexManager.php
+++ b/lib/Db/V9/IndexManager.php
@@ -59,39 +59,6 @@ class IndexManager extends DbManager {
 	}
 
 	/**
-	 * Ensure all tables have their primary key on 'id'.
-	 * All PKs in this app are autoincrement 'id' columns — if one is missing
-	 * (e.g. after a failed migration on a non-transactional DB engine), restore it.
-	 *
-	 * @return string[] logged messages
-	 */
-	public function repairPrimaryKeys(): array {
-		$this->needsSchema();
-		$messages = [];
-
-		foreach (array_keys(TableSchema::TABLES) as $tableName) {
-			$prefixedTable = $this->getTableName($tableName);
-
-			if (!$this->schema->hasTable($prefixedTable)) {
-				continue;
-			}
-
-			$table = $this->schema->getTable($prefixedTable);
-
-			if ($table->getPrimaryKey() === null) {
-				$table->setPrimaryKey(['id']);
-				$messages[] = 'Restored missing primary key for ' . $tableName;
-			}
-		}
-
-		if (empty($messages)) {
-			$messages[] = 'All primary keys intact';
-		}
-
-		return $messages;
-	}
-
-	/**
 	 * add 'on delete' fk contraints to all tables referencing the main polls table
 	 * Foreign key constraints are crucial for the correct operation of the polls app.
 	 * This for they have to be updated on every update.
@@ -294,7 +261,7 @@ class IndexManager extends DbManager {
 			$table = $this->schema->getTable($tableName);
 
 			foreach ($table->getIndexes() as $index) {
-				if (stripos($index->getName(), 'UNIQ_') === 0) {
+				if ($index->isUnique() && !$index->isPrimary()) {
 					$table->dropIndex($index->getName());
 					$messages[] = 'Removed ' . $index->getName() . ' from ' . $tableName;
 				}
@@ -435,49 +402,27 @@ class IndexManager extends DbManager {
 	 *
 	 * @return string[] logged messages
 	 */
-	public function createUniqueIndices(): array {
+	/**
+	 * @param bool $namedIndices
+	 *                           false (default) — column-based detection; an existing unique index on the
+	 *                           same columns is accepted regardless of its name.
+	 *                           true            — enforce the names from UNIQUE_INDICES; renames existing
+	 *                           indices with matching columns (used by polls:db:reset-unique-indices).
+	 */
+	public function createUniqueIndices(bool $namedIndices = false): array {
 		$messages = [];
 		$this->needsSchema();
 
-		try {
-			foreach (TableSchema::UNIQUE_INDICES as $tableName => $uniqueIndices) {
-				$prefixedTable = $this->getTableName($tableName);
+		foreach (TableSchema::UNIQUE_INDICES as $tableName => $uniqueIndices) {
+			$prefixedTable = $this->getTableName($tableName);
 
-				if (!$this->schema->hasTable($prefixedTable)) {
-					$messages[] = 'Table ' . $prefixedTable . ' does not exist, skip unique index creation';
-					continue;
-				}
-
-				foreach ($uniqueIndices as $name => $definition) {
-					$messages[] = $this->createIndex($tableName, $name, $definition['columns'], true);
-				}
+			if (!$this->schema->hasTable($prefixedTable)) {
+				$messages[] = 'Table ' . $prefixedTable . ' does not exist, skip unique index creation';
+				continue;
 			}
-		} catch (Exception $e) {
-			// If any exception was thrown, run a fallbach by dropping all unique indices and recreating them.
-			// The app relies on the unique indices for correct operation.
-			$messages[] = 'Failed creating unique indices (' . $e->getMessage() . '), falling back to complete recreation';
 
-			foreach (TableSchema::UNIQUE_INDICES as $tableName => $uniqueIndices) {
-				$prefixedTable = $this->getTableName($tableName);
-
-				if (!$this->schema->hasTable($prefixedTable)) {
-					$messages[] = 'Table ' . $prefixedTable . ' does not exist, skip unique index recreation';
-					continue;
-				}
-
-				$table = $this->schema->getTable($prefixedTable);
-
-				foreach ($table->getIndexes() as $index) {
-					if ($index->isUnique() && !$index->isPrimary()) {
-						$table->dropIndex($index->getName());
-						$messages[] = 'Dropped unique index ' . $index->getName() . ' from ' . $tableName;
-					}
-				}
-
-				foreach ($uniqueIndices as $name => $definition) {
-					$table->addUniqueIndex($definition['columns'], $name);
-					$messages[] = 'Recreated unique index ' . $name . ' in ' . $tableName;
-				}
+			foreach ($uniqueIndices as $name => $definition) {
+				$messages[] = $this->createIndex($tableName, $namedIndices ? $name : '', $definition['columns'], true);
 			}
 		}
 

--- a/lib/Migration/RepairSteps/CreateUniqueIndices.php
+++ b/lib/Migration/RepairSteps/CreateUniqueIndices.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace OCA\Polls\Migration\RepairSteps;
 
-use Doctrine\DBAL\Schema\Schema;
 use OCA\Polls\Db\V9\IndexManager;
 use OCP\IDBConnection;
 use OCP\Migration\IOutput;
@@ -19,7 +18,6 @@ class CreateUniqueIndices implements IRepairStep {
 	public function __construct(
 		private IndexManager $indexManager,
 		private IDBConnection $connection,
-		private Schema $schema,
 	) {
 	}
 
@@ -28,42 +26,11 @@ class CreateUniqueIndices implements IRepairStep {
 	}
 
 	public function run(IOutput $output): void {
-		$messages = [];
+		$schema = $this->connection->createSchema();
+		$this->indexManager->setSchema($schema);
 
-		$this->schema = $this->connection->createSchema();
-		$this->indexManager->setSchema($this->schema);
-
-		$messages = array_merge($messages, $this->indexManager->createUniqueIndices());
-
-		try {
-			$this->connection->migrateToSchema($this->schema);
-		} catch (\Exception $e) {
-			// Hard fallback!
-			// Recreating indices can affect system performance on some db engines with large datasets.
-			// But the app relies on these indices to function properly, so we have to ensure they are created.
-			// If for any reasons the unique indices cannot be created, we remove all unique indices and create them again.
-			// This is a workaround for index conflicts that might occur during migration.
-			$output->warning('Polls - Exception during index migration: ' . $e->getMessage() . "\n" . $e->getTraceAsString());
-
-			if (str_contains($e->getMessage(), 'already exists') || str_contains($e->getMessage(), '42P07')) {
-				$output->warning('Polls - Index conflict detected, rebuilding unique indices.');
-				if ($this->connection->inTransaction()) {
-					$this->connection->rollBack();
-				}
-				$this->schema = $this->connection->createSchema();
-				$this->indexManager->setSchema($this->schema);
-				$messages = array_merge($messages, $this->indexManager->repairPrimaryKeys());
-				$messages = array_merge($messages, $this->indexManager->removeAllUniqueIndices());
-				$this->connection->migrateToSchema($this->schema);
-
-				$this->schema = $this->connection->createSchema();
-				$this->indexManager->setSchema($this->schema);
-				$messages = array_merge($messages, $this->indexManager->createUniqueIndices());
-				$this->connection->migrateToSchema($this->schema);
-			} else {
-				throw $e;
-			}
-		}
+		$messages = $this->indexManager->createUniqueIndices();
+		$this->connection->migrateToSchema($schema);
 
 		foreach ($messages as $message) {
 			$output->info($message);

--- a/lib/Migration/RepairSteps/Install.php
+++ b/lib/Migration/RepairSteps/Install.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace OCA\Polls\Migration\RepairSteps;
 
-use Doctrine\DBAL\Schema\Schema;
 use OCA\Polls\Db\V9\IndexManager;
 use OCP\IDBConnection;
 use OCP\Migration\IOutput;
@@ -19,7 +18,6 @@ class Install implements IRepairStep {
 	public function __construct(
 		private IndexManager $indexManager,
 		private IDBConnection $connection,
-		private Schema $schema,
 	) {
 	}
 
@@ -28,20 +26,19 @@ class Install implements IRepairStep {
 	}
 
 	public function run(IOutput $output): void {
-		$messages = [];
-		$this->schema = $this->connection->createSchema();
-		$this->indexManager->setSchema($this->schema);
+		$schema = $this->connection->createSchema();
+		$this->indexManager->setSchema($schema);
 
-		$messages = array_merge($messages, $this->indexManager->createForeignKeyConstraints());
+		$messages = $this->indexManager->createForeignKeyConstraints();
 		$messages = array_merge($messages, $this->indexManager->createUniqueIndices());
+		$messages = array_merge($messages, $this->indexManager->createOptionalIndices());
 
-		$this->connection->migrateToSchema($this->schema);
+		$this->connection->migrateToSchema($schema);
 
 		foreach ($messages as $message) {
 			$output->info($message);
 		}
 
-		$output->info('Polls - Foreign key contraints created.');
 		$output->info('Polls - Indices created.');
 	}
 }


### PR DESCRIPTION
* Removed the usage of named unique indices
  * Unique indices now get a random name
  * Test on the existence of unique indices is only based on the column definition no more on the name
  * Existing unique indices do not get changed – not necessary 
  * `occ polls:db:recreate` will rebuild the unique indices with the random name. Prior unique indices get removed anyway
  * This should finally fix #4652 and #4619

* Opportunity used for 
  * updating of `occ.md` and `Installation-help.md` and
  * adding a workflow to push them to the wiki  
