### PR TITLE
Manually upgrade CodeQL action versions to 4.37.6

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -30,10 +30,10 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 #4.37.3
+      uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 #4.37.6
       with:
         languages: ${{ matrix.language }}
     - name: Autobuild
-      uses: github/codeql-action/autobuild@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 #4.37.3
+      uses: github/codeql-action/autobuild@5595ccaf912efad79be6eef63a5619ff05969be3 #4.37.6
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 #4.37.3
+      uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 #4.37.6


### PR DESCRIPTION
Updated CodeQL action versions to 4.37.6 for initialization, autobuild, and analysis steps.

Replaces failing dependabot PRs
* https://github.com/nextcloud/polls/pull/4941
* https://github.com/nextcloud/polls/pull/4942
* https://github.com/nextcloud/polls/pull/4944

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
