### PR TITLE
fix confidential comments for public users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 ## [Unreleased]
+### Fixed
+ - Public users could not add confidential comments
+
 ### Added
  - OpenAPI spec
 

--- a/lib/Controller/CommentApiController.php
+++ b/lib/Controller/CommentApiController.php
@@ -55,8 +55,8 @@ class CommentApiController extends BaseApiV2OCSController {
 	#[NoAdminRequired]
 	#[NoCSRFRequired]
 	#[ApiRoute(verb: 'POST', url: '/api/v1.0/poll/{pollId}/comment')]
-	public function add(int $pollId, string $comment): DataResponse {
-		return $this->response(fn () => ['comment' => $this->commentService->add($comment, $pollId)->jsonSerialize()]);
+	public function add(int $pollId, string $comment, ?bool $confidential = false): DataResponse {
+		return $this->response(fn () => ['comment' => $this->commentService->add($comment, $pollId, $confidential)->jsonSerialize()]);
 	}
 
 	/**

--- a/lib/Controller/CommentApiController.php
+++ b/lib/Controller/CommentApiController.php
@@ -49,13 +49,14 @@ class CommentApiController extends BaseApiV2OCSController {
 	 * 200: Comment added
 	 * @param int $pollId Poll id
 	 * @param string $comment Comment text to add
+	 * @param bool $confidential Whether the comment is only visible to the poll owner and the author
 	 * @return DataResponse<Http::STATUS_OK, array{comment: PollsComment}, array{}>
 	 */
 	#[CORS]
 	#[NoAdminRequired]
 	#[NoCSRFRequired]
 	#[ApiRoute(verb: 'POST', url: '/api/v1.0/poll/{pollId}/comment')]
-	public function add(int $pollId, string $comment, ?bool $confidential = false): DataResponse {
+	public function add(int $pollId, string $comment, bool $confidential = false): DataResponse {
 		return $this->response(fn () => ['comment' => $this->commentService->add($comment, $pollId, $confidential)->jsonSerialize()]);
 	}
 

--- a/lib/Controller/CommentController.php
+++ b/lib/Controller/CommentController.php
@@ -42,6 +42,7 @@ class CommentController extends BaseController {
 	 * Write a new comment to the db and returns the new comment as array
 	 * @param int $pollId Poll id
 	 * @param string $message Comment text to add
+	 * @param bool $confidential Whether the comment is only visible to the poll owner and the author
 	 */
 	#[NoAdminRequired]
 	#[FrontpageRoute(verb: 'POST', url: '/poll/{pollId}/comment')]

--- a/lib/Controller/PublicController.php
+++ b/lib/Controller/PublicController.php
@@ -314,9 +314,9 @@ class PublicController extends BaseController {
 	#[ShareTokenRequired]
 	#[OpenAPI(OpenAPI::SCOPE_IGNORE)]
 	#[FrontpageRoute(verb: 'POST', url: '/s/{token}/comment')]
-	public function addComment(string $message): JSONResponse {
+	public function addComment(string $message, ?bool $confidential = false): JSONResponse {
 		return $this->response(fn () => [
-			'comment' => $this->commentService->add($message, $this->userSession->getShare()->getPollIdOrFail())
+			'comment' => $this->commentService->add($message, $this->userSession->getShare()->getPollIdOrFail(), $confidential)
 		]);
 	}
 

--- a/lib/Controller/PublicController.php
+++ b/lib/Controller/PublicController.php
@@ -314,7 +314,7 @@ class PublicController extends BaseController {
 	#[ShareTokenRequired]
 	#[OpenAPI(OpenAPI::SCOPE_IGNORE)]
 	#[FrontpageRoute(verb: 'POST', url: '/s/{token}/comment')]
-	public function addComment(string $message, ?bool $confidential = false): JSONResponse {
+	public function addComment(string $message, bool $confidential = false): JSONResponse {
 		return $this->response(fn () => [
 			'comment' => $this->commentService->add($message, $this->userSession->getShare()->getPollIdOrFail(), $confidential)
 		]);

--- a/lib/Controller/PublicController.php
+++ b/lib/Controller/PublicController.php
@@ -309,6 +309,7 @@ class PublicController extends BaseController {
 	/**
 	 * Write a new comment to the db and returns the new comment as array
 	 * @param string $message Comment text to add
+	 * @param bool $confidential Whether the comment is only visible to the poll owner and the author
 	 */
 	#[PublicPage]
 	#[ShareTokenRequired]

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -1205,6 +1205,11 @@
                                     "comment": {
                                         "type": "string",
                                         "description": "Comment text to add"
+                                    },
+                                    "confidential": {
+                                        "type": "boolean",
+                                        "default": false,
+                                        "description": "Whether the comment is only visible to the poll owner and the author"
                                     }
                                 }
                             }

--- a/openapi.json
+++ b/openapi.json
@@ -1205,6 +1205,11 @@
                                     "comment": {
                                         "type": "string",
                                         "description": "Comment text to add"
+                                    },
+                                    "confidential": {
+                                        "type": "boolean",
+                                        "default": false,
+                                        "description": "Whether the comment is only visible to the poll owner and the author"
                                     }
                                 }
                             }


### PR DESCRIPTION
Public API was missing confidential flag for newly created comments
fixes #4924



## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
