### PR TITLE
fix: purge soft-deleted entries after 12 hours as documented

### DIFF
--- a/lib/Cron/JanitorCron.php
+++ b/lib/Cron/JanitorCron.php
@@ -29,6 +29,9 @@ use Psr\Log\LoggerInterface;
  */
 #[ManuallyRunnableCronJob]
 class JanitorCron extends TimedJob {
+	// undo window for virtually deleted entries before they get purged (12 hours)
+	private const UNDO_WINDOW_SECONDS = 43200;
+
 	// private AppSettings $appSettings;
 
 	public function __construct(
@@ -70,11 +73,12 @@ class JanitorCron extends TimedJob {
 			// first make sure all options and votes have a correct hash
 			$this->tableManager->updateHashes();
 
-			// purge entries virtually deleted more than 12 hours ago
+			// purge entries virtually deleted before the undo window started
+			$purgeBefore = time() - self::UNDO_WINDOW_SECONDS;
 			$deleted = [];
-			$deleted['comments'] = $this->commentMapper->purgeDeletedComments(time() - 4320);
-			$deleted['options'] = $this->optionMapper->purgeDeletedOptions(time() - 4320);
-			$deleted['shares'] = $this->shareMapper->purgeDeletedShares(time() - 4320);
+			$deleted['comments'] = $this->commentMapper->purgeDeletedComments($purgeBefore);
+			$deleted['options'] = $this->optionMapper->purgeDeletedOptions($purgeBefore);
+			$deleted['shares'] = $this->shareMapper->purgeDeletedShares($purgeBefore);
 
 			// purge orphaned votes; Votes without any corresponding option
 			$deleted['orphaned votes'] = $this->voteMapper->removeOrphanedVotes();

--- a/tests/Unit/Cron/JanitorCronTest.php
+++ b/tests/Unit/Cron/JanitorCronTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Polls\Tests\Unit\Cron;
+
+use OCA\Polls\Cron\JanitorCron;
+use OCA\Polls\Db\Comment;
+use OCA\Polls\Db\CommentMapper;
+use OCA\Polls\Db\Option;
+use OCA\Polls\Db\OptionMapper;
+use OCA\Polls\Db\Poll;
+use OCA\Polls\Db\PollMapper;
+use OCA\Polls\Db\Share;
+use OCA\Polls\Db\ShareMapper;
+use OCA\Polls\Tests\Unit\UnitTestCase;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+use OCP\Server;
+use ReflectionMethod;
+
+class JanitorCronTest extends UnitTestCase {
+	private JanitorCron $janitorCron;
+	private IDBConnection $connection;
+	private PollMapper $pollMapper;
+	private CommentMapper $commentMapper;
+	private OptionMapper $optionMapper;
+	private ShareMapper $shareMapper;
+	private Poll $poll;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->janitorCron = Server::get(JanitorCron::class);
+		$this->connection = Server::get(IDBConnection::class);
+		$this->pollMapper = Server::get(PollMapper::class);
+		$this->commentMapper = Server::get(CommentMapper::class);
+		$this->optionMapper = Server::get(OptionMapper::class);
+		$this->shareMapper = Server::get(ShareMapper::class);
+
+		$poll = $this->fm->instance('OCA\Polls\Db\Poll');
+		$this->poll = $this->pollMapper->insert($poll);
+	}
+
+	public function tearDown(): void {
+		parent::tearDown();
+		// comments, options and shares cascade-delete with the poll
+		$this->pollMapper->delete($this->poll);
+	}
+
+	/**
+	 * Entries deleted less than 12 hours ago must survive the janitor run
+	 * (undo window), entries deleted more than 12 hours ago get purged.
+	 */
+	public function testPurgeRespectsTwelveHourUndoWindow(): void {
+		$withinUndoWindow = time() - 7200; // deleted 2 hours ago
+		$outsideUndoWindow = time() - 46800; // deleted 13 hours ago
+
+		$recentComment = $this->createDeletedComment($withinUndoWindow);
+		$oldComment = $this->createDeletedComment($outsideUndoWindow);
+		$recentOption = $this->createDeletedOption($withinUndoWindow);
+		$oldOption = $this->createDeletedOption($outsideUndoWindow);
+		$recentShare = $this->createDeletedShare($withinUndoWindow);
+		$oldShare = $this->createDeletedShare($outsideUndoWindow);
+
+		$this->runJanitor();
+
+		$this->assertTrue($this->rowExists(Comment::TABLE, $recentComment->getId()), 'Comment deleted 2 hours ago must survive the 12 hours undo window');
+		$this->assertTrue($this->rowExists(Option::TABLE, $recentOption->getId()), 'Option deleted 2 hours ago must survive the 12 hours undo window');
+		$this->assertTrue($this->rowExists(Share::TABLE, $recentShare->getId()), 'Share deleted 2 hours ago must survive the 12 hours undo window');
+
+		$this->assertFalse($this->rowExists(Comment::TABLE, $oldComment->getId()), 'Comment deleted 13 hours ago must get purged');
+		$this->assertFalse($this->rowExists(Option::TABLE, $oldOption->getId()), 'Option deleted 13 hours ago must get purged');
+		$this->assertFalse($this->rowExists(Share::TABLE, $oldShare->getId()), 'Share deleted 13 hours ago must get purged');
+	}
+
+	private function createDeletedComment(int $deleted): Comment {
+		$comment = $this->fm->instance('OCA\Polls\Db\Comment');
+		$comment->setPollId($this->poll->getId());
+		$comment->setDeleted($deleted);
+		return $this->commentMapper->insert($comment);
+	}
+
+	private function createDeletedOption(int $deleted): Option {
+		$option = $this->fm->instance('OCA\Polls\Db\Option');
+		$option->setPoll($this->poll->getId());
+		$option->setDeleted($deleted);
+		return $this->optionMapper->insert($option);
+	}
+
+	private function createDeletedShare(int $deleted): Share {
+		$share = $this->fm->instance('OCA\Polls\Db\Share');
+		$share->setPollId($this->poll->getId());
+		$share->setDeleted($deleted);
+		return $this->shareMapper->insert($share);
+	}
+
+	private function runJanitor(): void {
+		$run = new ReflectionMethod($this->janitorCron, 'run');
+		$run->invoke($this->janitorCron, null);
+	}
+
+	private function rowExists(string $table, int $id): bool {
+		$qb = $this->connection->getQueryBuilder();
+		$qb->select('id')
+			->from($table)
+			->where($qb->expr()->eq('id', $qb->createNamedParameter($id, IQueryBuilder::PARAM_INT)));
+		$result = $qb->executeQuery();
+		$row = $result->fetchOne();
+		$result->closeCursor();
+
+		return $row !== false;
+	}
+}


### PR DESCRIPTION
The janitor cron purged comments, options and shares 4320 seconds (72 minutes) after their virtual deletion, while the comment states a 12 hours undo window (43200 seconds), a dropped zero, present since the purge was introduced.

Add a regression test covering both sides of the window.

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
