### PR TITLE
Replace deprecated Canceltoken by AbortController

### DIFF
--- a/src/Api/modules/HttpApi.js
+++ b/src/Api/modules/HttpApi.js
@@ -22,7 +22,6 @@ const axiosOcsConfig = {
 	},
 }
 
-const CancelToken = axios.CancelToken
 const httpInstance = axios.create(axiosConfig)
 const ocsInstance = axios.create(axiosOcsConfig)
 
@@ -53,12 +52,12 @@ const createCancelTokenHandler = (apiObject) => {
 			handleRequestCancellation: (subKey) => {
 				const key = String(subKey ?? '__default__')
 				if (!handlers[key]) {
-					handlers[key] = { cancelToken: undefined }
+					handlers[key] = { controller: undefined }
 				}
 				const handler = handlers[key]
-				handler.cancelToken?.cancel(`${propertyName} canceled`)
-				handler.cancelToken = CancelToken.source()
-				return handler.cancelToken
+				handler.controller?.abort(`${propertyName} canceled`)
+				handler.controller = new AbortController()
+				return handler.controller
 			},
 		}
 	})

--- a/src/Api/modules/activity.ts
+++ b/src/Api/modules/activity.ts
@@ -16,10 +16,10 @@ const activity = {
 				object_type: 'poll',
 				object_id: pollId,
 			},
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.getActivities.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 		return response
 	},

