### PR TITLE
Make modal closable and add click outside

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 ## [9.1.1] - 2026-05-06
 ### Fixed
  - Fix repairstep which deleted the display names from shares
+ - Make modal for sending out confirmations closeable
 
 ### Changed
  - Set default sort to last activity (renamed from last interaction) for poll list, navigation and dashboard

--- a/src/components/Actions/modules/ActionSendConfirmed.vue
+++ b/src/components/Actions/modules/ActionSendConfirmed.vue
@@ -75,7 +75,7 @@ async function clickAction() {
 
 		<NcModal
 			v-model:show="showModal"
-			no-close
+			close-on-click-outside
 			:name="t('polls', 'Result of sent confirmation mails')"
 			size="small">
 			<div class="modal-confirmation-result">


### PR DESCRIPTION
The modal for sending out the confirmations was not allowed to be closed.
* removed noClose
* added closeOnClickOutside

fix #4688