### PR TITLE
fix applying time zone for shares

### DIFF
--- a/lib/Activity/PollChanges.php
+++ b/lib/Activity/PollChanges.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
  * SPDX-FileCopyrightText: 2021 Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+
 namespace OCA\Polls\Activity;
 
 use OCA\Polls\AppInfo\Application;

--- a/lib/Controller/BaseApiV2OCSController.php
+++ b/lib/Controller/BaseApiV2OCSController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
  * SPDX-FileCopyrightText: 2024 Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+
 namespace OCA\Polls\Controller;
 
 use Closure;
@@ -45,10 +46,8 @@ class BaseApiV2OCSController extends OCSController {
 	protected function response(Closure $callback, int $successStatus = Http::STATUS_OK): DataResponse {
 		try {
 			return new DataResponse($callback(), $successStatus);
-
 		} catch (DoesNotExistException $e) {
 			throw new OCSNotFoundException($e->getMessage());
-
 		} catch (Exception $e) {
 			throw match ($e->getStatus()) {
 				Http::STATUS_NOT_MODIFIED => new OCSException($e->getMessage(), Http::STATUS_NOT_MODIFIED),

--- a/lib/Controller/PublicController.php
+++ b/lib/Controller/PublicController.php
@@ -121,7 +121,6 @@ class PublicController extends BaseController {
 		});
 	}
 
-
 	/**
 	 * Watch poll for updates
 	 * @param string $mode the mode of watching, e.g. 'longPolling'
@@ -447,7 +446,6 @@ class PublicController extends BaseController {
 			'share' => $this->shareService->setDisplayname($displayName, $token)
 		]);
 	}
-
 
 	/**
 	 * Set EmailAddress

--- a/lib/Controller/PublicController.php
+++ b/lib/Controller/PublicController.php
@@ -507,9 +507,10 @@ class PublicController extends BaseController {
 	#[FrontpageRoute(verb: 'POST', url: '/s/{token}/resend')]
 	public function resendInvitation(string $token): JSONResponse {
 		$share = $this->shareService->getEffectiveShare($token);
+		$sentResult = new SentResult();
 		return $this->response(fn () => [
 			'share' => $share,
-			'sentResult' => $this->mailService->sendInvitation($share, new SentResult()),
+			'sentResult' => $this->mailService->sendInvitation($share, $sentResult),
 		]);
 	}
 }

--- a/lib/Cron/JanitorCron.php
+++ b/lib/Cron/JanitorCron.php
@@ -102,7 +102,6 @@ class JanitorCron extends TimedJob {
 				$this->logger->info('JanitorCron: ' . $message);
 			}
 
-
 			// archive polls after defined days after closing date
 			$autoArchiveOffset = $this->appSettings->getAutoArchiveOffsetDays();
 

--- a/lib/Cron/UserDeletedJob.php
+++ b/lib/Cron/UserDeletedJob.php
@@ -13,7 +13,6 @@ use OCA\Polls\Db\CommentMapper;
 use OCA\Polls\Db\LogMapper;
 use OCA\Polls\Db\OptionMapper;
 use OCA\Polls\Db\PollMapper;
-
 use OCA\Polls\Db\PreferencesMapper;
 use OCA\Polls\Db\Share;
 use OCA\Polls\Db\ShareMapper;

--- a/lib/Db/CommentMapper.php
+++ b/lib/Db/CommentMapper.php
@@ -94,7 +94,6 @@ class CommentMapper extends QBMapperWithUser {
 		$query->setMaxResults(999);
 
 		return $query->executeStatement();
-
 	}
 
 	/**

--- a/lib/Db/Log.php
+++ b/lib/Db/Log.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 namespace OCA\Polls\Db;
 
 use JsonSerializable;
-
 use OCP\AppFramework\Db\Entity;
 
 /**

--- a/lib/Db/OptionMapper.php
+++ b/lib/Db/OptionMapper.php
@@ -134,7 +134,6 @@ class OptionMapper extends QBMapperWithUser {
 		return $qb->executeQuery()->fetchOne();
 	}
 
-
 	/**
 	 * Get the maximum date of all options in a poll
 	 *
@@ -207,14 +206,12 @@ class OptionMapper extends QBMapperWithUser {
 			->groupBy(self::TABLE . '.id')
 			->orderBy('order', 'ASC');
 
-
 		$this->joinVotesCount($qb, self::TABLE, hideResults: $hideResults);
 		$this->joinPollForLimits($qb, self::TABLE);
 		$this->joinCurrentUserVote($qb, self::TABLE, $currentUserId);
 		$this->joinCurrentUserVoteCount($qb, self::TABLE, $currentUserId);
 		$this->joinAnon($qb, self::TABLE);
 		$this->joinShareRole($qb, self::TABLE, $currentUserId);
-
 
 		return $qb;
 	}

--- a/lib/Db/Poll.php
+++ b/lib/Db/Poll.php
@@ -611,7 +611,6 @@ class Poll extends EntityWithUser implements JsonSerializable {
 		return $this->maxDate;
 	}
 
-
 	private function setMiscSettingsArray(array $value): void {
 		$this->setMiscSettings(json_encode($value));
 	}
@@ -926,7 +925,6 @@ class Poll extends EntityWithUser implements JsonSerializable {
 		return ($this->getUserRole() === Poll::ROLE_OWNER);
 	}
 
-
 	/**
 	 * Permission checks
 	 */
@@ -1043,6 +1041,5 @@ class Poll extends EntityWithUser implements JsonSerializable {
 		// return poll settings
 		return $this->getShowResults() === Poll::SHOW_RESULTS_ALWAYS;
 	}
-
 
 }

--- a/lib/Db/PollGroupMapper.php
+++ b/lib/Db/PollGroupMapper.php
@@ -98,7 +98,6 @@ class PollGroupMapper extends QBMapper {
 		$pollGroup->setCreated(time());
 		$pollGroup->setOwner($this->userSession->getCurrentUserId());
 		return $this->insert($pollGroup);
-
 	}
 
 	/**

--- a/lib/Db/QBMapperWithUser.php
+++ b/lib/Db/QBMapperWithUser.php
@@ -57,7 +57,6 @@ abstract class QBMapperWithUser extends QBMapper {
 			$qb->expr()->eq($joinAlias . '.id', $fromAlias . '.poll_id'),
 		);
 
-
 	}
 	/**
 	 * Joins share type for evaluating current user's role in a poll

--- a/lib/Db/Share.php
+++ b/lib/Db/Share.php
@@ -82,7 +82,6 @@ class Share extends EntityWithUser implements JsonSerializable {
 	public const TYPE_TEAM = 'circle';
 	public const TYPE_CONTACTGROUP = 'contactGroup';
 
-
 	public const CONVERATABLE_PUBLIC_SHARES = [
 		self::TYPE_EMAIL,
 		self::TYPE_CONTACT,
@@ -288,7 +287,6 @@ class Share extends EntityWithUser implements JsonSerializable {
 			}
 		}
 	}
-
 
 	public function getTimeZoneName(): string {
 		return $this->getMiscSettingsArray()['timeZone'] ?? '';

--- a/lib/Db/Subscription.php
+++ b/lib/Db/Subscription.php
@@ -31,7 +31,6 @@ class Subscription extends Entity implements JsonSerializable {
 	/** @var Log[] $logEntries */
 	protected array $logEntries = [];
 
-
 	public function __construct() {
 		$this->addType('id', 'integer');
 		$this->addType('pollId', 'integer');

--- a/lib/Db/UserMapper.php
+++ b/lib/Db/UserMapper.php
@@ -130,23 +130,6 @@ class UserMapper extends QBMapper {
 		throw new UserNotFoundException('User not found in cache');
 	}
 
-
-	public function getUserFromShareToken(string $token): UserBase {
-		$share = $this->getShareByToken($token);
-
-		return $share->resolveUser();
-	}
-
-	private function getShareByToken(string $token): Share {
-		$qb = $this->db->getQueryBuilder();
-
-		$qb->select('*')
-			->from($this->getTableName())
-			->where($qb->expr()->eq('token', $qb->createNamedParameter($token, IQueryBuilder::PARAM_STR)));
-
-		return $this->findEntity($qb);
-	}
-
 	/**
 	 * @param string $userId
 	 * @param int $pollId

--- a/lib/Db/V10/TableManager.php
+++ b/lib/Db/V10/TableManager.php
@@ -602,7 +602,6 @@ class TableManager extends DbManager {
 
 		$this->logger->info('No polls needed to get updated with last interaction info');
 		return 'Last interaction all set';
-
 	}
 
 	/**
@@ -649,10 +648,8 @@ class TableManager extends DbManager {
 					$vote->setVoteOptionHash(Hash::getOptionHash($vote->getPollId(), $vote->getVoteOptionText()));
 					$vote = $this->voteMapper->update($vote);
 
-
 					$updated++;
 				}
-
 
 				$count++;
 
@@ -712,7 +709,6 @@ class TableManager extends DbManager {
 
 					$option->setText($option->getPollOptionText());
 					$option = $this->optionMapper->update($option);
-
 
 					$updated++;
 				}

--- a/lib/Db/VoteMapper.php
+++ b/lib/Db/VoteMapper.php
@@ -60,7 +60,6 @@ class VoteMapper extends QBMapperWithUser {
 		return $this->findEntities($qb);
 	}
 
-
 	/**
 	 * @throws \OCP\AppFramework\Db\DoesNotExistException if not found
 	 * @return Vote[]
@@ -234,7 +233,6 @@ class VoteMapper extends QBMapperWithUser {
 		}
 		$this->joinAnon($qb, self::TABLE);
 		$this->joinShareRole($qb, self::TABLE, $currentUserId);
-
 
 		return $qb;
 	}

--- a/lib/Db/Watch.php
+++ b/lib/Db/Watch.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 namespace OCA\Polls\Db;
 
 use JsonSerializable;
-
 use OCP\AppFramework\Db\Entity;
 
 /**

--- a/lib/Event/BaseEvent.php
+++ b/lib/Event/BaseEvent.php
@@ -24,7 +24,6 @@ abstract class BaseEvent extends Event {
 	protected Poll $poll;
 	protected UserSession $userSession;
 
-
 	public function __construct(
 		protected Poll|Comment|Share|Option|Vote $eventObject,
 	) {

--- a/lib/Event/PollDeletedEvent.php
+++ b/lib/Event/PollDeletedEvent.php
@@ -8,7 +8,6 @@
 namespace OCA\Polls\Event;
 
 use OCA\Polls\Db\Poll;
-
 use OCA\Polls\Notification\Notifier;
 
 class PollDeletedEvent extends PollEvent {
@@ -18,7 +17,6 @@ class PollDeletedEvent extends PollEvent {
 		parent::__construct($poll);
 		$this->eventId = self::DELETE;
 	}
-
 
 	public function getNotification(): array {
 		if ($this->getActor() === $this->getPollOwner()) {

--- a/lib/Helper/Hash.php
+++ b/lib/Helper/Hash.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
  * Abstract class with functions to ensure for the different use cases
  * generating identical hashes
  */
+
 namespace OCA\Polls\Helper;
 
 /**

--- a/lib/Middleware/RequestAttributesMiddleware.php
+++ b/lib/Middleware/RequestAttributesMiddleware.php
@@ -4,6 +4,7 @@
  * SPDX-FileCopyrightText: 2022 Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+
 namespace OCA\Polls\Middleware;
 
 use OCA\Polls\Attributes\ShareTokenRequired;
@@ -51,7 +52,6 @@ class RequestAttributesMiddleware extends Middleware {
 		if ($clientLanguage) {
 			$this->userSession->setClientLanguage($clientLanguage);
 		}
-
 
 		if ($this->hasAttribute($reflectionMethod, ShareTokenRequired::class)) {
 			$this->userSession->setShareToken($this->getShareTokenFromURI());

--- a/lib/Middleware/RequestAttributesMiddleware.php
+++ b/lib/Middleware/RequestAttributesMiddleware.php
@@ -17,6 +17,7 @@ use ReflectionMethod;
 class RequestAttributesMiddleware extends Middleware {
 	private const CLIENT_ID_KEY = 'Nc-Polls-Client-Id';
 	private const TIME_ZONE_KEY = 'Nc-Polls-Client-Time-Zone';
+	private const LANGUAGE_KEY = 'Nc-Polls-Client-Language';
 	private const SHARE_TOKEN = 'Nc-Polls-Share-Token';
 
 	/** @psalm-suppress PossiblyUnusedMethod */
@@ -31,6 +32,7 @@ class RequestAttributesMiddleware extends Middleware {
 		$reflectionMethod = new ReflectionMethod($controller, $methodName);
 		$clientId = $this->request->getHeader(self::CLIENT_ID_KEY);
 		$clientTimeZone = $this->request->getHeader(self::TIME_ZONE_KEY);
+		$clientLanguage = $this->request->getHeader(self::LANGUAGE_KEY);
 
 		$this->userSession->cleanSession();
 
@@ -44,6 +46,10 @@ class RequestAttributesMiddleware extends Middleware {
 
 		if ($clientTimeZone) {
 			$this->userSession->setClientTimeZone($clientTimeZone);
+		}
+
+		if ($clientLanguage) {
+			$this->userSession->setClientLanguage($clientLanguage);
 		}
 
 

--- a/lib/Migration/FixVotes.php
+++ b/lib/Migration/FixVotes.php
@@ -6,7 +6,6 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-
 namespace OCA\Polls\Migration;
 
 use Doctrine\DBAL\Schema\Schema;

--- a/lib/Migration/RepairSteps/CleanTables.php
+++ b/lib/Migration/RepairSteps/CleanTables.php
@@ -6,7 +6,6 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-
 namespace OCA\Polls\Migration\RepairSteps;
 
 use Doctrine\DBAL\Schema\Schema;

--- a/lib/Migration/RepairSteps/CreateIndices.php
+++ b/lib/Migration/RepairSteps/CreateIndices.php
@@ -6,7 +6,6 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-
 namespace OCA\Polls\Migration\RepairSteps;
 
 use Doctrine\DBAL\Schema\Schema;

--- a/lib/Migration/RepairSteps/CreateTables.php
+++ b/lib/Migration/RepairSteps/CreateTables.php
@@ -6,7 +6,6 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-
 namespace OCA\Polls\Migration\RepairSteps;
 
 use Doctrine\DBAL\Schema\Schema;

--- a/lib/Migration/RepairSteps/CreateUniqueIndices.php
+++ b/lib/Migration/RepairSteps/CreateUniqueIndices.php
@@ -6,7 +6,6 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-
 namespace OCA\Polls\Migration\RepairSteps;
 
 use OCA\Polls\Db\V10\IndexManager;

--- a/lib/Migration/RepairSteps/DropOrphanedColumns.php
+++ b/lib/Migration/RepairSteps/DropOrphanedColumns.php
@@ -6,7 +6,6 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-
 namespace OCA\Polls\Migration\RepairSteps;
 
 use Doctrine\DBAL\Schema\Schema;

--- a/lib/Migration/RepairSteps/DropOrphanedIndices.php
+++ b/lib/Migration/RepairSteps/DropOrphanedIndices.php
@@ -6,7 +6,6 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-
 namespace OCA\Polls\Migration\RepairSteps;
 
 use Doctrine\DBAL\Schema\Schema;

--- a/lib/Migration/RepairSteps/DropOrphanedTables.php
+++ b/lib/Migration/RepairSteps/DropOrphanedTables.php
@@ -6,7 +6,6 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-
 namespace OCA\Polls\Migration\RepairSteps;
 
 use Doctrine\DBAL\Schema\Schema;

--- a/lib/Migration/RepairSteps/FixNullish.php
+++ b/lib/Migration/RepairSteps/FixNullish.php
@@ -6,7 +6,6 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-
 namespace OCA\Polls\Migration\RepairSteps;
 
 use OCA\Polls\Db\V10\TableManager;

--- a/lib/Migration/RepairSteps/Install.php
+++ b/lib/Migration/RepairSteps/Install.php
@@ -6,7 +6,6 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-
 namespace OCA\Polls\Migration\RepairSteps;
 
 use OCA\Polls\Db\V10\IndexManager;

--- a/lib/Migration/RepairSteps/MigratePublicToOpen.php
+++ b/lib/Migration/RepairSteps/MigratePublicToOpen.php
@@ -6,7 +6,6 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-
 namespace OCA\Polls\Migration\RepairSteps;
 
 use OCA\Polls\Db\V10\TableManager;

--- a/lib/Migration/RepairSteps/SetLastInteraction.php
+++ b/lib/Migration/RepairSteps/SetLastInteraction.php
@@ -6,7 +6,6 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-
 namespace OCA\Polls\Migration\RepairSteps;
 
 use OCA\Polls\Db\V10\TableManager;

--- a/lib/Migration/RepairSteps/UpdateHashes.php
+++ b/lib/Migration/RepairSteps/UpdateHashes.php
@@ -6,7 +6,6 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-
 namespace OCA\Polls\Migration\RepairSteps;
 
 use OCA\Polls\Db\V10\TableManager;

--- a/lib/Migration/RepairSteps/UpdateInteraction.php
+++ b/lib/Migration/RepairSteps/UpdateInteraction.php
@@ -6,7 +6,6 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-
 namespace OCA\Polls\Migration\RepairSteps;
 
 use OCA\Polls\Db\V10\TableManager;

--- a/lib/Model/Mail/ConfirmationMail.php
+++ b/lib/Model/Mail/ConfirmationMail.php
@@ -6,7 +6,6 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-
 namespace OCA\Polls\Model\Mail;
 
 use DateTimeZone;

--- a/lib/Model/Mail/InvitationMail.php
+++ b/lib/Model/Mail/InvitationMail.php
@@ -6,7 +6,6 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-
 namespace OCA\Polls\Model\Mail;
 
 use OCA\Polls\AppInfo\Application;

--- a/lib/Model/Mail/MailBase.php
+++ b/lib/Model/Mail/MailBase.php
@@ -6,7 +6,6 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-
 namespace OCA\Polls\Model\Mail;
 
 use League\CommonMark\Environment\Environment;

--- a/lib/Model/Mail/NotificationMail.php
+++ b/lib/Model/Mail/NotificationMail.php
@@ -6,7 +6,6 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-
 namespace OCA\Polls\Model\Mail;
 
 use OCA\Polls\AppInfo\Application;

--- a/lib/Model/Mail/ReminderMail.php
+++ b/lib/Model/Mail/ReminderMail.php
@@ -6,7 +6,6 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-
 namespace OCA\Polls\Model\Mail;
 
 use DateTime;

--- a/lib/Model/User/Contact.php
+++ b/lib/Model/User/Contact.php
@@ -111,8 +111,6 @@ class Contact extends UserBase {
 		return count($description) ? implode(', ', $description) : $this->l10n->t('Contact');
 	}
 
-
-
 	public static function isEnabled(): bool {
 		return Container::isAppEnabled('contacts');
 	}

--- a/lib/Model/User/Email.php
+++ b/lib/Model/User/Email.php
@@ -6,7 +6,6 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-
 namespace OCA\Polls\Model\User;
 
 use OCA\Polls\Model\UserBase;

--- a/lib/Model/User/GenericUser.php
+++ b/lib/Model/User/GenericUser.php
@@ -6,7 +6,6 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-
 namespace OCA\Polls\Model\User;
 
 use OCA\Polls\Model\UserBase;

--- a/lib/Model/UserBase.php
+++ b/lib/Model/UserBase.php
@@ -157,11 +157,7 @@ class UserBase implements JsonSerializable {
 	}
 
 	public function getLocaleCode(): string {
-		if (!$this->localeCode) {
-			return $this->languageCode;
-		}
-
-		return $this->localeCode;
+		return $this->localeCode ?: $this->languageCode;
 	}
 
 	public function getLocaleCodeIntl(): string {
@@ -173,10 +169,11 @@ class UserBase implements JsonSerializable {
 	}
 
 	public function getTimeZoneName(): string {
-		if ($this->timeZoneName) {
-			return $this->timeZoneName;
-		}
-		return '';
+		return $this->timeZoneName ?: '';
+	}
+
+	public function setLanguageCode(string $languageCode): void {
+		$this->languageCode = $languageCode;
 	}
 
 	public function setTimeZoneName(string $timeZoneName): void {

--- a/lib/Model/UserBase.php
+++ b/lib/Model/UserBase.php
@@ -176,7 +176,11 @@ class UserBase implements JsonSerializable {
 		if ($this->timeZoneName) {
 			return $this->timeZoneName;
 		}
-		return date_default_timezone_get();
+		return '';
+	}
+
+	public function setTimeZoneName(string $timeZoneName): void {
+		$this->timeZoneName = $timeZoneName;
 	}
 
 	public function getDisplayName(): string {

--- a/lib/Model/UserBase.php
+++ b/lib/Model/UserBase.php
@@ -458,5 +458,4 @@ class UserBase implements JsonSerializable {
 		return $this->getType();
 	}
 
-
 }

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -114,7 +114,6 @@ class Notifier implements INotifier {
 
 		$l = $this->l10nFactory->get(Application::APP_ID, $languageCode);
 
-
 		$notification->setIcon(
 			$this->urlGenerator->getAbsoluteURL(
 				$this->urlGenerator->imagePath(Application::APP_ID, 'polls-dark.svg')

--- a/lib/Provider/ReferenceProvider.php
+++ b/lib/Provider/ReferenceProvider.php
@@ -54,7 +54,6 @@ class ReferenceProvider extends ADiscoverableReferenceProvider implements ISearc
 		return 0;
 	}
 
-
 	/**
 	 * @inheritDoc
 	 */
@@ -64,7 +63,6 @@ class ReferenceProvider extends ADiscoverableReferenceProvider implements ISearc
 			$expired = false;
 			$expiry = 0;
 			$participated = false;
-
 
 			if ($pollId) {
 				try {

--- a/lib/Provider/SearchProvider.php
+++ b/lib/Provider/SearchProvider.php
@@ -8,7 +8,6 @@ declare(strict_types=1);
 
 declare(strict_types=1);
 
-
 namespace OCA\Polls\Provider;
 
 use OCA\Polls\AppInfo\Application;

--- a/lib/Service/ActivityService.php
+++ b/lib/Service/ActivityService.php
@@ -266,28 +266,24 @@ class ActivityService {
 					self::THIRD_PERSON_FULL => $this->l10n->t('{actor} has added a public share to poll {pollTitle}'),
 					self::FIRST_PERSON_FILTERED => $this->l10n->t('You have added a public share'),
 					self::THIRD_PERSON_FILTERED => $this->l10n->t('{actor} has added a public share'),
-
 				],
 				Share::TYPE_GROUP => [
 					self::FIRST_PERSON_FULL => $this->l10n->t('You have shared poll {pollTitle} with group {sharee}'),
 					self::THIRD_PERSON_FULL => $this->l10n->t('{actor} has shared poll {pollTitle} with group {sharee}'),
 					self::FIRST_PERSON_FILTERED => $this->l10n->t('You have shared this poll with group {sharee}'),
 					self::THIRD_PERSON_FILTERED => $this->l10n->t('{actor} has shared this poll with group {sharee}'),
-
 				],
 				Share::TYPE_TEAM => [
 					self::FIRST_PERSON_FULL => $this->l10n->t('You have shared poll {pollTitle} with team {sharee}'),
 					self::THIRD_PERSON_FULL => $this->l10n->t('{actor} has shared poll {pollTitle} with team {sharee}'),
 					self::FIRST_PERSON_FILTERED => $this->l10n->t('You have shared this poll with team {sharee}'),
 					self::THIRD_PERSON_FILTERED => $this->l10n->t('{actor} has shared this poll with team {sharee}'),
-
 				],
 				Share::TYPE_CONTACTGROUP => [
 					self::FIRST_PERSON_FULL => $this->l10n->t('You have shared poll {pollTitle} with contact group {sharee}'),
 					self::THIRD_PERSON_FULL => $this->l10n->t('{actor} has shared poll {pollTitle} with contact group {sharee}'),
 					self::FIRST_PERSON_FILTERED => $this->l10n->t('You have shared this poll with contact group {sharee}'),
 					self::THIRD_PERSON_FILTERED => $this->l10n->t('{actor} has shared this poll with contact group {sharee}'),
-
 				],
 				default => [
 					self::FIRST_PERSON_FULL => $this->l10n->t('You have shared poll {pollTitle} with {sharee}'),

--- a/lib/Service/CalendarService.php
+++ b/lib/Service/CalendarService.php
@@ -6,7 +6,6 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-
 namespace OCA\Polls\Service;
 
 use OCA\Polls\Db\OptionMapper;
@@ -58,7 +57,6 @@ class CalendarService {
 			$this->calendars = [];
 		}
 	}
-
 
 	/**
 	 * getTimerange - set timeranges to search within based on the option's time information

--- a/lib/Service/MailService.php
+++ b/lib/Service/MailService.php
@@ -60,7 +60,6 @@ class MailService {
 	private static function isValidEmail(string $eMailAddress): bool {
 		# Rely on PHP's filter
 		return (bool)filter_var($eMailAddress, FILTER_VALIDATE_EMAIL);
-
 		// Alternative
 		// return (bool) preg_match(self::REGEX_VALID_MAIL, $eMailAddress);
 	}
@@ -113,7 +112,6 @@ class MailService {
 		}
 
 		throw new NoEmailAddress($eMailString);
-
 	}
 
 	/** @psalm-suppress PossiblyUnusedMethod */

--- a/lib/Service/NotificationService.php
+++ b/lib/Service/NotificationService.php
@@ -27,7 +27,6 @@ class NotificationService {
 		$this->notificationManager->markProcessed($notification);
 	}
 
-
 	/**
 	 * Remove all notifications for a specific poll and the current user.
 	 *

--- a/lib/Service/OptionService.php
+++ b/lib/Service/OptionService.php
@@ -152,7 +152,6 @@ class OptionService {
 			}
 		}
 
-
 		if ($voteYes) {
 			// Set the vote for the new option on request
 			$this->voteService->set($newOption, Vote::VOTE_YES);

--- a/lib/Service/PollService.php
+++ b/lib/Service/PollService.php
@@ -327,7 +327,6 @@ class PollService {
 		}
 	}
 
-
 	/**
 	 * Move to archive or restore
 	 */

--- a/lib/Service/ShareService.php
+++ b/lib/Service/ShareService.php
@@ -160,10 +160,26 @@ class ShareService {
 			default => $this->share,
 		};
 
-		if ($effectiveShare->getType() === Share::TYPE_EXTERNAL && !$effectiveShare->getTimeZoneName()) {
-			$clientTz = $this->userSession->getClientTimeZoneName();
-			if ($clientTz) {
-				$effectiveShare->setTimeZoneName($clientTz);
+		if ($effectiveShare->getType() === Share::TYPE_EXTERNAL) {
+			$needsUpdate = false;
+
+			if (!$effectiveShare->getTimeZoneName()) {
+				$clientTz = $this->userSession->getClientTimeZoneName();
+				if ($clientTz) {
+					$effectiveShare->setTimeZoneName($clientTz);
+					$needsUpdate = true;
+				}
+			}
+
+			if (!$effectiveShare->getLanguage()) {
+				$clientLang = $this->userSession->getClientLanguageName();
+				if ($clientLang) {
+					$effectiveShare->setLanguage($clientLang);
+					$needsUpdate = true;
+				}
+			}
+
+			if ($needsUpdate) {
 				$this->shareMapper->update($effectiveShare);
 			}
 		}

--- a/lib/Service/ShareService.php
+++ b/lib/Service/ShareService.php
@@ -163,7 +163,8 @@ class ShareService {
 		if ($effectiveShare->getType() === Share::TYPE_EXTERNAL) {
 			$needsUpdate = false;
 
-			if (!$effectiveShare->getTimeZoneName()) {
+			// TODO: Remove UTC check after migration period — patches shares incorrectly saved with UTC default
+			if (!$effectiveShare->getTimeZoneName() || $effectiveShare->getTimeZoneName() === 'UTC') {
 				$clientTz = $this->userSession->getClientTimeZoneName();
 				if ($clientTz) {
 					$effectiveShare->setTimeZoneName($clientTz);

--- a/lib/Service/ShareService.php
+++ b/lib/Service/ShareService.php
@@ -141,7 +141,7 @@ class ShareService {
 			$this->share->setDisplayName('');
 		}
 
-		return match (true) {
+		$effectiveShare = match (true) {
 			// User is already involved: return their personal share or the accessed share
 			$poll->getIsInvolved()
 				=> $poll->getShareToken()
@@ -159,6 +159,16 @@ class ShareService {
 			// Default: return validated share as-is
 			default => $this->share,
 		};
+
+		if ($effectiveShare->getType() === Share::TYPE_EXTERNAL && !$effectiveShare->getTimeZoneName()) {
+			$clientTz = $this->userSession->getClientTimeZoneName();
+			if ($clientTz) {
+				$effectiveShare->setTimeZoneName($clientTz);
+				$this->shareMapper->update($effectiveShare);
+			}
+		}
+
+		return $effectiveShare;
 	}
 
 	/**
@@ -601,7 +611,7 @@ class ShareService {
 
 		$language = $this->systemService->getGenericLanguage();
 		$userId = $this->generatePublicUserId();
-		$user = UserMapper::createUserObject(Share::TYPE_EXTERNAL, $userId, $displayName, $emailAddress, $language, $language, $timeZone);
+		$user = UserMapper::createUserObject(Share::TYPE_EXTERNAL, $userId, $displayName, $emailAddress, $language, $language, $timeZone ?: $this->userSession->getClientTimeZone()->getName());
 
 		$this->createNewShare(
 			$this->share->getPollIdOrFail(),

--- a/lib/Service/ShareService.php
+++ b/lib/Service/ShareService.php
@@ -359,7 +359,6 @@ class ShareService {
 		}
 		$this->share->setEmailAddress($emailAddress ?? $this->share->getEmailAddress());
 
-
 		// convert to type external
 		$this->share->setType(Share::TYPE_EXTERNAL);
 
@@ -477,7 +476,6 @@ class ShareService {
 	public function resolveGroupByToken(string $token): array {
 		$share = $this->get($token);
 		return $this->resolveGroup($share);
-
 	}
 
 	/**

--- a/lib/Types.php
+++ b/lib/Types.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
  * SPDX-FileCopyrightText: 2025 Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+
 namespace OCA\Polls;
 
 /**

--- a/lib/UserSession.php
+++ b/lib/UserSession.php
@@ -197,7 +197,7 @@ class UserSession {
 		return $this->session->get(self::CLIENT_LANG);
 	}
 
-/**
+	/**
 	 * Get client time zone from session or return default time zone
 	 * @return DateTimeZone
 	 */

--- a/lib/UserSession.php
+++ b/lib/UserSession.php
@@ -30,6 +30,8 @@ class UserSession {
 	/** @var string */
 	public const CLIENT_TZ = 'ncPollsClientTimeZone';
 	/** @var string */
+	public const CLIENT_LANG = 'ncPollsClientLanguage';
+	/** @var string */
 	public const TABLE = Share::TABLE;
 
 	protected ?UserBase $currentUser = null;
@@ -69,6 +71,12 @@ class UserSession {
 						$clientTz = $this->session->get(self::CLIENT_TZ);
 						if ($clientTz) {
 							$this->currentUser->setTimeZoneName($clientTz);
+						}
+					}
+					if (!$share->getLanguage()) {
+						$clientLang = $this->session->get(self::CLIENT_LANG);
+						if ($clientLang) {
+							$this->currentUser->setLanguageCode($clientLang);
 						}
 					}
 				}
@@ -185,7 +193,11 @@ class UserSession {
 		return $this->session->get(self::CLIENT_TZ);
 	}
 
-	/**
+	public function getClientLanguageName(): ?string {
+		return $this->session->get(self::CLIENT_LANG);
+	}
+
+/**
 	 * Get client time zone from session or return default time zone
 	 * @return DateTimeZone
 	 */
@@ -197,4 +209,9 @@ class UserSession {
 	public function setClientTimeZone(string $clientTimeZone): void {
 		$this->session->set(self::CLIENT_TZ, $clientTimeZone);
 	}
+
+	public function setClientLanguage(string $clientLanguage): void {
+		$this->session->set(self::CLIENT_LANG, $clientLanguage);
+	}
+
 }

--- a/lib/UserSession.php
+++ b/lib/UserSession.php
@@ -62,7 +62,15 @@ class UserSession {
 				} elseif ($this->session->get(self::SESSION_KEY_CRON_JOB)) {
 					$this->currentUser = new Cron();
 				} else {
-					$this->currentUser = $this->userMapper->getUserFromShareToken($this->getShareToken());
+					$share = $this->shareMapper->findByToken($this->getShareToken());
+
+					$this->currentUser = $share->resolveUser();
+					if (!$share->getTimeZoneName()) {
+						$clientTz = $this->session->get(self::CLIENT_TZ);
+						if ($clientTz) {
+							$this->currentUser->setTimeZoneName($clientTz);
+						}
+					}
 				}
 			} catch (Exception $e) {
 				// In case of system jobs, we do not get a valid user, so we return a Ghost user
@@ -171,6 +179,10 @@ class UserSession {
 
 	public function setClientId(string $clientId): void {
 		$this->session->set(self::CLIENT_ID, $clientId);
+	}
+
+	public function getClientTimeZoneName(): ?string {
+		return $this->session->get(self::CLIENT_TZ);
 	}
 
 	/**

--- a/src/Api/modules/HttpApi.js
+++ b/src/Api/modules/HttpApi.js
@@ -4,6 +4,7 @@
  */
 import axios from '@nextcloud/axios'
 import { generateUrl, generateOcsUrl } from '@nextcloud/router'
+import { getLanguage } from '@nextcloud/l10n'
 import { useSessionStore } from '../../stores/session.ts'
 
 const axiosConfig = {
@@ -12,6 +13,7 @@ const axiosConfig = {
 		Accept: 'application/json',
 		'Nc-Polls-Client-Time-Zone':
 			Intl.DateTimeFormat().resolvedOptions().timeZone,
+		'Nc-Polls-Client-Language': getLanguage(),
 	},
 }
 

--- a/stubs/circles-stubs.php
+++ b/stubs/circles-stubs.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
  * SPDX-FileCopyrightText: 2025 Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+
 namespace OCA\Circles\Model;
 
 /**


### PR DESCRIPTION
* Remove fallback to default time zone to avoid applying a time zone to a share, which differs from the user's system time zone
* Apply time zone to users' share on registration or in case if personal invitation shares on first access
* Apply user's language to language code and locale code

fix #4727