--- a/src/Api/modules/admin.ts
+++ b/src/Api/modules/admin.ts
@@ -12,10 +12,10 @@ const adminJobs = {
 		return httpInstance.request({
 			method: 'GET',
 			url: 'administration/jobs',
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.getJobsList.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 
@@ -27,10 +27,10 @@ const adminJobs = {
 				job: job.className,
 			},
 
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.runJob.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 }

--- a/src/Api/modules/appSettings.ts
+++ b/src/Api/modules/appSettings.ts
@@ -14,10 +14,10 @@ const appSettings = {
 			method: 'GET',
 			url: 'settings/app',
 			params: { time: +new Date() },
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.getAppSettings.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 
@@ -28,10 +28,10 @@ const appSettings = {
 			method: 'POST',
 			url: 'settings/app',
 			data: { appSettings },
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.writeAppSettings.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 
@@ -39,10 +39,10 @@ const appSettings = {
 		return httpInstance.request({
 			method: 'GET',
 			url: `groups${query.trim() ? `/${query.trim()}` : ''}`,
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.getGroups.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 
@@ -54,10 +54,10 @@ const appSettings = {
 			method: 'GET',
 			url: `search/users${query.trim() ? `/${query.trim()}` : ''}`,
 			params: { types: types.toString() },
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.getUsers.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 }

--- a/src/Api/modules/calendar.ts
+++ b/src/Api/modules/calendar.ts
@@ -14,10 +14,10 @@ const calendar = {
 			method: 'GET',
 			url: 'calendars',
 			params: { time: +new Date() },
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.getCalendars.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 	getEvents(

--- a/src/Api/modules/comments.ts
+++ b/src/Api/modules/comments.ts
@@ -13,10 +13,10 @@ const comments = {
 			method: 'GET',
 			url: `poll/${pollId}/comments`,
 			params: { time: +new Date() },
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.getComments.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 	addComment(
@@ -29,10 +29,10 @@ const comments = {
 			url: `poll/${pollId}/comment`,
 			data: { message, confidential },
 			params: { time: +new Date() },
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.addComment.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 
@@ -42,10 +42,10 @@ const comments = {
 			url: `comment/${commentId}`,
 			params: { time: +new Date() },
 
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.deleteComment.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 	restoreComment(commentId: number): Promise<AxiosResponse<{ comment: Comment }>> {
@@ -54,10 +54,10 @@ const comments = {
 			url: `comment/${commentId}/restore`,
 			params: { time: +new Date() },
 
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.restoreComment.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 }

--- a/src/Api/modules/options.ts
+++ b/src/Api/modules/options.ts
@@ -15,10 +15,10 @@ const options = {
 			method: 'GET',
 			url: `poll/${pollId}/options`,
 			params: { time: +new Date() },
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.getOptions.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 
@@ -39,10 +39,10 @@ const options = {
 			url: `poll/${pollId}/option`,
 			// data: { ...option },
 			data: { option, sequence, voteYes },
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.addOption.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 
@@ -51,10 +51,10 @@ const options = {
 			method: 'PUT',
 			url: `option/${option.id}`,
 			data: { ...option },
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.updateOption.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 
@@ -63,10 +63,10 @@ const options = {
 			method: 'DELETE',
 			url: `option/${optionId}`,
 			params: { time: +new Date() },
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.deleteOption.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 
@@ -76,10 +76,10 @@ const options = {
 			url: `option/${optionId}/restore`,
 			params: { time: +new Date() },
 
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.restoreOption.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 
@@ -101,10 +101,10 @@ const options = {
 				pollId,
 				text: optionsBatch,
 			},
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.addOptions.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 
@@ -112,10 +112,10 @@ const options = {
 		return httpInstance.request({
 			method: 'PUT',
 			url: `option/${optionId}/confirm`,
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.confirmOption.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 
@@ -130,10 +130,10 @@ const options = {
 			method: 'POST',
 			url: `poll/${pollId}/options/reorder`,
 			data: { options },
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.reorderOptions.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 
@@ -147,10 +147,10 @@ const options = {
 			data: {
 				sequence,
 			},
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.addOptionsSequence.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 
@@ -166,10 +166,10 @@ const options = {
 				step,
 				unit,
 			},
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.shiftOptions.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 }

--- a/src/Api/modules/pollGroups.ts
+++ b/src/Api/modules/pollGroups.ts
@@ -14,10 +14,10 @@ const pollGroups = {
 			method: 'GET',
 			url: 'pollgroups',
 			params: { time: +new Date() },
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.getPollGroups.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 
@@ -46,10 +46,10 @@ const pollGroups = {
 			method: verb,
 			url,
 			data,
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.addPollToGroup.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 
@@ -60,10 +60,10 @@ const pollGroups = {
 		return httpInstance.request({
 			method: 'DELETE',
 			url: `pollgroup/${pollGroupId}/poll/${pollId}`,
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.removePollFromGroup.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 
@@ -81,10 +81,10 @@ const pollGroups = {
 				titleExt: payload.titleExt,
 				description: payload.description,
 			},
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.updatePollGroup.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 }

--- a/src/Api/modules/polls.ts
+++ b/src/Api/modules/polls.ts
@@ -31,10 +31,10 @@ const polls = {
 			method: 'GET',
 			url: 'polls',
 			params: { time: +new Date() },
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.getPolls.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 
@@ -43,10 +43,10 @@ const polls = {
 			method: 'GET',
 			url: `poll/${pollId}/poll`,
 			params: { time: +new Date() },
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.getPoll.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 
@@ -55,10 +55,10 @@ const polls = {
 			method: 'GET',
 			url: `poll/${pollId}`,
 			params: { time: +new Date() },
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.getPoll.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 
@@ -66,10 +66,10 @@ const polls = {
 		return httpInstance.request({
 			method: 'PUT',
 			url: `administration/poll/${pollId}/takeover`,
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.takeOver.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 
@@ -80,10 +80,10 @@ const polls = {
 		return httpInstance.request({
 			method: 'PUT',
 			url: `poll/${pollId}/changeowner/${userId}`,
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.changeOwner.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 
@@ -92,10 +92,10 @@ const polls = {
 			method: 'POST',
 			url: 'poll/add',
 			data: payload,
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.addPoll.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 
@@ -113,10 +113,10 @@ const polls = {
 			method: 'PUT',
 			url: `poll/${pollId}`,
 			data: { poll },
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.writePoll.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 
@@ -124,10 +124,10 @@ const polls = {
 		return httpInstance.request({
 			method: 'PUT',
 			url: `poll/${pollId}/lockAnonymous`,
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.lockAnonymous.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 
@@ -135,10 +135,10 @@ const polls = {
 		return httpInstance.request({
 			method: 'DELETE',
 			url: `poll/${pollId}`,
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.deletePoll.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 
@@ -146,10 +146,10 @@ const polls = {
 		return httpInstance.request({
 			method: 'PUT',
 			url: `poll/${pollId}/close`,
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.closePoll.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 
@@ -157,10 +157,10 @@ const polls = {
 		return httpInstance.request({
 			method: 'PUT',
 			url: `poll/${pollId}/reopen`,
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.reopenPoll.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 
@@ -168,10 +168,10 @@ const polls = {
 		return httpInstance.request({
 			method: 'PUT',
 			url: `poll/${pollId}/toggleArchive`,
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.toggleArchive.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 
@@ -179,10 +179,10 @@ const polls = {
 		return httpInstance.request({
 			method: 'POST',
 			url: `poll/${pollId}/clone`,
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.clonePoll.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 
@@ -192,10 +192,10 @@ const polls = {
 		return httpInstance.request({
 			method: 'POST',
 			url: `poll/${pollId}/confirmation`,
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.sendConfirmation.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 
@@ -205,10 +205,10 @@ const polls = {
 		return httpInstance.request({
 			method: 'GET',
 			url: `poll/${pollId}/addresses`,
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.getParticipantsEmailAddresses.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 
@@ -218,10 +218,10 @@ const polls = {
 		return httpInstance.request({
 			method: 'GET',
 			url: `poll/${pollId}/subscription`,
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.getSubscription.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 
@@ -232,10 +232,10 @@ const polls = {
 		return httpInstance.request({
 			method: 'PUT',
 			url: `poll/${pollId}${subscription ? '/subscribe' : '/unsubscribe'}`,
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.setSubscription.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 }

--- a/src/Api/modules/public.ts
+++ b/src/Api/modules/public.ts
@@ -25,10 +25,10 @@ const publicPoll = {
 			method: 'GET',
 			url: `/s/${shareToken}/poll`,
 			params: { time: +new Date() },
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.getPoll.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 
@@ -37,10 +37,10 @@ const publicPoll = {
 			method: 'GET',
 			url: `/s/${shareToken}/session`,
 			params: { time: +new Date() },
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.getSession.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 
@@ -49,10 +49,10 @@ const publicPoll = {
 			method: 'GET',
 			url: `/s/${shareToken}/options`,
 			params: { time: +new Date() },
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.getOptions.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 
@@ -66,10 +66,10 @@ const publicPoll = {
 			method: 'POST',
 			url: `/s/${shareToken}/option`,
 			data: { option, sequence, voteYes },
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.addOption.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 
@@ -81,10 +81,10 @@ const publicPoll = {
 			method: 'DELETE',
 			url: `s/${shareToken}/option/${optionId}`,
 			params: { time: +new Date() },
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.deleteOption.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 
@@ -97,10 +97,10 @@ const publicPoll = {
 			url: `s/${shareToken}/option/${optionId}/restore`,
 			params: { time: +new Date() },
 
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.restoreOption.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 
@@ -109,10 +109,10 @@ const publicPoll = {
 			method: 'GET',
 			url: `/s/${shareToken}/votes`,
 			params: { time: +new Date() },
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.getVotes.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 
@@ -128,10 +128,10 @@ const publicPoll = {
 				optionId,
 				setTo,
 			},
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.setVote.name
-				].handleRequestCancellation(optionId).token,
+				].handleRequestCancellation(optionId).signal,
 		})
 	},
 
@@ -139,10 +139,10 @@ const publicPoll = {
 		return httpInstance.request({
 			method: 'DELETE',
 			url: `s/${shareToken}/user`,
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.resetVotes.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 
@@ -152,10 +152,10 @@ const publicPoll = {
 		return httpInstance.request({
 			method: 'DELETE',
 			url: `s/${shareToken}/votes/orphaned`,
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.removeOrphanedVotes.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 
@@ -166,10 +166,10 @@ const publicPoll = {
 			method: 'GET',
 			url: `/s/${shareToken}/comments`,
 			params: { time: +new Date() },
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.getComments.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 
@@ -183,10 +183,10 @@ const publicPoll = {
 			url: `s/${shareToken}/comment`,
 			data: { message, confidential },
 			params: { time: +new Date() },
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.addComment.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 
@@ -199,10 +199,10 @@ const publicPoll = {
 			url: `s/${shareToken}/comment/${commentId}`,
 			params: { time: +new Date() },
 
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.deleteComment.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 
@@ -215,10 +215,10 @@ const publicPoll = {
 			url: `s/${shareToken}/comment/${commentId}/restore`,
 			params: { time: +new Date() },
 
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.restoreComment.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 
@@ -227,10 +227,10 @@ const publicPoll = {
 			method: 'GET',
 			url: `s/${shareToken}/share`,
 			params: { time: +new Date() },
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.getShare.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 
@@ -242,10 +242,10 @@ const publicPoll = {
 			method: 'PUT',
 			url: `s/${shareToken}/email/${emailAddress}`,
 			params: { time: +new Date() },
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.setEmailAddress.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 
@@ -256,10 +256,10 @@ const publicPoll = {
 			method: 'DELETE',
 			url: `s/${shareToken}/email`,
 			params: { time: +new Date() },
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.deleteEmailAddress.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 
@@ -271,10 +271,10 @@ const publicPoll = {
 			method: 'PUT',
 			url: `s/${shareToken}/name/${displayName}`,
 			params: { time: +new Date() },
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.setDisplayName.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 
@@ -285,10 +285,10 @@ const publicPoll = {
 			method: 'POST',
 			url: `s/${shareToken}/resend`,
 			params: { time: +new Date() },
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.resendInvitation.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 
@@ -298,10 +298,10 @@ const publicPoll = {
 		return httpInstance.request({
 			method: 'GET',
 			url: `s/${shareToken}/subscription`,
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.getSubscription.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 
@@ -312,10 +312,10 @@ const publicPoll = {
 		return httpInstance.request({
 			method: 'PUT',
 			url: `s/${shareToken}${subscription ? '/subscribe' : '/unsubscribe'}`,
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.setSubscription.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 
@@ -334,10 +334,10 @@ const publicPoll = {
 				timeZone,
 			},
 			params: { time: +new Date() },
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.register.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 }

--- a/src/Api/modules/session.ts
+++ b/src/Api/modules/session.ts
@@ -13,10 +13,10 @@ const session = {
 			method: 'GET',
 			url: '/session',
 			params: { time: +new Date() },
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.getSession.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 }

--- a/src/Api/modules/shares.ts
+++ b/src/Api/modules/shares.ts
@@ -27,10 +27,10 @@ const shares = {
 			method: 'GET',
 			url: `${purpose.toLowerCase()}/${pollOrPollGroupId}/shares`,
 			params: { time: +new Date() },
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.getShares.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 
@@ -44,10 +44,10 @@ const shares = {
 			method: 'POST',
 			url: `${purpose.toLowerCase()}/${pollOrPollGroupId}/share`,
 			data: user,
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.addUserShare.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 
@@ -55,10 +55,10 @@ const shares = {
 		return httpInstance.request({
 			method: 'POST',
 			url: `poll/${pollId}/publicshare`,
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.addPublicShare.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 
@@ -72,10 +72,10 @@ const shares = {
 			data: {
 				label,
 			},
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.writeLabel.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 
@@ -86,10 +86,10 @@ const shares = {
 		return httpInstance.request({
 			method: 'PUT',
 			url: `share/${shareToken}/${setTo}`,
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.switchAdmin.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 
@@ -100,10 +100,10 @@ const shares = {
 		return httpInstance.request({
 			method: 'PUT',
 			url: `share/${shareToken}/publicpollemail/${setTo}`,
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.setEmailAddressConstraint.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 
@@ -116,10 +116,10 @@ const shares = {
 		return httpInstance.request({
 			method: 'POST',
 			url: `share/${shareToken}/invite`,
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.sendInvitation.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 
@@ -128,10 +128,10 @@ const shares = {
 			method: 'GET',
 			url: `share/${shareToken}/resolve`,
 			params: { time: +new Date() },
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.resolveShare.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 
@@ -139,10 +139,10 @@ const shares = {
 		return httpInstance.request({
 			method: 'DELETE',
 			url: `share/${shareToken}`,
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.deleteShare.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 
@@ -150,10 +150,10 @@ const shares = {
 		return httpInstance.request({
 			method: 'PUT',
 			url: `share/${shareToken}/restore`,
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.restoreShare.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 
@@ -161,10 +161,10 @@ const shares = {
 		return httpInstance.request({
 			method: 'PUT',
 			url: `share/${shareToken}/lock`,
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.lockShare.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 
@@ -172,10 +172,10 @@ const shares = {
 		return httpInstance.request({
 			method: 'PUT',
 			url: `share/${shareToken}/unlock`,
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.unlockShare.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 
@@ -185,10 +185,10 @@ const shares = {
 		return httpInstance.request({
 			method: 'PUT',
 			url: `poll/${pollId}/inviteAll`,
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.inviteAll.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 }

--- a/src/Api/modules/userSettings.ts
+++ b/src/Api/modules/userSettings.ts
@@ -13,10 +13,10 @@ const userSettings = {
 			method: 'GET',
 			url: 'preferences',
 			params: { time: +new Date() },
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.getUserSettings.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 
@@ -27,10 +27,10 @@ const userSettings = {
 			method: 'POST',
 			url: 'preferences',
 			data: { preferences },
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.writeUserSettings.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 }

--- a/src/Api/modules/validators.ts
+++ b/src/Api/modules/validators.ts
@@ -13,10 +13,10 @@ const validators = {
 		return httpInstance.request({
 			method: 'GET',
 			url: `check/emailaddress/${emailAddress}`,
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.validateEmailAddress.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 
@@ -27,10 +27,10 @@ const validators = {
 		return httpInstance.request({
 			method: 'POST',
 			url: 'check/username',
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.validateName.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 			data: {
 				displayName: name,
 				token: pollToken,

--- a/src/Api/modules/votes.ts
+++ b/src/Api/modules/votes.ts
@@ -14,10 +14,10 @@ const votes = {
 			method: 'GET',
 			url: `poll/${pollId}/votes`,
 			params: { time: +new Date() },
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.getVotes.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 
@@ -32,10 +32,10 @@ const votes = {
 				optionId,
 				setTo,
 			},
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.setVote.name
-				].handleRequestCancellation(optionId).token,
+				].handleRequestCancellation(optionId).signal,
 		})
 	},
 
@@ -46,10 +46,10 @@ const votes = {
 		return httpInstance.request({
 			method: 'DELETE',
 			url: userId ? `poll/${pollId}/user/${userId}` : `poll/${pollId}/user`,
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.resetVotes.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 
@@ -59,10 +59,10 @@ const votes = {
 		return httpInstance.request({
 			method: 'DELETE',
 			url: `poll/${pollId}/votes/orphaned`,
-			cancelToken:
+			signal:
 				cancelTokenHandlerObject[
 					this.removeOrphanedVotes.name
-				].handleRequestCancellation().token,
+				].handleRequestCancellation().signal,
 		})
 	},
 }


### PR DESCRIPTION
Axios CancelToken is deprecated since 0.22.0. Now that @nextcloud/axios also deprecated the CanelToken we switch over to the AbortController